### PR TITLE
chore: add exo semantic-release channel [AIS-117]

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -25,7 +25,7 @@ jobs:
     secrets: inherit
 
   release:
-    if: github.event_name == 'push' && contains(fromJson('["refs/heads/main", "refs/heads/beta"]'), github.ref)
+    if: github.event_name == 'push' && contains(fromJson('["refs/heads/main", "refs/heads/beta", "refs/heads/exo"]'), github.ref)
     needs: [build, check, test-integration]
     permissions:
       contents: write   # Required for semantic-release to push commits and tags

--- a/package.json
+++ b/package.json
@@ -119,6 +119,11 @@
         "name": "testing-publishing-to-github-packages",
         "channel": "testing-publishing-to-github-packages",
         "prerelease": true
+      },
+      {
+        "name": "exo",
+        "channel": "exo",
+        "prerelease": "exo"
       }
     ],
     "plugins": [


### PR DESCRIPTION
## Summary
Create a exo build example: `contentful-import@1.x.x-exo.1`

- Adds `exo` branch to `release.branches` in `package.json` with `channel: exo` and `prerelease: exo` — releases from this branch will be versioned as `x.y.z-exo.N`
- Updates CI release gate in `.github/workflows/main.yaml` to allow semantic-release to run on pushes to `refs/heads/exo`

## Test plan

- [ ] Merge, then verify a push to the `exo` branch triggers the release job in CI
- [ ] Confirm npm dist-tag `exo` is created with the correct prerelease version string

🤖 Generated with [Claude Code](https://claude.ai/claude-code)