### PR TITLE
Iterate over each entry in entriesToArchive

### DIFF
--- a/lib/tasks/push-to-space/publishing.js
+++ b/lib/tasks/push-to-space/publishing.js
@@ -51,7 +51,7 @@ export function archiveEntities (entities) {
   const type = entity.sys.type || 'unknown type'
   logEmitter.emit('info', `Archiving ${entities.length} ${type}s`)
 
-  return Promise.map(entitiesToArchive, () => {
+  return Promise.map(entitiesToArchive, (entity) => {
     return entity.archive()
       .then((entity) => {
         return entity


### PR DESCRIPTION
bug: if `entitiesToArchive` was > 1 item long, it would attempt to archive the first item n times, resulting in errors.