### PR TITLE
fix(webhooks): exclude secret headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ The data to import should be structured like this:
 - This tool currently does **not** support the import of roles.
 - This tool is expecting the target space to have the same default locale as your previously exported space.
 - Imported webhooks with credentials will be imported as normal webhooks. Credentials should be added manually afterwards.
+- Imported webhooks with secret headers will be imported without these headers. Secret headers should be added manuall afterwards.
 - If you have custom UI extensions, you need to reinstall them manually in the new space.
 
 ## :memo: Changelog

--- a/lib/transform/transformers.js
+++ b/lib/transform/transformers.js
@@ -20,6 +20,16 @@ export function webhooks (webhook) {
   if (webhook.httpBasicUsername) {
     delete webhook.httpBasicUsername
   }
+
+  // Workaround for webhooks with secret headers
+  if (webhook.headers) {
+    webhook.headers = webhook.headers.reduce((accumulator, header) => {
+      if (!header.secret) {
+        accumulator.push(header)
+      }
+      return accumulator
+    }, [])
+  }
   return webhook
 }
 

--- a/lib/transform/transformers.js
+++ b/lib/transform/transformers.js
@@ -23,13 +23,9 @@ export function webhooks (webhook) {
 
   // Workaround for webhooks with secret headers
   if (webhook.headers) {
-    webhook.headers = webhook.headers.reduce((accumulator, header) => {
-      if (!header.secret) {
-        accumulator.push(header)
-      }
-      return accumulator
-    }, [])
+    webhook.headers = webhook.headers.filter(header => !header.secret)
   }
+
   return webhook
 }
 

--- a/test/unit/transform/transformers.test.js
+++ b/test/unit/transform/transformers.test.js
@@ -69,6 +69,16 @@ test('It should transform webhook with credentials to normal webhook', () => {
   expect(transformedWebhook.httpBasicUsername).toBeFalsy()
 })
 
+test('It should transform webhook with secret headers', () => {
+  const webhookMock = cloneMock('webhook')
+  const secretHeader = {key: 'Authorization', secret: true}
+  const nonSecretHeader = {key: 'headerkey', value: 'headerval'}
+  const headers = [secretHeader, nonSecretHeader]
+  webhookMock.headers = headers
+  const transformedWebhook = transformers.webhooks(webhookMock)
+  expect(transformedWebhook.headers).toHaveLength(headers.length - 1)
+})
+
 test('It should transform a locale and return it', () => {
   const localeMock = cloneMock('locale')
   localeMock.code = 'de-DE'


### PR DESCRIPTION
For security reasons, the value of secret headers are not exported with webhooks. This was causing an invalid webhook body on the import (and a 500 error). The fix is to exclude secret headers from the import.