### PR TITLE
Fix asset transformer with existing protocol

### DIFF
--- a/lib/transform/transformers.js
+++ b/lib/transform/transformers.js
@@ -43,7 +43,7 @@ export function assets (asset, _, tagsEnabled = false) {
       newFile[locale] = pick(localizedFile, 'contentType', 'fileName')
       if (!localizedFile.uploadFrom) {
         const assetUrl = localizedFile.url || localizedFile.upload
-        newFile[locale].upload = `${/^(http|https):\/\/i/.test(assetUrl) ? '' : 'https:'}${assetUrl}`
+        newFile[locale].upload = `${/^(http|https):\/\//i.test(assetUrl) ? '' : 'https:'}${assetUrl}`
       } else {
         newFile[locale].uploadFrom = localizedFile.uploadFrom
       }

--- a/test/unit/transform/transformers.test.js
+++ b/test/unit/transform/transformers.test.js
@@ -28,7 +28,7 @@ test('It should transform processed asset with and without protocol', () => {
   const transformedAsset = transformers.assets(assetMock)
   expect(transformedAsset.fields.file['en-US'].upload).toBeTruthy()
   expect(transformedAsset.fields.file['de-DE'].upload).toBeTruthy()
-  expect(transformedAsset.fields.file['en-US'].upload).toBe('https:' + assetMock.fields.file['en-US'].url)
+  expect(transformedAsset.fields.file['en-US'].upload).toBe(assetMock.fields.file['en-US'].url)
   expect(transformedAsset.fields.file['de-DE'].upload).toBe('https:' + assetMock.fields.file['de-DE'].url)
 })
 


### PR DESCRIPTION
### What does this PR do?
Modifies the regex used in the asset transformer to properly check for protocol on asset url.

### Background Info
The protocol regex was always failing to detect protocol because the case insensitive modifier was being included in the regex instead of being outside the regex definition. This caused every url to have an extra `https:` prepended even those that already provided the protocol.

The test was also incorrectly checking for an extra `https:` to be added and thus started to fail with the changes in this PR so it was updated to pass.

This PR was tested against an import of 300+ images from an external source that all had the protocol already attached. Without the PR the import failed and the validation error showed the extra `https:` being added. With this PR the import worked successfully.