### PR TITLE
fix(webhooks): url validation

### DIFF
--- a/lib/utils/schema.js
+++ b/lib/utils/schema.js
@@ -59,7 +59,7 @@ const localeSchema = {
 
 const webhookSchema = {
   name: Joi.string(),
-  url: Joi.string().uri().required(),
+  url: Joi.string().replace(/{[^}{]+?}/, 'x').regex(/^https?:\/\/[^ /}{][^ }{]*$/i).required(),
   topics: Joi.array().required(),
   httpBasicUsername: Joi.string().allow(['', null])
 }

--- a/lib/utils/schema.js
+++ b/lib/utils/schema.js
@@ -64,6 +64,9 @@ const webhookSchema = {
   httpBasicUsername: Joi.string().allow(['', null])
 }
 
+/**
+ * @returns normalized validation object. Don't use normalized output as payload
+ */
 const payloadSchema = Joi.object({
   entries: Joi.array().items([entrySchema]),
   contentTypes: Joi.array().items([contentTypeSchema]),

--- a/test/unit/utils/schema.test.js
+++ b/test/unit/utils/schema.test.js
@@ -1,0 +1,25 @@
+import { webhookSchema } from '../../../lib/utils/schema'
+import Joi from 'joi'
+
+describe('webhooks schema', () => {
+  test('with valid url', () => {
+    expect(Joi.assert('https://www.contentful.com', webhookSchema.url)).toBeUndefined()
+  })
+  test('with invalid url', () => {
+    try {
+      Joi.assert('ttps://www.contentful.com', webhookSchema.url)
+    } catch (e) {
+      expect(e.name).toBe('ValidationError')
+    }
+  })
+  test('with valid url containing custom payload definition', () => {
+    expect(Joi.assert('https://www.contentful.com/webhooks/{ /payload/sys/id }', webhookSchema.url)).toBeUndefined()
+  })
+  test('with invalid url containing custom payload definition', () => {
+    try {
+      Joi.assert('https://www.contentful.com/webhooks/{ /payload/sys/id ', webhookSchema.url)
+    } catch (e) {
+      expect(e.name).toBe('ValidationError')
+    }
+  })
+})


### PR DESCRIPTION
This fix allows the usage of JSON placeholders in webhook urls.

fixes #369 and https://github.com/contentful/contentful-cli/issues/577