### PR TITLE
fix skipping of locales by introducing flag for content model only

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Options:
   --content-file             JSON file that contains data to be import to your
                              space                           [string] [required]
 
+  --content-model-only       Import only content types[boolean] [default: false]
+
   --skip-content-model       Skip importing content types and locales
                                                       [boolean] [default: false]
 

--- a/lib/get-transformed-destination-response.js
+++ b/lib/get-transformed-destination-response.js
@@ -10,6 +10,7 @@ export default function getTransformedDestinationResponse ({
   managementClient,
   spaceId,
   sourceResponse,
+  skipLocales,
   skipContentModel
 }) {
   return getOutdatedDestinationContent({
@@ -21,6 +22,10 @@ export default function getTransformedDestinationResponse ({
   .then((destinationResponse) => {
     if (skipContentModel) {
       destinationResponse.contentTypes = []
+      destinationResponse.locales = []
+    }
+
+    if (skipLocales) {
       destinationResponse.locales = []
     }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -39,6 +39,14 @@ export default function runContentfulImport (usageParams) {
     return Promise.reject(new Error('Either the `contentFile` or `content` option are required.'))
   }
 
+  if (opts.contentModelOnly && opts.skipContentModel) {
+    return Promise.reject(new Error('`contentModelOnly` and `skipContentModel` cannot be used together'))
+  }
+
+  if (opts.skipLocales && !opts.contentModelOnly) {
+    return Promise.reject(new Error('`skipLocales` can only be used together with `contentModelOnly`'))
+  }
+
   opts.content.webhooks = opts.content.webhooks || []
   opts.destinationSpace = opts.spaceId
   opts.destinationManagementToken = opts.managementToken

--- a/lib/usageParams.js
+++ b/lib/usageParams.js
@@ -20,6 +20,11 @@ export default yargs
     type: 'string',
     demand: true
   })
+  .option('content-model-only', {
+    describe: 'Import only content types',
+    type: 'boolean',
+    default: false
+  })
   .option('skip-content-model', {
     describe: 'Skip importing content types and locales',
     type: 'boolean',


### PR DESCRIPTION
We are accidentally missing the `contentModelOnly` flag to make `skipLocales` work.