### PR TITLE
feat!: add breaking change rule to semantic-release config [DX-932]

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,6 +127,10 @@
         {
           "releaseRules": [
             {
+              "breaking": true,
+              "release": "major"
+            },
+            {
               "type": "build",
               "scope": "deps",
               "release": "patch"


### PR DESCRIPTION
[DX-932](https://contentful.atlassian.net/browse/DX-932)

## Summary
- `conventional-commits-parser` v6 + `@semantic-release/commit-analyzer` v13 changed how `!` commits are handled: `feat!:` marks the commit `breaking: true` but no longer auto-populates the `notes` array with a `BREAKING CHANGE` entry
- The commit-analyzer checks `notes` for a `BREAKING CHANGE` token, not the `breaking` flag — so `feat!:` and `fix!:` were silently skipped with no release triggered
- This caused the `feat!:` CMA v12 merge ([DX-782](https://contentful.atlassian.net/browse/DX-782)) to land on `main` without a major release
- Fix: prepend `{ "breaking": true, "release": "major" }` to `releaseRules` so any commit with `breaking: true` correctly maps to a major release

## Test plan
- [ ] Verify CI passes on this branch
- [ ] Confirm the next `feat!:` or `fix!:` commit to `main` triggers a major release

Generated with [Claude Code](https://claude.com/claude-code)

[DX-932]: https://contentful.atlassian.net/browse/DX-932?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DX-782]: https://contentful.atlassian.net/browse/DX-782?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ