### PR TITLE
Fix logical error in parseOptions.js

### DIFF
--- a/lib/parseOptions.js
+++ b/lib/parseOptions.js
@@ -76,7 +76,7 @@ export default function parseOptions (params) {
 
   // Clean up content to only include supported entity types
   Object.keys(options.content).forEach((type) => {
-    if (!SUPPORTED_ENTITY_TYPES.indexOf(type) >= 0) {
+    if (SUPPORTED_ENTITY_TYPES.indexOf(type) === -1) {
       delete options.content[type]
     }
   })


### PR DESCRIPTION
I experienced some problems when trying to duplicate all my stuff from one space to another using `contentful-export` and `contentful-import`.

Specifically, the export went well, but the import didn't recognize the data in my json dump, yielding a successful import of zero entities of every entity type.

See this gist for the output of `contentful-import`:
https://gist.github.com/ewendel/db9a67b3a6a38104891be68b70a7ca7c

After some digging, I find that these lines are the culprit:

```
// Clean up content to only include supported entity types
  Object.keys(options.content).forEach(function (type) {
    if (!SUPPORTED_ENTITY_TYPES.indexOf(type) >= 0) {
      delete options.content[type];
    }
  });
```

`!SUPPORTED_ENTITY_TYPES.indexOf(type) >= 0` evaluates to true for all entity types on my system, hence removing all of my precious data.

An explanation of why this happens can be found in my commit message.

It worked perfectly when I edited the condition to the following:

`SUPPORTED_ENTITY_TYPES.indexOf(type) === -1`

These are my installed versions:

```
contentful-import@6.0.1
node@8.9.1
npm@5.5.1
```


EDIT: Seems like this bug was introduced when changing implementation from `includes` to `indexOf` a couple of days ago:
https://github.com/contentful/contentful-import/commit/f6d039cde3df22ae69d8019301d66d8edc10fa82