### PR TITLE
fix: execution as CLI [NONE]

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
   },
   "tsup": {
     "entry": [
-      "lib/index.ts"
+      "lib/index.ts",
+      "lib/usageParams.ts"
     ],
     "format": [
       "cjs",


### PR DESCRIPTION
After the TS migration, [`usageParams.ts`](https://github.com/contentful/contentful-import/blob/master/lib/usageParams.ts) is not part of the bundle, and therefore can not be imported [here](https://github.com/contentful/contentful-import/blob/master/bin/contentful-import#L3). The change adds it as additiuonal entry point for the bundler to ensure it get's exported.  