### PR TITLE
fix(error-log): do not display log twice and throw only errors

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -152,11 +152,11 @@ export default function runContentfulImport (params) {
       })
     })
     .then((data) => {
-      const errorLog = log.filter((logMessage) => logMessage.level !== 'info' || logMessage.level !== 'warning')
-      const warningLog = log.filter((logMessage) => logMessage.level !== 'error' && logMessage.level !== 'info')
-      displayErrorLog(warningLog)
+      const errorLog = log.filter((logMessage) => logMessage.level !== 'info' && logMessage.level !== 'warning')
+      const displayLog = log.filter((logMessage) => logMessage.level !== 'info')
+      displayErrorLog(displayLog)
+
       if (errorLog.length) {
-        displayErrorLog(errorLog)
         return writeErrorLogFile(options.errorLogFile, errorLog)
           .then(() => {
             const multiError = new Error('Errors occured')


### PR DESCRIPTION
We did log the error log twice and errorLog still contained warnings. This PR fixes this.