### PR TITLE
fix(proxy): Fix httpsAgent Creation

### DIFF
--- a/lib/utils/proxy.js
+++ b/lib/utils/proxy.js
@@ -68,5 +68,5 @@ export function agentFromProxy (proxy) {
   })
   const { host, port } = proxy
   const agent = new HttpsProxyAgent({ host, port })
-  return { httpsAgent: agent }
+  return agent
 }


### PR DESCRIPTION
[`options.httsAgent`](https://github.com/contentful/contentful-import/blob/master/lib/parseOptions.js#L69) needs to be an `httpsAgent` and not a `{httpsAgent: agent}` object
