### PR TITLE
fix(github-packages-publishing): rename branch channel and name

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,4 +70,4 @@ workflows:
               only:
                 - main
                 - beta
-                - testing_publishing_to_github_packages
+                - testing-publishing-to-github-packages

--- a/package.json
+++ b/package.json
@@ -116,8 +116,8 @@
         "prerelease": true
       },
       {
-        "name": "testing_publishing_to_github_packages",
-        "channel": "testing_publishing_to_github_packages",
+        "name": "testing-publishing-to-github-packages",
+        "channel": "testing-publishing-to-github-packages",
         "prerelease": true
       }
     ],


### PR DESCRIPTION
Rename to use hyphens and keep name and channel name consistent for release configs.