### PR TITLE
fix: use null and not undefined as fallback code values for locales [PHX-2767]

### DIFF
--- a/lib/utils/sort-locales.js
+++ b/lib/utils/sort-locales.js
@@ -20,16 +20,23 @@ export default function sortLocales (locales) {
   return sortByFallbackKey(localeByFallback)
 }
 
-function sortByFallbackKey (localeByFallback, key) {
+function sortByFallbackKey(localeByFallback, key) {
   if (!localeByFallback[key]) {
     return []
   }
 
   const sortedLocales = localeByFallback[key]
 
-  sortedLocales.forEach(locale => {
-    sortByFallbackKey(localeByFallback, locale.code)
-      .forEach(x => sortedLocales.push(x))
+  sortedLocales.forEach((locale) => {
+    sortByFallbackKey(localeByFallback, locale.code).forEach((x) => sortedLocales.push(x))
+  })
+
+  // We have to reset the undefined fallback code to null so that the locales are properly created without fallback and
+  // not the default (en-US)
+  sortedLocales.forEach((locale) => {
+    if (!locale.fallbackCode) {
+      locale.fallbackCode = null
+    }
   })
 
   return sortedLocales

--- a/test/unit/sort-locales.test.js
+++ b/test/unit/sort-locales.test.js
@@ -58,9 +58,24 @@ test('Sorts locales by "fallback" order', () => {
 
   expect(sortedLocales).toHaveLength(9)
 
-  expect(sortedLocales.map(x => x.code)).toEqual(
-    ['base', 'base2', 'a', 'b', 'c', 'fallback_a', 'fallback_fallback_a', 'fallback_b', 'fallback_c']
-  )
+  expect(sortedLocales.map((x) => x.code)).toEqual([
+    'base',
+    'base2',
+    'a',
+    'b',
+    'c',
+    'fallback_a',
+    'fallback_fallback_a',
+    'fallback_b',
+    'fallback_c',
+  ])
+})
+
+test('Does not mutate fallbackCode to undefined during sorting', () => {
+  const sortedLocales = sortLocales(locales)
+  // We need empty fallbackCode values to be null not undefined as only this way they will be properly created by the
+  // contentful-management client without en-US fallback
+  expect(sortedLocales.filter((x) => x.fallbackCode !== undefined)).toHaveLength(9)
 })
 
 /*


### PR DESCRIPTION
Aims to fix [this issue](https://github.com/contentful/contentful-cli/issues/2170).

See issue description for all the details.