### PR TITLE
--skip-assets, --merge-entries

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -121,6 +121,7 @@ export default function runContentfulImport (params) {
           contentModelOnly: options.contentModelOnly,
           skipLocales: options.skipLocales,
           skipContentModel: options.skipContentModel,
+          skipAssets: options.skipAssets,
           skipContentPublishing: options.skipContentPublishing,
           prePublishDelay: options.prePublishDelay,
           timeout: options.timeout,

--- a/lib/index.js
+++ b/lib/index.js
@@ -122,6 +122,7 @@ export default function runContentfulImport (params) {
           skipLocales: options.skipLocales,
           skipContentModel: options.skipContentModel,
           skipAssets: options.skipAssets,
+          mergeEntries: options.mergeEntries,
           skipContentPublishing: options.skipContentPublishing,
           prePublishDelay: options.prePublishDelay,
           timeout: options.timeout,

--- a/lib/tasks/push-to-space/creation.js
+++ b/lib/tasks/push-to-space/creation.js
@@ -1,7 +1,7 @@
 import Promise from 'bluebird'
 import {partial} from 'lodash/function'
 import {find} from 'lodash/collection'
-import {assign, get, omitBy, omit} from 'lodash/object'
+import {assign, get, omitBy, omit, merge} from 'lodash/object'
 
 import getEntityName from 'contentful-batch-libs/dist/get-entity-name'
 import { logEmitter } from 'contentful-batch-libs/dist/logging'
@@ -11,20 +11,20 @@ import { logEmitter } from 'contentful-batch-libs/dist/logging'
  * Applies to all entities except Entries, as the CMA API for those is slightly different
  * See handleCreationErrors for details on what errors reject the promise or not.
  */
-export function createEntities (context, entities, destinationEntities, concurrency = 6) {
-  return createEntitiesWithConcurrency(context, entities, destinationEntities, concurrency, Promise.map)
+export function createEntities (context, entities, destinationEntities, concurrency = 6, merge = false) {
+  return createEntitiesWithConcurrency(context, entities, destinationEntities, concurrency, Promise.map, merge)
 }
 
 export function createLocales (context, entities, destinationEntities) {
   return createEntitiesWithConcurrency(context, entities, destinationEntities, 1, Promise.mapSeries)
 }
 
-function createEntitiesWithConcurrency (context, entities, destinationEntities, concurrency, mapper) {
+function createEntitiesWithConcurrency (context, entities, destinationEntities, concurrency, mapper, merge = false) {
   return mapper(entities, (entity) => {
     const destinationEntity = getDestinationEntityForSourceEntity(destinationEntities, entity.transformed)
     const operation = destinationEntity ? 'update' : 'create'
     const promise = destinationEntity
-      ? updateDestinationWithSourceData(destinationEntity, entity.transformed)
+      ? updateDestinationWithSourceData(destinationEntity, entity.transformed, false)
       : createInDestination(context, entity.transformed)
     return promise
       .then(partial(creationSuccessNotifier, operation))
@@ -35,19 +35,19 @@ function createEntitiesWithConcurrency (context, entities, destinationEntities, 
 /**
  * Creates a list of entries
  */
-export function createEntries (context, entries, destinationEntries) {
+export function createEntries (context, entries, destinationEntries, merge = false) {
   return Promise.map(entries, (entry) => createEntry(
-    entry, context.target, context.skipContentModel, destinationEntries),
+    entry, context.target, context.skipContentModel, destinationEntries, merge),
   {concurrency: 6})
 }
 
-function createEntry (entry, target, skipContentModel, destinationEntries) {
+function createEntry (entry, target, skipContentModel, destinationEntries, merge = false) {
   const contentTypeId = entry.original.sys.contentType.sys.id
   const destinationEntry = getDestinationEntityForSourceEntity(
     destinationEntries, entry.transformed)
   const operation = destinationEntry ? 'update' : 'create'
   const promise = destinationEntry
-    ? updateDestinationWithSourceData(destinationEntry, entry.transformed)
+    ? updateDestinationWithSourceData(destinationEntry, entry.transformed, merge)
     : createEntryInDestination(target, contentTypeId, entry.transformed)
   return promise
     .then(partial(creationSuccessNotifier, operation))
@@ -55,9 +55,13 @@ function createEntry (entry, target, skipContentModel, destinationEntries) {
       destinationEntries))
 }
 
-function updateDestinationWithSourceData (destinationEntity, sourceEntity) {
+function updateDestinationWithSourceData (destinationEntity, sourceEntity, mergeNotAssign = false) {
   const plainData = getPlainData(sourceEntity)
-  assign(destinationEntity, plainData)
+  if (mergeNotAssign) {
+    merge(destinationEntity, plainData)
+  } else {
+    assign(destinationEntity, plainData)
+  }
   return destinationEntity.update()
 }
 

--- a/lib/tasks/push-to-space/push-to-space.js
+++ b/lib/tasks/push-to-space/push-to-space.js
@@ -47,6 +47,7 @@ export default function pushToSpace ({
   environmentId,
   prePublishDelay,
   contentModelOnly,
+  skipAssets,
   skipContentModel,
   skipLocales,
   skipContentPublishing,
@@ -174,7 +175,7 @@ export default function pushToSpace ({
             }
           })
       }),
-      skip: (ctx) => contentModelOnly
+      skip: (ctx) => contentModelOnly || skipAssets
     },
     {
       title: 'Publishing Assets',
@@ -185,7 +186,7 @@ export default function pushToSpace ({
             ctx.data.publishedAssets = assets
           })
       }),
-      skip: (ctx) => contentModelOnly || skipContentPublishing
+      skip: (ctx) => contentModelOnly || skipContentPublishing || skipAssets
     },
     {
       title: 'Archiving Assets',
@@ -196,7 +197,7 @@ export default function pushToSpace ({
             ctx.data.archivedAssets = assets
           })
       }),
-      skip: (ctx) => contentModelOnly || skipContentPublishing
+      skip: (ctx) => contentModelOnly || skipContentPublishing || skipAssets
     },
     {
       title: 'Importing Content Entries',

--- a/lib/tasks/push-to-space/push-to-space.js
+++ b/lib/tasks/push-to-space/push-to-space.js
@@ -48,6 +48,7 @@ export default function pushToSpace ({
   prePublishDelay,
   contentModelOnly,
   skipAssets,
+  mergeEntries,
   skipContentModel,
   skipLocales,
   skipContentPublishing,
@@ -205,7 +206,8 @@ export default function pushToSpace ({
         return creation.createEntries(
           {target: ctx.environment, skipContentModel},
           sourceData.entries,
-          destinationData.entries
+          destinationData.entries,
+          mergeEntries
         )
           .then(removeEmptyEntities)
           .then((entries) => {

--- a/lib/usageParams.js
+++ b/lib/usageParams.js
@@ -45,6 +45,11 @@ export default yargs
     type: 'boolean',
     default: false
   })
+  .option('skip-assets', {
+    describe: 'Skips importing assets',
+    type: 'boolean',
+    default: false
+  })
   .option('error-log-file', {
     describe: 'Full path to the error log file',
     type: 'string'

--- a/lib/usageParams.js
+++ b/lib/usageParams.js
@@ -50,6 +50,11 @@ export default yargs
     type: 'boolean',
     default: false
   })
+  .option('merge-entries', {
+    describe: 'Merge instead of overwriting entries - e.g. to preserve locales',
+    type: 'boolean',
+    default: false
+  })
   .option('error-log-file', {
     describe: 'Full path to the error log file',
     type: 'string'


### PR DESCRIPTION
Importing was deleting translations when target had them, but source did not.  Added --merge-entries to fix.  Also didn't want to import assets.  

It was easier for me to tweak your import than to start from scratch.  Maybe you guys want this.  Maybe not.  Minimal testing done.
