### PR TITLE
fix(parseOption): handle non existing lists

### DIFF
--- a/lib/parseOptions.js
+++ b/lib/parseOptions.js
@@ -50,8 +50,9 @@ export default function parseOptions (params) {
   options.destinationManagementToken = options.managementToken
   options.content = options.content || JSON.parse(fs.readFileSync(options.contentFile))
 
-  // to avoid loping through an undefined object later on
+  // to avoid looping through an undefined array later on
   options.content.contentTypes = options.content.contentTypes || []
+  options.content.entries = options.content.entries || []
   options.content.assets = options.content.assets || []
   options.content.locales = options.content.locales || []
   options.content.webhooks = options.content.webhooks || []

--- a/lib/parseOptions.js
+++ b/lib/parseOptions.js
@@ -49,7 +49,14 @@ export default function parseOptions (params) {
   options.destinationSpace = options.spaceId
   options.destinationManagementToken = options.managementToken
   options.content = options.content || JSON.parse(fs.readFileSync(options.contentFile))
+
+  // to avoid loping through an undefined object later on
+  options.content.contentTypes = options.content.contentTypes || []
+  options.content.assets = options.content.assets || []
+  options.content.locales = options.content.locales || []
   options.content.webhooks = options.content.webhooks || []
+  options.content.roles = options.content.roles || []
+  options.content.editorInterfaces = options.content.editorInterfaces || []
 
   if (typeof options.proxy === 'string') {
     const chunks = options.proxy.split('@')


### PR DESCRIPTION
When the json is changed manually and one of the arrays that the tool is expecting is removed the tool will crash, this PR fixes that