### PR TITLE
fix: parsing of large files > 512 MB [ZEND-3117]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -197,5 +197,3 @@ $RECYCLE.BIN/
 # ignore left over error files
 errorlogfile.json
 
-# test input
-large-space.json

--- a/.gitignore
+++ b/.gitignore
@@ -196,3 +196,6 @@ $RECYCLE.BIN/
 
 # ignore left over error files
 errorlogfile.json
+
+# test input
+large-space.json

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,11 +7,7 @@ import VerboseRenderer from 'listr-verbose-renderer'
 import { startCase } from 'lodash'
 import PQueue from 'p-queue'
 
-import {
-  setupLogging,
-  displayErrorLog,
-  writeErrorLogFile
-} from 'contentful-batch-libs/dist/logging'
+import { displayErrorLog, setupLogging, writeErrorLogFile } from 'contentful-batch-libs/dist/logging'
 import { wrapTask } from 'contentful-batch-libs/dist/listr'
 
 import initClient from './tasks/init-client'
@@ -35,9 +31,9 @@ function createListrOptions (options) {
   }
 }
 
-export default function runContentfulImport (params) {
+export default async function runContentfulImport (params) {
   const log = []
-  const options = parseOptions(params)
+  const options = await parseOptions(params)
   const listrOptions = createListrOptions(options)
   const requestQueue = new PQueue({
     interval: ONE_SECOND,
@@ -77,10 +73,11 @@ export default function runContentfulImport (params) {
         assertPayload(options.content)
       }
     },
+
     {
       title: 'Initialize client',
       task: wrapTask(async (ctx) => {
-        ctx.client = initClient(options)
+        ctx.client = initClient({ ...options, content: undefined })
       })
     },
     {

--- a/lib/parseOptions.js
+++ b/lib/parseOptions.js
@@ -78,6 +78,7 @@ export default async function parseOptions (params) {
   options.accessToken = options.managementToken
 
   if (!options.content) {
+    // using a stream parser allows input files > 512 MB
     const fileStream = fs.createReadStream(options.contentFile, { encoding: 'utf8' })
     options.content = await parseChunked(fileStream)
   }

--- a/lib/parseOptions.js
+++ b/lib/parseOptions.js
@@ -6,6 +6,7 @@ import { version } from '../package'
 import { getHeadersConfig } from './utils/headers'
 import { proxyStringToObject, agentFromProxy } from 'contentful-batch-libs/dist/proxy'
 import addSequenceHeader from 'contentful-batch-libs/dist/add-sequence-header'
+import { parseChunked } from '@discoveryjs/json-ext'
 
 const SUPPORTED_ENTITY_TYPES = [
   'contentTypes',
@@ -17,7 +18,7 @@ const SUPPORTED_ENTITY_TYPES = [
   'editorInterfaces'
 ]
 
-export default function parseOptions (params) {
+export default async function parseOptions (params) {
   const defaultOptions = {
     skipContentModel: false,
     skipLocales: false,
@@ -74,10 +75,12 @@ export default function parseOptions (params) {
   } else {
     options.errorLogFile = resolve(process.cwd(), options.errorLogFile)
   }
-
-  // Further processing
   options.accessToken = options.managementToken
-  options.content = options.content || JSON.parse(fs.readFileSync(options.contentFile))
+
+  if (!options.content) {
+    const fileStream = fs.createReadStream(options.contentFile, { encoding: 'utf8' })
+    options.content = await parseChunked(fileStream)
+  }
 
   // Clean up content to only include supported entity types
   Object.keys(options.content).forEach((type) => {

--- a/lib/tasks/get-destination-data.js
+++ b/lib/tasks/get-destination-data.js
@@ -20,6 +20,7 @@ async function batchedIdQuery ({ environment, type, ids, requestQueue }) {
   let totalFetched = 0
 
   const allPendingResponses = batches.map((idBatch) => {
+    // TODO: add batch count to indicate that it's running
     return requestQueue.add(async () => {
       const response = await environment[method]({
         'sys.id[in]': idBatch,

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,10 +5,10 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "contentful-import",
       "version": "0.0.0-determined-by-semantic-release",
       "license": "MIT",
       "dependencies": {
+        "@discoveryjs/json-ext": "^0.5.7",
         "bluebird": "^3.5.1",
         "cli-table3": "^0.6.0",
         "contentful-batch-libs": "^9.4.2",
@@ -2029,6 +2029,14 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@discoveryjs/json-ext": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
+      "integrity": "sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/@endemolshinegroup/cosmiconfig-typescript-loader": {
@@ -17772,6 +17780,11 @@
           }
         }
       }
+    },
+    "@discoveryjs/json-ext": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
+      "integrity": "sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw=="
     },
     "@endemolshinegroup/cosmiconfig-typescript-loader": {
       "version": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "url": "https://github.com/contentful/contentful-import/issues"
   },
   "dependencies": {
+    "@discoveryjs/json-ext": "^0.5.7",
     "bluebird": "^3.5.1",
     "cli-table3": "^0.6.0",
     "contentful-batch-libs": "^9.4.2",

--- a/test/unit/parseOptions.test.js
+++ b/test/unit/parseOptions.test.js
@@ -16,70 +16,64 @@ const toBeAbsolutePathWithPattern = (received, pattern) => {
   return (!isAbsolute(received) || !RegExp(`/${escapedPattern}$/`).test(received))
 }
 
-test('parseOptions requires spaceId', () => {
-  expect(
-    () => parseOptions({})
-  ).toThrow('The `spaceId` option is required.')
+test('parseOptions requires spaceId', async () => {
+  await expect(parseOptions({})).rejects.toThrow('The `spaceId` option is required.')
 })
 
-test('parseOptions requires managementToken', () => {
-  expect(
-    () => parseOptions({
-      spaceId
-    })
-  ).toThrow('The `managementToken` option is required.')
+test('parseOptions requires managementToken', async () => {
+  await expect(parseOptions({ spaceId })).rejects.toThrow('The `managementToken` option is required.')
 })
 
-test('parseOptions requires contentFile or content', () => {
-  expect(
-    () => parseOptions({
-      spaceId,
-      managementToken
-    })
-  ).toThrow('Either the `contentFile` or `content` option are required.')
-  expect(
-    () => parseOptions({
+test('parseOptions requires contentFile or content', async () => {
+  await expect(parseOptions({
+    spaceId,
+    managementToken
+  })
+  ).rejects.toThrow('Either the `contentFile` or `content` option are required.')
+
+  await expect(
+    parseOptions({
       spaceId,
       managementToken,
       content: {}
     })
-  ).not.toThrow('Either the `contentFile` or `content` option are required.')
-  expect(
-    () => parseOptions({
+  ).resolves.toBeTruthy()
+  await expect(
+    parseOptions({
       spaceId,
       managementToken,
       contentFile
     })
-  ).not.toThrow('Either the `contentFile` or `content` option are required.')
+  ).resolves.toBeTruthy()
 })
 
-test('parseOptions does not allow contentModelOnly and skipContentModel at the same time', () => {
-  expect(
-    () => parseOptions({
+test('parseOptions does not allow contentModelOnly and skipContentModel at the same time', async () => {
+  await expect(
+    parseOptions({
       spaceId,
       managementToken,
       contentFile,
       contentModelOnly: true,
       skipContentModel: true
     })
-  ).toThrow('`contentModelOnly` and `skipContentModel` cannot be used together')
+  ).rejects.toThrow('`contentModelOnly` and `skipContentModel` cannot be used together')
 })
 
-test('parseOptions does allow skipLocales only when contentModelOnly is set', () => {
-  expect(
+test('parseOptions does allow skipLocales only when contentModelOnly is set', async () => {
+  await expect(
     () => parseOptions({
       spaceId,
       managementToken,
       contentFile,
       skipLocales: true
     })
-  ).toThrow('`skipLocales` can only be used together with `contentModelOnly`')
+  ).rejects.toThrow('`skipLocales` can only be used together with `contentModelOnly`')
 })
 
-test('parseOptions sets correct default options', () => {
+test('parseOptions sets correct default options', async () => {
   const version = require(resolve(basePath, 'package.json')).version
 
-  const options = parseOptions({
+  const options = await parseOptions({
     spaceId,
     managementToken,
     contentFile
@@ -114,11 +108,11 @@ test('parseOptions sets correct default options', () => {
   expect(options.useVerboseRenderer).toBe(false)
 })
 
-test('parseOption accepts config file', () => {
+test('parseOption accepts config file', async () => {
   const configFileName = join('test', 'unit', 'example-config.json')
   const config = require(resolve(basePath, configFileName))
 
-  const options = parseOptions({
+  const options = await parseOptions({
     config: configFileName
   })
   Object.keys(config).forEach((key) => {
@@ -126,9 +120,9 @@ test('parseOption accepts config file', () => {
   })
 })
 
-test('parseOption overwrites errorLogFile', () => {
+test('parseOption overwrites errorLogFile', async () => {
   const errorLogFile = 'error.log'
-  const options = parseOptions({
+  const options = await parseOptions({
     spaceId,
     managementToken,
     contentFile,
@@ -137,19 +131,19 @@ test('parseOption overwrites errorLogFile', () => {
   expect(options.errorLogFile).toBe(resolve(basePath, errorLogFile))
 })
 
-test('parseOptions detects malformed proxy config', () => {
-  expect(
-    () => parseOptions({
+test('parseOptions detects malformed proxy config', async () => {
+  await expect(
+    parseOptions({
       spaceId,
       managementToken,
       contentFile,
       proxy: 'invalid'
     })
-  ).toThrow('Please provide the proxy config in the following format:\nhost:port or user:password@host:port')
+  ).rejects.toThrow('Please provide the proxy config in the following format:\nhost:port or user:password@host:port')
 })
 
-test('parseOption accepts proxy config as string', () => {
-  const options = parseOptions({
+test('parseOption accepts proxy config as string', async () => {
+  const options = await parseOptions({
     spaceId,
     managementToken,
     contentFile,
@@ -162,8 +156,8 @@ test('parseOption accepts proxy config as string', () => {
   expect(options.httpsAgent.options).not.toHaveProperty('auth')
 })
 
-test('parseOption accepts proxy config as object', () => {
-  const options = parseOptions({
+test('parseOption accepts proxy config as object', async () => {
+  const options = await parseOptions({
     spaceId,
     managementToken,
     content: {},
@@ -181,8 +175,8 @@ test('parseOption accepts proxy config as object', () => {
   expect(options.httpsAgent.options).not.toHaveProperty('auth')
 }, 'broken')
 
-test('parseOption cleans up content to only include supported entity types', () => {
-  const options = parseOptions({
+test('parseOption cleans up content to only include supported entity types', async () => {
+  const options = await parseOptions({
     spaceId,
     managementToken,
     content: {
@@ -202,11 +196,11 @@ test('parseOption cleans up content to only include supported entity types', () 
   expect(content.invalid).toBeUndefined()
 })
 
-test('parseOptions accepts custom application & feature', () => {
+test('parseOptions accepts custom application & feature', async () => {
   const managementApplication = 'managementApplicationMock'
   const managementFeature = 'managementFeatureMock'
 
-  const options = parseOptions({
+  const options = await parseOptions({
     spaceId,
     managementToken,
     content: {},
@@ -218,8 +212,8 @@ test('parseOptions accepts custom application & feature', () => {
   expect(options.feature).toBe(managementFeature)
 })
 
-test('parseOption parses headers option', () => {
-  const options = parseOptions({
+test('parseOption parses headers option', async () => {
+  const options = await parseOptions({
     spaceId,
     managementToken,
     content: {},
@@ -235,8 +229,8 @@ test('parseOption parses headers option', () => {
   })
 })
 
-test('parses params.header if provided', function () {
-  const config = parseOptions({
+test('parses params.header if provided', async () => {
+  const config = await parseOptions({
     spaceId,
     managementToken,
     content: {},


### PR DESCRIPTION
Parsing large input files (> 512 MB) caused `JSON.parse` to throw an error:
```
Error: Cannot create a string longer than 0x1fffffe8 characters
```
this is a node internal hard limit for parsing strings to objects. 

This PR introduces a streaming library to allow bigger input files.