### PR TITLE
fix: use filename for local asset to match export behavior [DX-336]

### DIFF
--- a/lib/tasks/push-to-space/assets.ts
+++ b/lib/tasks/push-to-space/assets.ts
@@ -1,16 +1,16 @@
 import fs from 'fs'
-import { join } from 'path'
 import { promisify } from 'util'
 
 import getEntityName from 'contentful-batch-libs/dist/get-entity-name'
 import { logEmitter } from 'contentful-batch-libs/dist/logging'
+import { buildLocalFilePath } from '../../utils/buildLocalFilePath'
 import { ContentfulAssetError, ContentfulEntityError } from '../../utils/errors'
 
 const stat = promisify(fs.stat)
 
-export async function getAssetStreamForURL (url, assetsDirectory) {
-  const [, assetPath] = url.split('//')
-  const filePath = join(assetsDirectory, assetPath)
+export async function getAssetStreamForURL (url, assetsDirectory, fileName) {
+  const filePath = buildLocalFilePath(url, assetsDirectory, fileName)
+
   try {
     await stat(filePath)
     return fs.createReadStream(filePath)

--- a/lib/tasks/push-to-space/push-to-space.ts
+++ b/lib/tasks/push-to-space/push-to-space.ts
@@ -243,7 +243,7 @@ export default function pushToSpace ({
             allPendingUploads.push(requestQueue.add(async () => {
               try {
                 logEmitter.emit('info', `Uploading Asset file ${file.upload}`)
-                const assetStream = await assets.getAssetStreamForURL(file.upload, assetsDirectory)
+                const assetStream = await assets.getAssetStreamForURL(file.upload, assetsDirectory, file.fileName)
                 const upload = await ctx.environment.createUpload({
                   fileName: asset.transformed.sys.id,
                   file: assetStream
@@ -282,7 +282,7 @@ export default function pushToSpace ({
           return
         }
         const assetsToProcess = await creation.createEntities({
-          context: { target: ctx.environment, type: 'Asset'},
+          context: { target: ctx.environment, type: 'Asset' },
           entities: sourceData.assets,
           destinationEntitiesById: destinationDataById.assets,
           skipUpdates: skipAssetUpdates,

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -15,7 +15,16 @@ export type ResourcesUnion = (ContentTypeProps | TagProps | LocaleProps | EntryP
 export type DestinationData = Resources
 
 export type TransformedAsset = {
-  fields: { file: { upload?: string, uploadFrom: Link<'Upload'> }[] },
+  fields: {
+    file: {
+      [locale: string]: {
+        upload?: string,
+        uploadFrom?: Link<'Upload'>,
+        fileName?: string,
+        contentType?: string
+      }
+    }
+  },
   sys: {id: string}
 }
 

--- a/lib/utils/buildLocalFilePath.ts
+++ b/lib/utils/buildLocalFilePath.ts
@@ -1,0 +1,15 @@
+import path from 'path'
+
+export function buildLocalFilePath (url, directory, fileName) {
+  // handle urls without protocol
+  if (url.startsWith('//')) {
+    url = 'https:' + url
+  }
+
+  const { host, pathname } = new URL(url)
+  // Extract directory path without leading slash
+  const pathWithoutFilename = pathname.substring(1, pathname.lastIndexOf('/') + 1)
+  const localFilePath = fileName ? path.join(directory, host, pathWithoutFilename, fileName) : path.join(directory, host, decodeURIComponent(pathname))
+
+  return localFilePath
+}

--- a/test/integration/exports/with-assets/space-with-downloaded-assets.json
+++ b/test/integration/exports/with-assets/space-with-downloaded-assets.json
@@ -354,7 +354,7 @@
                 "height": 640
               }
             },
-            "fileName": "Window",
+            "fileName": "logo.jpg",
             "contentType": "image/jpeg"
           }
         }
@@ -428,7 +428,7 @@
                 "height": 480
               }
             },
-            "fileName": "What",
+            "fileName": "logo.jpg",
             "contentType": "image/jpeg"
           }
         }

--- a/test/unit/tasks/push/push-to-space.test.ts
+++ b/test/unit/tasks/push/push-to-space.test.ts
@@ -250,10 +250,12 @@ test('Upload each local asset file before pushing to space', () => {
         fields: {
           file: {
             'en-US': {
-              upload: 'https://images/contentful-en.jpg'
+              upload: 'https://images/contentful-en.jpg',
+              fileName: 'contentful-en.jpg'
             },
             'de-DE': {
-              upload: 'https://images/contentful-de.jpg'
+              upload: 'https://images/contentful-de.jpg',
+              fileName: 'contentful-de.jpg'
             }
           }
         }
@@ -278,8 +280,8 @@ test('Upload each local asset file before pushing to space', () => {
     .run({ data: {} })
     .then(() => {
       expect((assets.getAssetStreamForURL as jest.Mock).mock.calls).toHaveLength(2)
-      expect(assets.getAssetStreamForURL).toHaveBeenCalledWith('https://images/contentful-en.jpg', 'assets')
-      expect(assets.getAssetStreamForURL).toHaveBeenCalledWith('https://images/contentful-de.jpg', 'assets')
+      expect(assets.getAssetStreamForURL).toHaveBeenCalledWith('https://images/contentful-en.jpg', 'assets', 'contentful-en.jpg')
+      expect(assets.getAssetStreamForURL).toHaveBeenCalledWith('https://images/contentful-de.jpg', 'assets', 'contentful-de.jpg')
       expect(transformedAssets[0].transformed.fields.file['en-US']).not.toHaveProperty('upload')
       expect(transformedAssets[0].transformed.fields.file['en-US']).toHaveProperty('uploadFrom')
     })

--- a/test/unit/transform/transformers.test.ts
+++ b/test/unit/transform/transformers.test.ts
@@ -8,8 +8,8 @@ test('It should transform processed asset', () => {
   const assetMock = cloneMock('asset')
   assetMock.fields = {
     file: {
-      'en-US': { fileName: 'filename.jpg', url: '//server/filename.jpg' },
-      'de-DE': { fileName: 'filename.jpg', url: '//server/filename-de.jpg' }
+      'en-US': { fileName: 'filename.jpg', url: '//server/filename.jpg', contentType: 'image/jpeg' },
+      'de-DE': { fileName: 'filename.jpg', url: '//server/filename-de.jpg', contentType: 'image/jpeg' }
     }
   }
   const transformedAsset = transformers.assets(assetMock, _)
@@ -17,6 +17,10 @@ test('It should transform processed asset', () => {
   expect(transformedAsset.fields.file['de-DE'].upload).toBeTruthy()
   expect(transformedAsset.fields.file['en-US'].upload).toBe('https:' + assetMock.fields.file['en-US'].url)
   expect(transformedAsset.fields.file['de-DE'].upload).toBe('https:' + assetMock.fields.file['de-DE'].url)
+  expect(transformedAsset.fields.file['en-US'].fileName).toBe('filename.jpg')
+  expect(transformedAsset.fields.file['de-DE'].fileName).toBe('filename.jpg')
+  expect(transformedAsset.fields.file['en-US'].contentType).toBe('image/jpeg')
+  expect(transformedAsset.fields.file['de-DE'].contentType).toBe('image/jpeg')
 })
 
 test('It should transform processed asset with and without protocol', () => {

--- a/test/unit/utils/buildLocalFilePath.test.ts
+++ b/test/unit/utils/buildLocalFilePath.test.ts
@@ -1,0 +1,68 @@
+import path from 'path'
+import { buildLocalFilePath } from '../../../lib/utils/buildLocalFilePath'
+
+describe('buildLocalFilePath', () => {
+  const baseDirectory = '/export'
+
+  test('builds correct path for standard URL', () => {
+    const url = 'https://images.ctfassets.net/space123/asset456/hash789/image.jpg'
+    const fileName = 'image.jpg'
+
+    const result = buildLocalFilePath(url, baseDirectory, fileName)
+
+    expect(result).toBe(path.join(baseDirectory, 'images.ctfassets.net', 'space123/asset456/hash789/', fileName))
+  })
+
+  test('builds correct path for URL with Unicode filename', () => {
+    const url = 'https://images.ctfassets.net/space123/asset456/hash789/测试文件.jpg'
+    const fileName = '测试文件.jpg'
+
+    const result = buildLocalFilePath(url, baseDirectory, fileName)
+
+    expect(result).toBe(path.join(baseDirectory, 'images.ctfassets.net', 'space123/asset456/hash789/', fileName))
+  })
+
+  test('handles long Unicode filename', () => {
+    const url = 'https://images.ctfassets.net/space123/asset456/hash789/encoded.jpg'
+    const fileName = '测试文件'.repeat(25) + '.jpg'
+
+    const result = buildLocalFilePath(url, baseDirectory, fileName)
+
+    expect(result).toBe(path.join(baseDirectory, 'images.ctfassets.net', 'space123/asset456/hash789/', fileName))
+  })
+
+  test('handles different filename than URL path', () => {
+    const url = 'https://images.ctfassets.net/space123/asset456/hash789/encoded_filename.jpg'
+    const fileName = 'actual filename with spaces.jpg'
+
+    const result = buildLocalFilePath(url, baseDirectory, fileName)
+
+    expect(result).toBe(path.join(baseDirectory, 'images.ctfassets.net', 'space123/asset456/hash789/', fileName))
+  })
+
+  test('handles nested base directory', () => {
+    const url = 'https://images.ctfassets.net/space123/asset456/hash789/image.jpg'
+    const fileName = 'image.jpg'
+    const customDirectory = '/custom/export/path'
+
+    const result = buildLocalFilePath(url, customDirectory, fileName)
+
+    expect(result).toBe(path.join(customDirectory, 'images.ctfassets.net', 'space123/asset456/hash789/', fileName))
+  })
+
+  test('fallback to URL pathname when fileName is undefined', () => {
+    const url = 'https://images.ctfassets.net/space123/asset456/hash789/encoded_filename.jpg'
+
+    const result = buildLocalFilePath(url, baseDirectory, undefined)
+
+    expect(result).toBe(path.join(baseDirectory, 'images.ctfassets.net', '/space123/asset456/hash789/encoded_filename.jpg'))
+  })
+
+  test('fallback handles Unicode filename in URL', () => {
+    const url = 'https://images.ctfassets.net/space123/asset456/hash789/测试文件.jpg'
+
+    const result = buildLocalFilePath(url, baseDirectory, null)
+
+    expect(result).toBe(path.join(baseDirectory, 'images.ctfassets.net', '/space123/asset456/hash789/测试文件.jpg'))
+  })
+})


### PR DESCRIPTION
### PR Description
When the contentful-import tool is used with the `uploadAssets` option, the tool finds the assets in the local file system and uploads them. 

We are proposing changes to where these files are saved when using the `contentful-export` tool (see https://github.com/contentful/contentful-export/pull/2119), and this PR adds matching logic for the filename the tool should look for in the local file system. The tool will look for the original filename in the local file system, rather than one extracted from the `url` property. In the case where the filename is not available, the fallback is to use the decoded filename from the url path instead of the encoded one. Tests have been added to reflect this new logic.

See related issue: https://github.com/contentful/contentful-export/issues/2113 and [PR](https://github.com/contentful/contentful-export/pull/2119).