### PR TITLE
chore: add semantic-release-ecosystem policy for GHA [DX-505]

### DIFF
--- a/.contentful/vault-secrets.yaml
+++ b/.contentful/vault-secrets.yaml
@@ -3,6 +3,7 @@ services:
   github-action:
     policies:
       - dependabot
+      - semantic-release-ecosystem
   circleci:
     policies:
       - semantic-release-ecosystem


### PR DESCRIPTION
Add `semantic-release-ecosystem` policy for GitHub Actions