### PR TITLE
chore: [SECURITY-1357] refine condition for dependabot approval in workflow

### DIFF
--- a/.github/workflows/dependabot-approve-and-request-merge.yaml
+++ b/.github/workflows/dependabot-approve-and-request-merge.yaml
@@ -9,7 +9,7 @@ jobs:
       id-token: write
       pull-requests: write
     runs-on: ubuntu-latest
-    if: github.actor == 'dependabot[bot]'
+    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == github.event.pull_request.head.repo.full_name
     steps:
       - uses: contentful/github-auto-merge@v2
         with:


### PR DESCRIPTION
This change improves the security of the dependabot auto-approval workflow by:
- Checking the PR user login instead of github.actor
- Verifying the PR is from the same repository (not a fork)

This prevents potential security issues where forked PRs could be auto-approved.