### PR TITLE
fix(webhooks): support multiple placeholders [ZEND-1275]

### DIFF
--- a/lib/utils/schema.js
+++ b/lib/utils/schema.js
@@ -60,7 +60,7 @@ const localeSchema = {
 
 const webhookSchema = {
   name: Joi.string(),
-  url: Joi.string().replace(/{[^}{]+?}/, 'x').regex(/^https?:\/\/[^ /}{][^ }{]*$/i).required(),
+  url: Joi.string().replace(/{[^}{]+?}/g, 'x').regex(/^https?:\/\/[^ /}{][^ }{]*$/i).required(),
   topics: Joi.array().required(),
   httpBasicUsername: Joi.string().allow(['', null])
 }

--- a/test/unit/utils/schema.test.js
+++ b/test/unit/utils/schema.test.js
@@ -22,4 +22,16 @@ describe('webhooks schema', () => {
       expect(e.name).toBe('ValidationError')
     }
   })
+  test('with valid url containing more than one custom payload definition', () => {
+    expect(
+      Joi.assert('https://www.contentful.com/webhooks/{ /payload/sys/id }/{ /payload/sys/id }', webhookSchema.url)
+    ).toBeUndefined()
+  })
+  test('with invalid url containing more than one custom payload definition', () => {
+    try {
+      Joi.assert('https://www.contentful.com/webhooks/{ /payload/sys/id }/{ /payload/sys/id ', webhookSchema.url)
+    } catch (e) {
+      expect(e.name).toBe('ValidationError')
+    }
+  })
 })


### PR DESCRIPTION
As we support [webhooks with multiple placeholder](https://github.com/contentful/webhook_consumer/blob/326efa7a5377c56eb7a887a5b1c44c0342ae92a7/lib/request/request-options/transform-request.spec.js#L38) in the BE, the import tool should do so as well.