### PR TITLE
Adds an error type option to skip writing the log file 

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -172,7 +172,7 @@ export default function runContentfulImport (params) {
       displayErrorLog(displayLog)
 
       if (errorLog.length) {
-        if(options.errorType = 'file') {
+        if(options.errorLogType = 'file') {
           return writeErrorLogFile(options.errorLogFile, errorLog)
           .then(() => {
             const multiError = new Error('Errors occurred')

--- a/lib/index.js
+++ b/lib/index.js
@@ -172,13 +172,20 @@ export default function runContentfulImport (params) {
       displayErrorLog(displayLog)
 
       if (errorLog.length) {
-        return writeErrorLogFile(options.errorLogFile, errorLog)
+        if(options.errorType = 'file') {
+          return writeErrorLogFile(options.errorLogFile, errorLog)
           .then(() => {
             const multiError = new Error('Errors occurred')
             multiError.name = 'ContentfulMultiError'
             multiError.errors = errorLog
             throw multiError
           })
+        } else {
+            const multiError = new Error('Errors occurred')
+            multiError.name = 'ContentfulMultiError'
+            multiError.errors = errorLog
+            throw multiError
+        }
       }
 
       console.log('The import was successful.')

--- a/lib/parseOptions.js
+++ b/lib/parseOptions.js
@@ -24,7 +24,8 @@ export default function parseOptions (params) {
     useVerboseRenderer: false,
     prePublishDelay: 3000,
     environmentId: 'master',
-    rawProxy: false
+    rawProxy: false,
+    errorLogType: 'file'
   }
 
   const configFile = params.config


### PR DESCRIPTION
We have a server that does not allow Writing to the file system, instead, we want to just send the error log back to the user. This allows us to pass a custom option to skip writing the error log file