### PR TITLE
fix(import): check for tags enabled

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -174,7 +174,7 @@ export default function runContentfulImport (params) {
       if (errorLog.length) {
         return writeErrorLogFile(options.errorLogFile, errorLog)
           .then(() => {
-            const multiError = new Error('Errors occured')
+            const multiError = new Error('Errors occurred')
             multiError.name = 'ContentfulMultiError'
             multiError.errors = errorLog
             throw multiError

--- a/lib/transform/transform-space.js
+++ b/lib/transform/transform-space.js
@@ -19,6 +19,7 @@ export default function (
   const baseSpaceData = omit(sourceData, ...entities)
 
   sourceData['locales'] = sortLocales(sourceData['locales'])
+  const tagsEnabled = !!destinationData.tags
 
   return entities.reduce((transformedSpaceData, type) => {
     // tags don't contain links to other entities, don't need to be sorted
@@ -26,7 +27,7 @@ export default function (
 
     const transformedEntities = sortedEntities.map((entity) => ({
       original: entity,
-      transformed: transformers[type](entity, destinationData[type])
+      transformed: transformers[type](entity, destinationData[type], tagsEnabled)
     }))
     transformedSpaceData[type] = transformedEntities
     return transformedSpaceData

--- a/lib/transform/transformers.js
+++ b/lib/transform/transformers.js
@@ -15,8 +15,8 @@ export function tags (tag) {
   return tag
 }
 
-export function entries (entry) {
-  return entry
+export function entries (entry, _, tagsEnabled = false) {
+  return removeMetadataTags(entry, tagsEnabled)
 }
 
 export function webhooks (webhook) {
@@ -33,7 +33,7 @@ export function webhooks (webhook) {
   return webhook
 }
 
-export function assets (asset) {
+export function assets (asset, _, tagsEnabled = false) {
   const transformedAsset = omit(asset, 'sys')
   transformedAsset.sys = pick(asset.sys, 'id')
   transformedAsset.fields = pick(asset.fields, 'title', 'description')
@@ -51,7 +51,7 @@ export function assets (asset) {
     },
     {}
   )
-  return transformedAsset
+  return removeMetadataTags(transformedAsset, tagsEnabled)
 }
 
 export function locales (locale, destinationLocales) {
@@ -62,4 +62,11 @@ export function locales (locale, destinationLocales) {
   }
 
   return transformedLocale
+}
+
+function removeMetadataTags (entity, tagsEnabled = false) {
+  if (!tagsEnabled) {
+    delete entity.metadata
+  }
+  return entity
 }

--- a/test/unit/transform/transformers.test.js
+++ b/test/unit/transform/transformers.test.js
@@ -88,3 +88,17 @@ test('It should transform a locale and return it', () => {
   const transformedLocale = transformers.locales(localeMock, destinationLocalesMock)
   expect(transformedLocale.sys.id).toBe(destinationLocalesMock[0].sys.id)
 })
+
+test('It should transform an entry with tags enabled, and return it', () => {
+  const entryMock = cloneMock('entry')
+  entryMock.metadata = {tags: []}
+  const transformed = transformers.entries(entryMock, null, true);
+  expect(transformed.metadata).toEqual({tags: []})
+})
+
+test('It should transform an entry with tags disabled, and return it', () => {
+  const entryMock = cloneMock('entry')
+  entryMock.metadata = {tags: []}
+  const transformed = transformers.entries(entryMock, null, false);
+  expect(transformed.metadata).toBe(undefined)
+})


### PR DESCRIPTION
This PR fixes a [reported issue](https://github.com/contentful/contentful-import/issues/251) where an import with metadata tags fails on a space with tags feature not activated yet.
In this case the import would always fail. This fix checks for tags being present in remote data, to detect tags enablement.

For spaces without tags being enabled, we strip metadata tags from every entity before importing.