### PR TITLE
feat(contentful-import): Add api host option

### DIFF
--- a/lib/usageParams.js
+++ b/lib/usageParams.js
@@ -39,6 +39,11 @@ export default yargs
     describe: 'Full path to the error log file',
     type: 'string'
   })
+  .option('managementHost', {
+    describe: 'Management API host',
+    type: 'string',
+    default: 'api.contentful.com'
+  })
   .config('config', 'An optional configuration JSON file containing all the options for a single run')
   .check(function (argv) {
     if (!argv.spaceId) {


### PR DESCRIPTION
This PR adds the possibility to specify the API host, this is useful for example if we want to test against staging for example.
The property `managementHost` is coming from [here](https://github.com/contentful/contentful-batch-libs/blob/master/lib/utils/create-clients.js#L40) 