### PR TITLE
chore: update README with embargoed asset info [DX-63]

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,8 @@ Path to a JSON file with the configuration options. This file will be merged wit
 
 ## :rescue_worker_helmet: Troubleshooting
 
+### Proxy
+
 Unable to connect to Contentful through your Proxy? Try to set the `rawProxy` option to `true`.
 
 ```javascript
@@ -223,6 +225,24 @@ contentfulImport({
   rawProxy: true,
   ...
 })
+```
+
+### Embargoed Assets
+
+If a space is configured to use the [embargoed assets feature](https://www.contentful.com/help/media/embargoed-assets/), certain options will need to be set to use the export/import tooling. When exporting content ([using `contentful-export`](https://github.com/contentful/contentful-export)), the `downloadAssets` option must be set to `true`. This will download the asset files to your local machine. Then, when importing content, the `uploadAssets` option must be set to `true` and the `assetsDirectory` must be set to the directory that contains all of the exported asset folders.
+
+```javascript
+const contentfulImport = require('contentful-import')
+
+const options = {
+  contentFile: '/path/to/result/of/contentful-export.json',
+  spaceId: '<space_id>',
+  managementToken: '<content_management_api_key>',
+  uploadAssets: true,
+  assetsDirectory: '/path/to/exported/assets.json'
+}
+
+contentfulImport(options)
 ```
 
 ## :card_file_box: Expected input data structure


### PR DESCRIPTION
Add instructions in the `Troubleshooting` section for how to use `contentful-export` and `contentful-import` with embargoed assets. See equivalent PR in `contentful-export` here: https://github.com/contentful/contentful-export/pull/2037