### PR TITLE
chore: change ownership to developer-experience [PHX-2975]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @contentful/team-phoenix
+* @contentful/team-developer-experience

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -7,8 +7,8 @@ metadata:
   annotations:
     circleci.com/project-slug: github/contentful/contentful-import
     github.com/project-slug: contentful/contentful-import
-    contentful.com/ci-alert-slack: prd-phoenix-ci-alerts
+    contentful.com/ci-alert-slack: prd-extensibility-bots
 spec:
   type: cli
   lifecycle: production
-  owner: group:team-phoenix
+  owner: group:team-developer-experience


### PR DESCRIPTION
change ownership from `phoenix` to `developer-experience`
