### PR TITLE
fix: default should be last in exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,10 +9,10 @@
     "node": ">=18"
   },
   "exports": {
-    "default": "./dist/index.js",
     "require": "./dist/index.js",
     "import": "./dist/index.mjs",
-    "node": "./dist/index.js"
+    "node": "./dist/index.js",
+    "default": "./dist/index.js"
   },
   "bin": {
     "contentful-import": "./bin/contentful-import"


### PR DESCRIPTION
This fixes issue #955, "Error: Module not found: Error: Default condition should be last one".

I haven't created an open source PR before, so I apologize if I haven't gotten something quite right.  There is very little info in the contributing guidelines.