### PR TITLE
feat: add ExO import support [AIS-119]

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -10,7 +10,7 @@ import PQueue from 'p-queue'
 import { displayErrorLog, setupLogging, writeErrorLogFile } from 'contentful-batch-libs/dist/logging'
 import { wrapTask } from 'contentful-batch-libs/dist/listr'
 
-import initClient from './tasks/init-client'
+import initClient, { initPlainClient } from './tasks/init-client'
 import getDestinationData from './tasks/get-destination-data'
 import pushToSpace from './tasks/push-to-space/push-to-space'
 import transformSpace from './transform/transform-space'
@@ -59,6 +59,7 @@ type RunContentfulImportParams = {
   headers?: object,
   errorLogFile?: string,
   useVerboseRenderer?: boolean,
+  includeExperienceOrchestration?: boolean,
   // TODO These properties are not documented in the Readme
   timeout?: number,
   retryLimit?: number,
@@ -112,6 +113,7 @@ async function runContentfulImport (params: RunContentfulImportParams) {
       title: 'Initialize client',
       task: wrapTask(async (ctx) => {
         ctx.client = initClient({ ...options, content: undefined })
+        ctx.plainClient = initPlainClient({ ...options, content: undefined })
       })
     },
     {
@@ -146,7 +148,9 @@ async function runContentfulImport (params: RunContentfulImportParams) {
           sourceData: ctx.sourceData,
           destinationData: ctx.destinationData,
           client: ctx.client,
+          plainClient: ctx.plainClient,
           spaceId: options.spaceId,
+          includeExperienceOrchestration: options.includeExperienceOrchestration,
           environmentId: options.environmentId,
           contentModelOnly: options.contentModelOnly,
           skipLocales: options.skipLocales,

--- a/lib/parseOptions.ts
+++ b/lib/parseOptions.ts
@@ -15,7 +15,12 @@ const SUPPORTED_ENTITY_TYPES = [
   'assets',
   'locales',
   'webhooks',
-  'editorInterfaces'
+  'editorInterfaces',
+  'componentTypes',
+  'templates',
+  'dataAssemblies',
+  'fragments',
+  'experiences'
 ]
 
 export default async function parseOptions (params) {
@@ -29,7 +34,8 @@ export default async function parseOptions (params) {
     environmentId: 'master',
     rawProxy: false,
     uploadAssets: false,
-    rateLimit: 7
+    rateLimit: 7,
+    includeExperienceOrchestration: false
   }
 
   const configFile = params.config

--- a/lib/tasks/init-client.ts
+++ b/lib/tasks/init-client.ts
@@ -17,3 +17,11 @@ export default function initClient (opts) {
   }
   return createClient(config, { type: 'legacy' })
 }
+
+export function initPlainClient (opts) {
+  return createClient({
+    accessToken: opts.managementToken,
+    host: opts.host,
+    logHandler
+  })
+}

--- a/lib/tasks/push-to-space/push-to-space.ts
+++ b/lib/tasks/push-to-space/push-to-space.ts
@@ -28,8 +28,10 @@ type PushToSpaceParams = {
   destinationData: DestinationData,
   sourceData: TransformedSourceData,
   client: any,
+  plainClient: any,
   spaceId: string,
   environmentId: string,
+  includeExperienceOrchestration?: boolean,
   contentModelOnly?: boolean,
   skipContentModel?: boolean,
   skipContentUpdates?: boolean,
@@ -75,8 +77,10 @@ export default function pushToSpace ({
   sourceData,
   destinationData = {},
   client,
+  plainClient,
   spaceId,
   environmentId,
+  includeExperienceOrchestration,
   contentModelOnly,
   skipContentModel,
   skipContentUpdates,
@@ -377,8 +381,109 @@ export default function pushToSpace ({
       }),
       skip: () =>
         contentModelOnly || (environmentId !== 'master' && 'Webhooks can only be imported in master environment')
+    },
+    {
+      title: 'Importing Component Types',
+      task: wrapTask(async (ctx) => {
+        const results = await Promise.all((sourceData.componentTypes || []).map(async (entity) => {
+          try {
+            const result = await plainClient.componentType.upsert({ spaceId, environmentId, componentTypeId: entity.sys.id }, omitSys(entity))
+            logEmitter.emit('info', `UPSERT ComponentType ${entity.sys.id}`)
+            return result
+          } catch (err) {
+            logEmitter.emit('error', err)
+            return null
+          }
+        }))
+        ctx.data.componentTypes = results.filter(Boolean)
+      }),
+      skip: () => !includeExperienceOrchestration || !(sourceData.componentTypes || []).length
+    },
+    {
+      title: 'Importing Templates',
+      task: wrapTask(async (ctx) => {
+        const results = await Promise.all((sourceData.templates || []).map(async (entity) => {
+          try {
+            const result = await plainClient.template.upsert({ spaceId, environmentId, templateId: entity.sys.id }, omitSys(entity))
+            logEmitter.emit('info', `UPSERT Template ${entity.sys.id}`)
+            return result
+          } catch (err) {
+            logEmitter.emit('error', err)
+            return null
+          }
+        }))
+        ctx.data.templates = results.filter(Boolean)
+      }),
+      skip: () => !includeExperienceOrchestration || !(sourceData.templates || []).length
+    },
+    {
+      title: 'Importing Fragments',
+      task: wrapTask(async (ctx) => {
+        const results = await Promise.all((sourceData.fragments || []).map(async (entity) => {
+          try {
+            const result = await plainClient.fragment.upsert({ spaceId, environmentId, fragmentId: entity.sys.id }, omitSys(entity))
+            logEmitter.emit('info', `UPSERT Fragment ${entity.sys.id}`)
+            return result
+          } catch (err) {
+            logEmitter.emit('error', err)
+            return null
+          }
+        }))
+        ctx.data.fragments = results.filter(Boolean)
+      }),
+      skip: () => !includeExperienceOrchestration || !(sourceData.fragments || []).length
+    },
+    {
+      title: 'Importing Data Assemblies',
+      task: wrapTask(async (ctx) => {
+        const results = await Promise.all((sourceData.dataAssemblies || []).map(async (entity) => {
+          try {
+            let result
+            try {
+              const existing = await plainClient.dataAssembly.get({ spaceId, environmentId, dataAssemblyId: entity.sys.id })
+              result = await plainClient.dataAssembly.update({ spaceId, environmentId, dataAssemblyId: entity.sys.id }, { ...omitSys(entity), sys: { version: existing.sys.version } })
+            } catch (getErr: any) {
+              if (getErr.status === 404) {
+                result = await plainClient.dataAssembly.create({ spaceId, environmentId }, omitSys(entity))
+              } else {
+                throw getErr
+              }
+            }
+            logEmitter.emit('info', `UPSERT DataAssembly ${entity.sys.id}`)
+            return result
+          } catch (err) {
+            logEmitter.emit('error', err)
+            return null
+          }
+        }))
+        ctx.data.dataAssemblies = results.filter(Boolean)
+      }),
+      skip: () => !includeExperienceOrchestration || !(sourceData.dataAssemblies || []).length
+    },
+    {
+      title: 'Importing Experiences',
+      task: wrapTask(async (ctx) => {
+        const results = await Promise.all((sourceData.experiences || []).map(async (entity) => {
+          try {
+            const result = await plainClient.experience.upsert({ spaceId, environmentId, experienceId: entity.sys.id }, omitSys(entity))
+            logEmitter.emit('info', `UPSERT Experience ${entity.sys.id}`)
+            return result
+          } catch (err) {
+            logEmitter.emit('error', err)
+            return null
+          }
+        }))
+        ctx.data.experiences = results.filter(Boolean)
+      }),
+      skip: () => !includeExperienceOrchestration || !(sourceData.experiences || []).length
     }
   ], listrOptions)
+}
+
+function omitSys (entity) {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { sys: _sys, ...rest } = entity
+  return rest
 }
 
 function archiveEntities ({ entities, sourceEntities, requestQueue }) {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,4 +1,7 @@
 import type { AssetProps, ContentTypeProps, EditorInterfaceProps, EntryProps, Link, LocaleProps, TagProps, WebhookProps } from 'contentful-management'
+import type { ComponentType, DataAssembly, DesignToken, Experience, Fragment, Template } from '@contentful/experiences-api-schemas'
+
+export type { ComponentType, DataAssembly, DesignToken, Experience, Fragment, Template }
 
 export type Resources = {
   contentTypes?: ContentTypeProps[]
@@ -8,6 +11,12 @@ export type Resources = {
   assets?: AssetProps[]
   editorInterfaces?: EditorInterfaceProps[]
   webhooks?: WebhookProps[]
+  componentTypes?: ComponentType[]
+  templates?: Template[]
+  fragments?: Fragment[]
+  dataAssemblies?: DataAssembly[]
+  experiences?: Experience[]
+  designTokens?: DesignToken[]
 }
 
 export type ResourcesUnion = (ContentTypeProps | TagProps | LocaleProps | EntryProps | AssetProps | EditorInterfaceProps | WebhookProps)[]
@@ -36,6 +45,12 @@ export type TransformedSourceData = {
   tags: EntityTransformed<TagProps, any>[]
   webhooks: EntityTransformed<WebhookProps, any>[]
   editorInterfaces: EditorInterfaceProps[]
+  componentTypes?: ComponentType[]
+  templates?: Template[]
+  fragments?: Fragment[]
+  dataAssemblies?: DataAssembly[]
+  experiences?: Experience[]
+  designTokens?: DesignToken[]
 }
 
 export type TransformedSourceDataUnion = (

--- a/lib/usageParams.ts
+++ b/lib/usageParams.ts
@@ -83,5 +83,10 @@ export default yargs
     type: 'string',
     describe: 'Pass an additional HTTP Header'
   })
+  .option('include-experience-orchestration', {
+    describe: 'Import Experience Orchestration entities (componentTypes, templates, fragments, dataAssemblies, experiences). Requires a space with ExO enabled.',
+    type: 'boolean',
+    default: false
+  })
   .config('config', 'An optional configuration JSON file containing all the options for a single run')
   .argv

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
       "version": "0.0.0-determined-by-semantic-release",
       "license": "MIT",
       "dependencies": {
+        "@contentful/experiences-api-schemas": "^4.99.0",
+        "@contentful/experiences-management-api-contract": "^5.140.0",
         "@discoveryjs/json-ext": "^0.6.3",
         "bluebird": "^3.7.2",
         "cli-table3": "^0.6.5",
@@ -118,6 +120,333 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/checksums": {
+      "version": "3.1000.14",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/checksums/-/checksums-3.1000.14.tgz",
+      "integrity": "sha512-9j0TSNmYVywV+shhBXXkIhaazZwZ+nDSGfG6V47nFLqXdk6mPYk/OJkV4+uRvIg2Ju5F6HTvgM/sfsuTsbAYwg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.29",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3": {
+      "version": "3.1081.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1081.0.tgz",
+      "integrity": "sha512-mHAdLBibsbFwcW2YHrH5sIQlaXjB3zha7Nkooa2gqTlXxRpVJ+ba/v/mg19B6rJeZmOEteRHFz+INOlAbCbxJg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/checksums": "^3.1000.14",
+        "@aws-sdk/core": "^3.974.29",
+        "@aws-sdk/credential-provider-node": "^3.972.64",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.60",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.38",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/fetch-http-handler": "^5.6.2",
+        "@smithy/node-http-handler": "^4.9.2",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns": {
+      "version": "3.1081.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sns/-/client-sns-3.1081.0.tgz",
+      "integrity": "sha512-3W50Y0WN6XxV6QDtQxbP4oRMxIlWp6/EYkyLjxeeaLAwfTljjX0zPtWXYQaFo4kM/unf6JlePOHZn3flMUn3ZA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.29",
+        "@aws-sdk/credential-provider-node": "^3.972.64",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/fetch-http-handler": "^5.6.2",
+        "@smithy/node-http-handler": "^4.9.2",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.974.29",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.29.tgz",
+      "integrity": "sha512-yqKcltLbtRh1ubzhRSldIs8jFHNZlyMlgoIccCC0aDVbrB99nXaBdmfr89mK7obWX/NVg4rAMpCpZ6dCDiVBtA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.15",
+        "@aws-sdk/xml-builder": "^3.972.33",
+        "@aws/lambda-invoke-store": "^0.3.0",
+        "@smithy/core": "^3.29.0",
+        "@smithy/signature-v4": "^5.6.1",
+        "@smithy/types": "^4.15.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.55",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.55.tgz",
+      "integrity": "sha512-Ah36tYkqyaVnaHkx7VseoTYrHUmwgBps3V+wnrC1idhIIMGlviH0FtrX9EIPdAlVHvXC7FQZLhmHBRz+pLaiWg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.29",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.57",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.57.tgz",
+      "integrity": "sha512-/vp6i5YEliJqRm5k/BDmYjAyRAMTdkjW6UciVRk9oh/0OfDCWeb/ih7hqte4lFvKXkIbsqe9AdK9LQK6NGardw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.29",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/fetch-http-handler": "^5.6.2",
+        "@smithy/node-http-handler": "^4.9.2",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.972.62",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.62.tgz",
+      "integrity": "sha512-pQIRiQQs+MUlVnJdWJ7/6KS0WxcLRVfut57OFgwC3cnM1F8mXw3Kh4gAVwj6AtvD6CWx8x6+po4ENRcqe64XrQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.29",
+        "@aws-sdk/credential-provider-env": "^3.972.55",
+        "@aws-sdk/credential-provider-http": "^3.972.57",
+        "@aws-sdk/credential-provider-login": "^3.972.61",
+        "@aws-sdk/credential-provider-process": "^3.972.55",
+        "@aws-sdk/credential-provider-sso": "^3.972.61",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.61",
+        "@aws-sdk/nested-clients": "^3.997.29",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/credential-provider-imds": "^4.4.5",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.61",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.61.tgz",
+      "integrity": "sha512-jtrxWwC7slqxh7DnAWHrwsA3UwCsnlypdYtavGT7EX5p791wxWQys7QzkCZ7JvOMAyylDtPoxyV+ic0zg3rV9g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.29",
+        "@aws-sdk/nested-clients": "^3.997.29",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.64",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.64.tgz",
+      "integrity": "sha512-zyKVYDyMR9VQL/kPi03ygN2vtD9uLMuWRLoJ77KxgZZaS1VlJloI+SzleF9Zg4HWUI+AIu+ZRs8zsJFNqbrxsw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.55",
+        "@aws-sdk/credential-provider-http": "^3.972.57",
+        "@aws-sdk/credential-provider-ini": "^3.972.62",
+        "@aws-sdk/credential-provider-process": "^3.972.55",
+        "@aws-sdk/credential-provider-sso": "^3.972.61",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.61",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/credential-provider-imds": "^4.4.5",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.55",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.55.tgz",
+      "integrity": "sha512-x0XjjF0l1WGRtK2vEhTZqCguQuAIZLep9l2+eeEmuxQQjjD3BlGQXY5xADR+l3t576UX+dxRkRtTjEu40l81Vw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.29",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.972.61",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.61.tgz",
+      "integrity": "sha512-d/V0VRsz73i+PHhbult/tx0Y1+de1SNQVsXkcQCmpfeBq7uODy/RTxNsOLpT9ZVHxcRNzbQFuywLKC33fUMIxA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.29",
+        "@aws-sdk/nested-clients": "^3.997.29",
+        "@aws-sdk/token-providers": "3.1081.0",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.61",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.61.tgz",
+      "integrity": "sha512-Bv4n3NOI6hPy+rmr6Bw9R6LnBVRkcp3ncj2E2IKSYJG+0UkysSitWMvbgndNvMxDw7gE1pQ/ErwkNceuKwj7zQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.29",
+        "@aws-sdk/nested-clients": "^3.997.29",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3": {
+      "version": "3.972.60",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.60.tgz",
+      "integrity": "sha512-f8SREKL6uQUYt8fwreiUgaAJQ31/M+UkWfJMDY/TBJC5FdHgNzxuvRFeZ9eMbnf2ydQ3p4pcKEhaLk35DDIPxw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.29",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.38",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.29",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.29.tgz",
+      "integrity": "sha512-ot6v8J5W8P0w6ryyuIkXP1bHZHTlvwtn83mVCYaBE0GJ6tJX4vPSBx7M98w9O4wmmDruFsDBUMjhEHA+OosUFQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.29",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.38",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/fetch-http-handler": "^5.6.2",
+        "@smithy/node-http-handler": "^4.9.2",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.38",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.38.tgz",
+      "integrity": "sha512-C379Sk+MiFZCfWZphKlMyLHKxV22OjoGM5KJjj5IJNJcOCWL4IGIpnEGzv1FQiRwhYXfq55SJMfxlqPE08JJ9g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/signature-v4": "^5.6.1",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1081.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1081.0.tgz",
+      "integrity": "sha512-kduAeI6cL+zqwj3gjPh9LhuX7kBZ83msYxutavaR+UPm5K8J7iThJBvNRAsFNyWTji92CSU8dogUgvi9T0BehA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.29",
+        "@aws-sdk/nested-clients": "^3.997.29",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.973.15",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.15.tgz",
+      "integrity": "sha512-IULn8uBV/SMtmOIANsm4WHXIOtVPBWfOWs3WGL0j/sI+KhaYehvOw0ET+9urnn8MBpiijuU/0JOpuwKOE451PQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.33",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.33.tgz",
+      "integrity": "sha512-ezbwz9WpuLctm6o7P2t2naDhVVPI5jFGrVefVybhcKGjU57VIyT46pQVO0RI2RYkUdhdj2Z9uSIlAzGZE9NW9A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz",
+      "integrity": "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -801,6 +1130,267 @@
         "node": ">=8"
       }
     },
+    "node_modules/@contentful/assemblies-management-api-contract": {
+      "version": "3.75.0",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/assemblies-management-api-contract/3.75.0/da83b371f7acc02cf9b416da4b38469f29713c10",
+      "integrity": "sha512-cA4+l/6MviPb6B/HmWvPNaHpI4qc4lscPELwKYk6G4IINSh4z5C5x0l0qKIXfFyiUJJZBWuqbUfs5anmljrsrA==",
+      "dependencies": {
+        "@contentful/assemblies-types": "3.68.0",
+        "@contentful/bulk-actions": "0.9.0",
+        "@contentful/query-to-constraints": "3.55.0",
+        "@contentful/service-kit": "6.10.0",
+        "zod": "4.4.3"
+      }
+    },
+    "node_modules/@contentful/assemblies-types": {
+      "version": "3.68.0",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/assemblies-types/3.68.0/15da1136cd22f8fb35708282ca430abd81d6e53a",
+      "integrity": "sha512-dswBf6ALGwV2UfvAerdVgLlw0G9f6jNZwtxdw8WoYX9/yeP0vRNjuEzytVl4Gg96l4bijUmZsGNfyWGV3xKhKw==",
+      "dependencies": {
+        "@contentful/data-type": "0.41.0",
+        "@contentful/pointer-syntax": "0.39.0",
+        "zod": "4.4.3"
+      }
+    },
+    "node_modules/@contentful/authorization-policy-service-client": {
+      "version": "10.14.3",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/authorization-policy-service-client/10.14.3/539e0b3da9af19f5e5a37462cfd52c13d8458e54",
+      "integrity": "sha512-MZyUP1uIjnRYH/U38hUk4btQL/omgIIr0FzH5LQUIzWjjapYddxKe7rEwtb4SM7qtVQOADtr0jZDRZWkbpHGkg==",
+      "license": "UNLICENSED",
+      "dependencies": {
+        "@contentful/errors": "^4.14.11",
+        "@contentful/http-client": "^6.16.19",
+        "crypto-js": "^4.2.0",
+        "lodash": "^4.18.1",
+        "lru-cache": "^11.5.1",
+        "qs": "^6.15.2",
+        "runtypes": "^7.0.4",
+        "uuid-random": "^1.3.2"
+      },
+      "peerDependencies": {
+        "@contentful/spock": ">=3.2.0"
+      }
+    },
+    "node_modules/@contentful/authorization-policy-service-client/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@contentful/aws-message-patterns-common": {
+      "version": "1.2.49",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/aws-message-patterns-common/1.2.49/b1241119090800fc6d19685b6444df0999d25c31",
+      "integrity": "sha512-zX8+Knn6rmf+nuZWs9PEqN+dkLmXRygwSGD93vzN0xmGinh0w4vZM4i550NH7nkqsp/588E0hY1dXY0DfYclVA==",
+      "license": "UNLICENSED",
+      "dependencies": {
+        "@contentful/uuid": "^2.4.11"
+      }
+    },
+    "node_modules/@contentful/aws-message-patterns-s3-client": {
+      "version": "1.4.49",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/aws-message-patterns-s3-client/1.4.49/593f4d114e258b7684d3e6ac8a740e77e0c77a97",
+      "integrity": "sha512-F/7bxBgkxE9cP99lqTs3ZIEvJVQtAehGzXx/sBtzEO7H0brvH/XIdh8mLbRI2jhXOC6zG5lBbGA9hWMXNL1pdw==",
+      "license": "UNLICENSED",
+      "dependencies": {
+        "@aws-sdk/client-s3": "^3.1075.0",
+        "@contentful/aws-message-patterns-common": "1.2.49"
+      }
+    },
+    "node_modules/@contentful/aws-message-patterns-sns-producer": {
+      "version": "1.3.49",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/aws-message-patterns-sns-producer/1.3.49/0ab136ac3175e9baf201ad3415a228f0c4955f93",
+      "integrity": "sha512-UH9YzK9/chFnymkEiddrk54eOsOcMtyUg64AFfNlYfi/LIEkwiZK9IkFDLQGjShSAknGIX3hPuevoAvhBKM9bg==",
+      "license": "UNLICENSED",
+      "dependencies": {
+        "@aws-sdk/client-sns": "^3.1075.0",
+        "@contentful/aws-message-patterns-common": "1.2.49",
+        "@contentful/aws-message-patterns-s3-client": "1.4.49",
+        "p-map": "^4.0.0"
+      }
+    },
+    "node_modules/@contentful/aws-message-patterns-sns-producer/node_modules/aggregate-error": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+      "license": "MIT",
+      "dependencies": {
+        "clean-stack": "^2.0.0",
+        "indent-string": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@contentful/aws-message-patterns-sns-producer/node_modules/clean-stack": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@contentful/aws-message-patterns-sns-producer/node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@contentful/aws-message-patterns-sns-producer/node_modules/p-map": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
+      "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+      "license": "MIT",
+      "dependencies": {
+        "aggregate-error": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@contentful/bulk-actions": {
+      "version": "0.9.0",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/bulk-actions/0.9.0/cd06382b1c2a9549b7f8cbba72bbdf367bad46d7",
+      "integrity": "sha512-IaSY0q8x7uITAO1WdO5bIVDCr5QNRLJ9ru6LeD3QJ0c/p28AvSk922bVRBjqrbZ4/Gz0YkXioSFAr9s4wF5l8w==",
+      "dependencies": {
+        "@contentful/service-kit": "6.10.0",
+        "zod": "4.4.3"
+      }
+    },
+    "node_modules/@contentful/content-internal-api-contract": {
+      "version": "3.62.0",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/content-internal-api-contract/3.62.0/c07b8dd4a7db1ae0cac9360fa9c77b1be40a7fd1",
+      "integrity": "sha512-iMuJejbTwTImDa5tEQrozp9zx+Ru6E1i+KL0fwGqAjnHA5Bja/iGJmK+mapXGNAYVaqJjwz/ahkrKfDvIuyptg==",
+      "dependencies": {
+        "@contentful/service-kit": "6.10.0",
+        "zod": "4.4.3"
+      }
+    },
+    "node_modules/@contentful/data-type": {
+      "version": "0.41.0",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/data-type/0.41.0/46ec95bb1ea70037c87242e80747ee2821c6b9d3",
+      "integrity": "sha512-VxeKs1g31HYgHWYSrTmWjuDYekgzopAFrPxnbRuXXjirYYPCFDGizbVlnf+3IQzJWTZtCRZ3nv8ww+8aJR2g8A==",
+      "dependencies": {
+        "zod": "4.4.3"
+      }
+    },
+    "node_modules/@contentful/errors": {
+      "version": "4.14.11",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/errors/4.14.11/e2b7836879dc0249034a9e134694409672b68f2f",
+      "integrity": "sha512-26IJLvq6yZ4xXIXedON4UVc4ysInRBrftnnE/DoaKnFNOCGztSyJDDZ1DIREMec/dhbBXipCSHPb1xnMePnmVw==",
+      "license": "UNLICENSED",
+      "dependencies": {
+        "@contentful/mimetype": "^2.6.5"
+      }
+    },
+    "node_modules/@contentful/experiences-api-schemas": {
+      "version": "4.99.0",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/experiences-api-schemas/4.99.0/6827fa298a5f5f60f03f3b6a26ab2e087a69f27f",
+      "integrity": "sha512-eFfk2mMZjFhxOpPaYvstv9u1tvx0twTW2YPLxgUFpTxWNGQcNS1a55NUC5G+uGoC45wgjUTQbK+m37Q1vxodJw==",
+      "dependencies": {
+        "@contentful/assemblies-types": "3.68.0",
+        "@contentful/data-type": "0.41.0",
+        "@contentful/resource-names": "^1.9.1",
+        "@contentful/service-kit": "6.10.0",
+        "zod": "4.4.3"
+      }
+    },
+    "node_modules/@contentful/experiences-management-api-contract": {
+      "version": "5.140.0",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/experiences-management-api-contract/5.140.0/71e049089cc2b61e23e101b32ddd8f469528cb4d",
+      "integrity": "sha512-/5W6JJimOd1JtPUP7G5nQ9dG673TicU7nDeqvlxnwKsE9HiTDov27utV+SfSutshLo0fZkZeqAgCruRZmAn4uA==",
+      "dependencies": {
+        "@contentful/assemblies-management-api-contract": "3.75.0",
+        "@contentful/assemblies-types": "3.68.0",
+        "@contentful/bulk-actions": "0.9.0",
+        "@contentful/content-internal-api-contract": "3.62.0",
+        "@contentful/experiences-api-schemas": "4.99.0",
+        "@contentful/query-to-constraints": "3.55.0",
+        "@contentful/service-kit": "6.10.0",
+        "@contentful/view-delivery-contract": "3.108.0",
+        "zod": "4.4.3"
+      }
+    },
+    "node_modules/@contentful/http-client": {
+      "version": "6.16.19",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/http-client/6.16.19/fd578c225956db1bb1c67b0433e7b67bc85c0419",
+      "integrity": "sha512-8ZUtniGEYkRFLoN4N9J40/VocXHaFTImQqRHyV3GEO+OAMk6H3T/7F5lx9aXH/hZFX5+6Euv61xrvUgKJUOquA==",
+      "license": "ISC",
+      "dependencies": {
+        "@types/sinon": "^21.0.0",
+        "concat-stream": "^2.0.0",
+        "got": "^11.5.1",
+        "promise-retry": "^2.0.1",
+        "type-fest": "^4.0.0"
+      }
+    },
+    "node_modules/@contentful/http-client/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@contentful/mimetype": {
+      "version": "2.6.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/mimetype/2.6.5/b4f7001ad66096a2c13b0eea62642e98e914cc98",
+      "integrity": "sha512-Raf+xYKctjzrA5/reT51AUjCpYgVKV2C20fj9l+5LrT4rx+jwp9hlhsUK2jvCN5j1t9fqgd/Q6qGMv/qBexHbQ==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.18.1"
+      }
+    },
+    "node_modules/@contentful/personalization-api-contract": {
+      "version": "1.49.0",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/personalization-api-contract/1.49.0/51d3145b3857f37bddaa1e46e96563d7a8afe346",
+      "integrity": "sha512-J5EDisj/1VNyIgNvDvLXceTQgqKX4htrEZ40pLhTzklFVZu7nBLu3XlYqcDCQgHzdfMuSfV1yKBUJVVsCmzh+Q==",
+      "dependencies": {
+        "@contentful/service-kit": "6.10.0",
+        "zod": "4.4.3"
+      }
+    },
+    "node_modules/@contentful/pointer-syntax": {
+      "version": "0.39.0",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/pointer-syntax/0.39.0/14872fededcba23d9ba376259a0ebfd467e55f61",
+      "integrity": "sha512-my/ipqspPoz1jpLNtqDgZwmyrp7FdRBw+1tiSfascqbsFRPeVnIIKJjKsUpEgWPG1VF5YQPM0Dg4P3rHVxnakg==",
+      "dependencies": {
+        "@contentful/data-type": "0.41.0",
+        "zod": "4.4.3"
+      },
+      "engines": {
+        "npm": ">=7.14.0",
+        "pnpm": ">=10.33.0"
+      }
+    },
+    "node_modules/@contentful/query-to-constraints": {
+      "version": "3.55.0",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/query-to-constraints/3.55.0/a0efd2576a6b8e5674d2a33f9863190fcf8bf2fd",
+      "integrity": "sha512-eJ93Hb/PBGbGbAf0QKkWJtoTfd2ZAms0ehJrjCi3Kf2/TnCb1Bf4iiMzf51l4Bn9uw3AVOjrX+G5ZW3kXUHMTA==",
+      "dependencies": {
+        "@contentful/spock": "^5.5.0",
+        "zod": "4.4.3"
+      }
+    },
+    "node_modules/@contentful/resource-names": {
+      "version": "1.9.2",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/resource-names/1.9.2/950742d04fa70fc97b1fe443726d5ad37640b80b",
+      "integrity": "sha512-DnFA9gBT+GmFHKqNH18CteBIZKs1Gd2cnbSVM2V71th9c+DWQAKiHM1N+vWzQ2lmx0KTICdcwjnPpBY7zmRzBg==",
+      "license": "ISC"
+    },
     "node_modules/@contentful/rich-text-types": {
       "version": "16.8.3",
       "resolved": "https://registry.npmjs.org/@contentful/rich-text-types/-/rich-text-types-16.8.3.tgz",
@@ -809,12 +1399,362 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@contentful/service-kit": {
+      "version": "6.10.0",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/service-kit/6.10.0/00569dea72ea2bef5ab3194b7441a8dab2b4227a",
+      "integrity": "sha512-gkh+SE1dS/O8jvzDh7HdHqZstYNf7aPgj0nDfDPRutziGBMxiMlv/MqrGdxQzi8UtB5Z+jhX39m9He1OYixTjw==",
+      "dependencies": {
+        "@contentful/authorization-policy-service-client": "^10.13.6",
+        "@contentful/aws-message-patterns-sns-producer": "^1.3.30",
+        "@contentful/errors": "4.14.11",
+        "@hono/node-server": "1.19.14",
+        "@launchdarkly/openfeature-node-server": "^1.2.0",
+        "@openfeature/server-sdk": "^1.21.0",
+        "@opentelemetry/api": "^1.9.1",
+        "@ts-rest/core": "3.53.0-rc.1",
+        "@ts-rest/open-api": "3.53.0-rc.1",
+        "@ts-rest/react-query": "3.53.0-rc.1",
+        "dd-trace": "5.96.0",
+        "get-port-please": "^3.2.0",
+        "hono": "4.12.18",
+        "klona": "^2.0.6",
+        "openapi3-ts": "^2.0.2",
+        "pino": "10.3.1",
+        "type-fest": "5.7.0",
+        "zod": "4.4.3"
+      },
+      "bin": {
+        "service-kit-asyncapi": "dist/asyncapi/cli.js",
+        "service-kit-openapi": "dist/contract/openapi/generate.js"
+      },
+      "optionalDependencies": {
+        "pino-pretty": "^13.1.3"
+      },
+      "peerDependencies": {
+        "@tanstack/react-query": "<5.0.0",
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/service-kit/node_modules/@ts-rest/core": {
+      "version": "3.53.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@ts-rest/core/-/core-3.53.0-rc.1.tgz",
+      "integrity": "sha512-hDMXqKHSys6w+kXFW1Q6EvN8QgRvtXKXJ2TpYByKI4TquaPjiTOv99aLD26X4LNRzdna8Ci1PVyzr0jYZv0oNQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/node": "^18.18.7 || >=20.8.4"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@contentful/service-kit/node_modules/@ts-rest/open-api": {
+      "version": "3.53.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@ts-rest/open-api/-/open-api-3.53.0-rc.1.tgz",
+      "integrity": "sha512-JqmmdwFP2AHlyK9T4dwgsFL3QGNRppV9JIBh0G9mbJE7m7Kj403VsxJZ5X128E3XqwH7JIgJ4wsyGRX4Zbtqvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@anatine/zod-openapi": "^1.12.0",
+        "openapi3-ts": "^2.0.2"
+      },
+      "peerDependencies": {
+        "@ts-rest/core": "3.53.0-rc.1",
+        "zod": "^3.22.3"
+      }
+    },
+    "node_modules/@contentful/service-kit/node_modules/@ts-rest/open-api/node_modules/@anatine/zod-openapi": {
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/@anatine/zod-openapi/-/zod-openapi-1.14.2.tgz",
+      "integrity": "sha512-q0qHfnuNYVKu0Swrnnvfj9971AEyW7c8v9jCOZGCl5ZbyGMNG4RPyJkRcMi/JC8CRfdOe0IDfNm1nNsi2avprg==",
+      "license": "MIT",
+      "dependencies": {
+        "ts-deepmerge": "^6.0.3"
+      },
+      "peerDependencies": {
+        "openapi3-ts": "^2.0.0 || ^3.0.0",
+        "zod": "^3.20.0"
+      }
+    },
+    "node_modules/@contentful/service-kit/node_modules/@ts-rest/react-query": {
+      "version": "3.53.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@ts-rest/react-query/-/react-query-3.53.0-rc.1.tgz",
+      "integrity": "sha512-wqn29MGKFhQWQsQatVH/vsBA/+faXKTXlgsR7hwbwpwABUcebuuj7JwZttxZoGWQqjNJJH+rsOQ6BQDhhyfuoQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@tanstack/react-query": "^4.0.0 || ^5.0.0",
+        "@ts-rest/core": "3.53.0-rc.1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@contentful/service-kit/node_modules/type-fest": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.7.0.tgz",
+      "integrity": "sha512-1URUxUqfHFM1c+zfSPsa3gnkO7Aq21qyH75SIduNYz4SzY964rn1X2vCMQaHSHhktiw+0kPa2iyb6PUpXqB6Vg==",
+      "license": "(MIT OR CC0-1.0)",
+      "dependencies": {
+        "tagged-tag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@contentful/spock": {
+      "version": "5.5.0",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/spock/5.5.0/544208e5cb5af942dc5e2eff833748285266e38d",
+      "integrity": "sha512-Cn30mGPm34KEfB04j0yvcebDc1s6kod9HH6vhbHQt3yvDy5LxEs2q/Kuhg4pSNxTpvpSeoLFr3PEmhmwkfoziA==",
+      "license": "UNLICENSED",
+      "dependencies": {
+        "lodash": "^4.17.21",
+        "safe-regex": "^2.1.1"
+      }
+    },
+    "node_modules/@contentful/uuid": {
+      "version": "2.4.11",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/uuid/2.4.11/9e7254441498e539c7d213aaddc7b6c383a7d9c1",
+      "integrity": "sha512-j4J5jY7l6/4CiOWqGnPSwMlkMvIvDSHys2SFbTzdFt1coLug7G3zUjvv4p1lMtUtZubEnvfuBNdUbi+rdZc4IA==",
+      "license": "UNLICENSED",
+      "dependencies": {
+        "base-x": "^4.0.1",
+        "uuid": "^11.1.0"
+      }
+    },
+    "node_modules/@contentful/uuid/node_modules/uuid": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
+    },
+    "node_modules/@contentful/view-delivery-contract": {
+      "version": "3.108.0",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/view-delivery-contract/3.108.0/abdc54137d78d32c54763bc1faf3c1f956391978",
+      "integrity": "sha512-Y9j0f4FfZDz98bKVuWDRes1Wt/c2gPjMfkTJ8vivoTbMXCZaEz1FuYh++p2dr+eTZ9Rb+emKzy7sglJkpOUSvg==",
+      "dependencies": {
+        "@contentful/assemblies-types": "3.68.0",
+        "@contentful/experiences-api-schemas": "4.99.0",
+        "@contentful/personalization-api-contract": "1.49.0",
+        "@contentful/service-kit": "6.10.0",
+        "zod": "4.4.3"
+      }
+    },
+    "node_modules/@datadog/flagging-core": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@datadog/flagging-core/-/flagging-core-1.2.1.tgz",
+      "integrity": "sha512-qeDkki9fFlqyoZBrn7tneT6pZ04EKKvf3xxisYw1a74zbJihvQui/ARUsjXCurRpzpFqGGTJw/oz+HnXaKhcdw==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "spark-md5": "^3.0.2"
+      }
+    },
+    "node_modules/@datadog/libdatadog": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@datadog/libdatadog/-/libdatadog-0.9.2.tgz",
+      "integrity": "sha512-grOerTYuU3wHuFIOBGg3jB144A3KEthEdVEL3meeiXYo7E7fBXXGRgAOwVE42VXFXfl0r8kDKCL7KupBc511tg==",
+      "license": "Apache-2.0",
+      "optional": true
+    },
+    "node_modules/@datadog/native-appsec": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@datadog/native-appsec/-/native-appsec-11.0.1.tgz",
+      "integrity": "sha512-Y/XfknUmmJcw4hhQVhqzgdQvfjy+EGmXuUBgtVkI1r+/qS00egYu+wD/x7pOvjdbZNqN96znVszAnXvDQAzMDQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "node-gyp-build": "^3.9.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@datadog/native-iast-taint-tracking": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@datadog/native-iast-taint-tracking/-/native-iast-taint-tracking-4.1.0.tgz",
+      "integrity": "sha512-g9K9Ddx1YQfrQIC2hgtfnYUGuzAFvSvhvt2lPZOAWBPo+bkYoW5KEkMHoY5XykCigTfXBYcQicRV0xB22AMkHw==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "node-gyp-build": "^3.9.0"
+      }
+    },
+    "node_modules/@datadog/native-metrics": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@datadog/native-metrics/-/native-metrics-3.1.1.tgz",
+      "integrity": "sha512-MU1gHrolwryrU4X9g+fylA1KPH3S46oqJPEtVyrO+3Kh29z80fegmtyrU22bNt8LigPUK/EdPCnSbMe88QbnxQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "node-addon-api": "^6.1.0",
+        "node-gyp-build": "^3.9.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@datadog/openfeature-node-server": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@datadog/openfeature-node-server/-/openfeature-node-server-1.2.1.tgz",
+      "integrity": "sha512-iY32juuL2w07vOlrTG1Y1U0y3ehyvRxuwzJvaLqjmQE8jj2L3o2SRm2UwgmLnzh6JWzMfNxbfs66KvOmPja7dQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@datadog/flagging-core": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@openfeature/server-sdk": ">=1.15.1"
+      }
+    },
+    "node_modules/@datadog/pprof": {
+      "version": "5.14.1",
+      "resolved": "https://registry.npmjs.org/@datadog/pprof/-/pprof-5.14.1.tgz",
+      "integrity": "sha512-MlODCE9Gltmx7WChOg1BkIm7W2iE4CDW7K72BMwgzCvxFkG9rFWVsuA7/NEZL1nDvJ0qDe2du7DZZdZHTjcVPw==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "node-gyp-build": "<4.0",
+        "pprof-format": "^2.2.1",
+        "source-map": "^0.7.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@datadog/pprof/node_modules/source-map": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@datadog/wasm-js-rewriter": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@datadog/wasm-js-rewriter/-/wasm-js-rewriter-5.0.1.tgz",
+      "integrity": "sha512-EzbV3Lrdt3udQEsbDOVC5gB1y7yxfpBbrSIk4jaEsGjyj0Dbv2HGj7tZjs+qXzIzNonHc8h5El2bYZOGfC2wwg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "js-yaml": "^4.1.0",
+        "lru-cache": "^7.14.0",
+        "module-details-from-path": "^1.0.3",
+        "node-gyp-build": "^4.5.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@datadog/wasm-js-rewriter/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0",
+      "optional": true
+    },
+    "node_modules/@datadog/wasm-js-rewriter/node_modules/js-yaml": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/@datadog/wasm-js-rewriter/node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "license": "ISC",
+      "optional": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@datadog/wasm-js-rewriter/node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
+    },
     "node_modules/@discoveryjs/json-ext": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.6.3.tgz",
       "integrity": "sha512-4B4OijXeVNOPZlYA2oEwWOTkzyltLao+xbotHQeqN++Rv27Y6s818+n2Qkp8q+Fxhn0t/5lA5X1Mxktud8eayQ==",
       "engines": {
         "node": ">=14.17.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
+      "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
+      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@endemolshinegroup/cosmiconfig-typescript-loader": {
@@ -1412,6 +2352,18 @@
       "integrity": "sha512-KR3rD5inZbGMrHmgPxsJ9dbi6zEK+C3ZwUwTa+eMwWLz7oijWUTWD2pMSNNYJAU6Qq+65NkxXjqHr/7LM2Xkqg==",
       "dependencies": {
         "@hapi/hoek": "^11.0.2"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -2235,6 +3187,97 @@
         "@jridgewell/sourcemap-codec": "1.4.14"
       }
     },
+    "node_modules/@launchdarkly/js-sdk-common": {
+      "version": "2.25.1",
+      "resolved": "https://registry.npmjs.org/@launchdarkly/js-sdk-common/-/js-sdk-common-2.25.1.tgz",
+      "integrity": "sha512-erG2RbA8QQMKW+D9Y7Uahez1dU+TzmyTzv9qlB7b0Pr/DS2SmUg5H8pJbkLcRrSxoshczZdB1UqsuE3RAk7UYQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@launchdarkly/js-server-sdk-common": {
+      "version": "2.19.2",
+      "resolved": "https://registry.npmjs.org/@launchdarkly/js-server-sdk-common/-/js-server-sdk-common-2.19.2.tgz",
+      "integrity": "sha512-SZApHxn0PqYyRFfXtrJKQAGx6tlLD2sV0XvqOUkUdey1lKeObOL4hIw+70gQ3jrRAIvEH+SBC0uqlJ7uGlrRyA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@launchdarkly/js-sdk-common": "2.25.1",
+        "semver": "7.5.4"
+      }
+    },
+    "node_modules/@launchdarkly/js-server-sdk-common/node_modules/semver": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@launchdarkly/node-server-sdk": {
+      "version": "9.12.0",
+      "resolved": "https://registry.npmjs.org/@launchdarkly/node-server-sdk/-/node-server-sdk-9.12.0.tgz",
+      "integrity": "sha512-tbiRBnEln0Bvf0ZkukElGoGEVhB8A3kwnC7QRa9HzHA0gvpnYnL+JjoDWAIL0+EMLlEpFl7EJMwCfi/488yHZQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@launchdarkly/js-server-sdk-common": "2.19.2",
+        "https-proxy-agent": "^7.0.6",
+        "launchdarkly-eventsource": "2.2.0"
+      }
+    },
+    "node_modules/@launchdarkly/openfeature-js-server-common": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@launchdarkly/openfeature-js-server-common/-/openfeature-js-server-common-1.0.0.tgz",
+      "integrity": "sha512-aCJUn4d/pkjCICqzQVXlL3Q4d3OvZmt7dgOya9aawXxZv8G5ooedkFNjEecmsWhScjORLHzTU0UdaNDwP6XhFA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@launchdarkly/js-sdk-common": "2.25.1"
+      },
+      "peerDependencies": {
+        "@openfeature/server-sdk": "^1.16.0"
+      }
+    },
+    "node_modules/@launchdarkly/openfeature-node-server": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@launchdarkly/openfeature-node-server/-/openfeature-node-server-1.3.2.tgz",
+      "integrity": "sha512-Y4K9U2aZimup3IIL68s/j3swcJUFfBVBVZCF/UIVal5nrTDtTEAiEQjMaI3Knxu6/rQyXvyIUpMhWPyXlUOx/Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@launchdarkly/openfeature-js-server-common": "1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@launchdarkly/node-server-sdk": "^9.0.0",
+        "@openfeature/server-sdk": "^1.16.0"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "dev": true,
@@ -2411,6 +3454,407 @@
       "dependencies": {
         "@octokit/openapi-types": "^26.0.0"
       }
+    },
+    "node_modules/@openfeature/core": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@openfeature/core/-/core-1.11.0.tgz",
+      "integrity": "sha512-P0u3/ht/oZCQT89fOed+laLk0kZR529a825cS02uPDglxXbE97irWYpDAeRGGVETIzKfuy+H2g8c3Ccv/tXJNQ==",
+      "license": "Apache-2.0",
+      "peer": true
+    },
+    "node_modules/@openfeature/server-sdk": {
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@openfeature/server-sdk/-/server-sdk-1.22.0.tgz",
+      "integrity": "sha512-YBrf6SQkn0FNB/dRAtLEs41dvFMUE8CrQTwI+iLaMFUIqWlqGNJfGnulKSneEKS+2OgKTAC6DdmKcZ6tK7kBcg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@openfeature/core": "^1.11.0"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/api-logs": {
+      "version": "0.220.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.220.0.tgz",
+      "integrity": "sha512-CmVa4ImJ+ynfrPMNaAXHET6Bhb44SwzmfyVJFq9ni2jgXJR/l7C6gfVFddNmHP+ZOkP9cf4f9DBe68qVLTHc9w==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-android-arm-eabi": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm-eabi/-/binding-android-arm-eabi-0.121.0.tgz",
+      "integrity": "sha512-n07FQcySwOlzap424/PLMtOkbS7xOu8nsJduKL8P3COGHKgKoDYXwoAHCbChfgFpHnviehrLWIPX0lKGtbEk/A==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-android-arm64": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.121.0.tgz",
+      "integrity": "sha512-/Dd1xIXboYAicw+twT2utxPD7bL8qh7d3ej0qvaYIMj3/EgIrGR+tSnjCUkiCT6g6uTC0neSS4JY8LxhdSU/sA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-darwin-arm64": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.121.0.tgz",
+      "integrity": "sha512-A0jNEvv7QMtCO1yk205t3DWU9sWUjQ2KNF0hSVO5W9R9r/R1BIvzG01UQAfmtC0dQm7sCrs5puixurKSfr2bRQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-darwin-x64": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.121.0.tgz",
+      "integrity": "sha512-SsHzipdxTKUs3I9EOAPmnIimEeJOemqRlRDOp9LIj+96wtxZejF51gNibmoGq8KoqbT1ssAI5po/E3J+vEtXGA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-freebsd-x64": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.121.0.tgz",
+      "integrity": "sha512-v1APOTkCp+RWOIDAHRoaeW/UoaHF15a60E8eUL6kUQXh+i4K7PBwq2Wi7jm8p0ymID5/m/oC1w3W31Z/+r7HQw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm-gnueabihf": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.121.0.tgz",
+      "integrity": "sha512-PmqPQuqHZyFVWA4ycr0eu4VnTMmq9laOHZd+8R359w6kzuNZPvmmunmNJ8ybkm769A0nCoVp3TJ6dUz7B3FYIQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm-musleabihf": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.121.0.tgz",
+      "integrity": "sha512-vF24htj+MOH+Q7y9A8NuC6pUZu8t/C2Fr/kDOi2OcNf28oogr2xadBPXAbml802E8wRAVfbta6YLDQTearz+jw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm64-gnu": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.121.0.tgz",
+      "integrity": "sha512-wjH8cIG2Lu/3d64iZpbYr73hREMgKAfu7fqpXjgM2S16y2zhTfDIp8EQjxO8vlDtKP5Rc7waZW72lh8nZtWrpA==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm64-musl": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.121.0.tgz",
+      "integrity": "sha512-qT663J/W8yQFw3dtscbEi9LKJevr20V7uWs2MPGTnvNZ3rm8anhhE16gXGpxDOHeg9raySaSHKhd4IGa3YZvuw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-ppc64-gnu": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.121.0.tgz",
+      "integrity": "sha512-mYNe4NhVvDBbPkAP8JaVS8lC1dsoJZWH5WCjpw5E+sjhk1R08wt3NnXYUzum7tIiWPfgQxbCMcoxgeemFASbRw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-riscv64-gnu": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.121.0.tgz",
+      "integrity": "sha512-+QiFoGxhAbaI/amqX567784cDyyuZIpinBrJNxUzb+/L2aBRX67mN6Jv40pqduHf15yYByI+K5gUEygCuv0z9w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-riscv64-musl": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.121.0.tgz",
+      "integrity": "sha512-9ykEgyTa5JD/Uhv2sttbKnCfl2PieUfOjyxJC/oDL2UO0qtXOtjPLl7H8Kaj5G7p3hIvFgu3YWvAxvE0sqY+hQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-s390x-gnu": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.121.0.tgz",
+      "integrity": "sha512-DB1EW5VHZdc1lIRjOI3bW/wV6R6y0xlfvdVrqj6kKi7Ayu2U3UqUBdq9KviVkcUGd5Oq+dROqvUEEFRXGAM7EQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-x64-gnu": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.121.0.tgz",
+      "integrity": "sha512-s4lfobX9p4kPTclvMiH3gcQUd88VlnkMTF6n2MTMDAyX5FPNRhhRSFZK05Ykhf8Zy5NibV4PbGR6DnK7FGNN6A==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-x64-musl": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.121.0.tgz",
+      "integrity": "sha512-P9KlyTpuBuMi3NRGpJO8MicuGZfOoqZVRP1WjOecwx8yk4L/+mrCRNc5egSi0byhuReblBF2oVoDSMgV9Bj4Hw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-openharmony-arm64": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-openharmony-arm64/-/binding-openharmony-arm64-0.121.0.tgz",
+      "integrity": "sha512-R+4jrWOfF2OAPPhj3Eb3U5CaKNAH9/btMveMULIrcNW/hjfysFQlF8wE0GaVBr81dWz8JLgQlsxwctoL78JwXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-wasm32-wasi": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-wasm32-wasi/-/binding-wasm32-wasi-0.121.0.tgz",
+      "integrity": "sha512-5TFISkPTymKvsmIlKasPVTPuWxzCcrT8pM+p77+mtQbIZDd1UC8zww4CJcRI46kolmgrEX6QpKO8AvWMVZ+ifw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-win32-arm64-msvc": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.121.0.tgz",
+      "integrity": "sha512-V0pxh4mql4XTt3aiEtRNUeBAUFOw5jzZNxPABLaOKAWrVzSr9+XUaB095lY7jqMf5t8vkfh8NManGB28zanYKw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-win32-ia32-msvc": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.121.0.tgz",
+      "integrity": "sha512-4Ob1qvYMPnlF2N9rdmKdkQFdrq16QVcQwBsO8yiPZXof0fHKFF+LmQV501XFbi7lHyrKm8rlJRfQ/M8bZZPVLw==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-win32-x64-msvc": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.121.0.tgz",
+      "integrity": "sha512-BOp1KCzdboB1tPqoCPXgntgFs0jjeSyOXHzgxVFR7B/qfr3F8r4YDacHkTOUNXtDgM8YwKnkf3rE5gwALYX7NA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.121.0.tgz",
+      "integrity": "sha512-CGtOARQb9tyv7ECgdAlFxi0Fv7lmzvmlm2rpD/RdijOO9rfk/JvB1CjT8EnoD+tjna/IYgKKw3IV7objRb+aYw==",
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@pinojs/redact": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
+      "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
+      "license": "MIT"
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -3203,7 +4647,6 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
       "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -3240,10 +4683,152 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
+    "node_modules/@smithy/core": {
+      "version": "3.29.2",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.29.2.tgz",
+      "integrity": "sha512-DXUk6yU0C1Q1tYvJh1VCtl8QOBcSoZpKwjTPkxT6A4MUQYHvgeKGByL8mrEdxnvhdf9nq5GyzmRb5n/vPgu3Lw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.4.7",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.7.tgz",
+      "integrity": "sha512-UEMLOoA0Fl4uYBxh6l0uN0H6EJe/A89OGeDNTteQeXpJ20BcpfIr4wlCY9pel1jEAUHAxaYwuqrYlrKdXE1GKQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.29.2",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.6.4",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.4.tgz",
+      "integrity": "sha512-psnst7NZWdAEvJvyW8YZEE7xNVMyLrQFfHtyrVFrxNyy+dKWkQ+rqC6oI5ZhxThpUy9RSfEshgm34zqbOxzsRw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.29.2",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.9.4",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.4.tgz",
+      "integrity": "sha512-BNTop/fSOptmoVk8g+efwHCofFh37g70OWGAFES1TeAAJja1K5aAI8rTE26ETSc5k8IQuWY2kAIoPla01NgYrA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.29.2",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.3.tgz",
+      "integrity": "sha512-8qVKKzqh7naF27ePmx0SkUfnGP/wBI9dyaeAmhHvopnbIlItUAmB/e6PkPCU3rRb2v9BY8D4EZXSoydSibatvw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.29.2",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.16.0.tgz",
+      "integrity": "sha512-aVUabzlBBmY0PfvVgLKQSOGFIL5/7R54JE3uD9a5Ay/jSED61SkuAcCYENNXJzYUvJ1NPrWO0P+rAXHCkbBUKw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="
+    },
+    "node_modules/@szmarczak/http-timer": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
+      "integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
+      "license": "MIT",
+      "dependencies": {
+        "defer-to-connect": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "4.44.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-4.44.0.tgz",
+      "integrity": "sha512-swSgb7OiPRR3UuIL7NuDrZNSMGmQD+wdtHxPD7j60SvBEnxbXurl5XOirtGEX2gm2hbK6mC8kMV1I+uO3l0UOw==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "4.44.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-4.44.0.tgz",
+      "integrity": "sha512-RuIqHYrS98LrK/8kJJOJMMSQ/BCpojwsXDh7p0fBmp38ZOz6dlk+uyFRRusH+V+t3POoCsDOQ2zhomEYOeReXw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@tanstack/query-core": "4.44.0",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-native": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.1",
@@ -3282,6 +4867,18 @@
         "@babel/types": "^7.20.7"
       }
     },
+    "node_modules/@types/cacheable-request": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
+      "integrity": "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-cache-semantics": "*",
+        "@types/keyv": "^3.1.4",
+        "@types/node": "*",
+        "@types/responselike": "^1.0.0"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -3295,6 +4892,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/http-cache-semantics": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==",
+      "license": "MIT"
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.3",
@@ -3333,6 +4936,15 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
     },
+    "node_modules/@types/keyv": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
+      "integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/lodash": {
       "version": "4.17.24",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.24.tgz",
@@ -3341,7 +4953,6 @@
     },
     "node_modules/@types/node": {
       "version": "20.6.3",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/normalize-package-data": {
@@ -3355,6 +4966,30 @@
       "dev": true,
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/@types/responselike": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
+      "integrity": "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/sinon": {
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-21.0.1.tgz",
+      "integrity": "sha512-5yoJSqLbjH8T9V2bksgRayuhpZy+723/z6wBOR+Soe4ZlXC0eW8Na71TeaZPUWDQvM7LYKa9UGFc6LRqxiR5fQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/sinonjs__fake-timers": "*"
+      }
+    },
+    "node_modules/@types/sinonjs__fake-timers": {
+      "version": "15.0.1",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-15.0.1.tgz",
+      "integrity": "sha512-Ko2tjWJq8oozHzHV+reuvS5KYIRAokHnGbDwGh/J64LntgpbuylF74ipEL24HCyRjf9FOlBiBHWBR1RlVKsI1w==",
+      "license": "MIT"
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.1",
@@ -3648,12 +5283,10 @@
       }
     },
     "node_modules/agent-base": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
-      "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
-      "dependencies": {
-        "debug": "^4.3.4"
-      },
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
       "engines": {
         "node": ">= 14"
       }
@@ -3939,6 +5572,15 @@
         "node": ">= 4.0.0"
       }
     },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -4120,6 +5762,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base-x": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.1.tgz",
+      "integrity": "sha512-uAZ8x6r6S3aUM9rbHGVOIsR15U/ZSc82b3ymnCPsT45Gk1DDvhDPdIgB5MrhirZWt+5K0EEPQH985kNqZgNPFw==",
+      "license": "MIT"
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "dev": true,
@@ -4177,6 +5825,12 @@
       "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
       "integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==",
       "dev": true
+    },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
@@ -4275,7 +5929,6 @@
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/builtin-modules": {
@@ -4334,6 +5987,60 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/cacheable-lookup": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
+      "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.6.0"
+      }
+    },
+    "node_modules/cacheable-request": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.4.tgz",
+      "integrity": "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==",
+      "license": "MIT",
+      "dependencies": {
+        "clone-response": "^1.0.2",
+        "get-stream": "^5.1.0",
+        "http-cache-semantics": "^4.0.0",
+        "keyv": "^4.0.0",
+        "lowercase-keys": "^2.0.0",
+        "normalize-url": "^6.0.1",
+        "responselike": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cacheable-request/node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cacheable-request/node_modules/normalize-url": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
+      "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/cachedir": {
@@ -4789,6 +6496,18 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/clone-response": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
+      "integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "dev": true,
@@ -4820,6 +6539,13 @@
     "node_modules/color-name": {
       "version": "1.1.3",
       "license": "MIT"
+    },
+    "node_modules/colorette": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -4890,6 +6616,35 @@
       "version": "0.0.1",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "engines": [
+        "node >= 6.0"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "node_modules/concat-stream/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/confbox": {
       "version": "0.1.8",
@@ -5195,6 +6950,12 @@
         "node": ">= 8"
       }
     },
+    "node_modules/crypto-js": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
+      "license": "MIT"
+    },
     "node_modules/crypto-random-string": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-4.0.0.tgz",
@@ -5309,6 +7070,51 @@
         "url": "https://opencollective.com/date-fns"
       }
     },
+    "node_modules/dateformat": {
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
+      "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/dc-polyfill": {
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/dc-polyfill/-/dc-polyfill-0.1.11.tgz",
+      "integrity": "sha512-TyyeGcjx0YeThAI9fTFtgsvj5qd4R+aGfVmXiUhevbgzWFDr7IK4tv4YjE6jaGzLHQTchk4h7DHdr5q4WGgaZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
+    "node_modules/dd-trace": {
+      "version": "5.96.0",
+      "resolved": "https://registry.npmjs.org/dd-trace/-/dd-trace-5.96.0.tgz",
+      "integrity": "sha512-L6GeXM86dMR/tK5AgweMR5hJDtW+Nm0WQXe79Ff/j+dogChGdDZ/oP4ohQ26ZKni6xv5Ci4SAcAMoqprSHE4Pw==",
+      "hasInstallScript": true,
+      "license": "(Apache-2.0 OR BSD-3-Clause)",
+      "dependencies": {
+        "dc-polyfill": "^0.1.10",
+        "import-in-the-middle": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18 <26"
+      },
+      "optionalDependencies": {
+        "@datadog/libdatadog": "0.9.2",
+        "@datadog/native-appsec": "11.0.1",
+        "@datadog/native-iast-taint-tracking": "4.1.0",
+        "@datadog/native-metrics": "3.1.1",
+        "@datadog/openfeature-node-server": "^1.1.1",
+        "@datadog/pprof": "5.14.1",
+        "@datadog/wasm-js-rewriter": "5.0.1",
+        "@opentelemetry/api": ">=1.0.0 <1.10.0",
+        "@opentelemetry/api-logs": "<1.0.0",
+        "oxc-parser": "^0.121.0"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
@@ -5324,6 +7130,33 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/decompress-response/node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/dedent": {
@@ -5359,6 +7192,15 @@
       "license": "MIT",
       "dependencies": {
         "clone": "^1.0.2"
+      }
+    },
+    "node_modules/defer-to-connect": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+      "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/define-data-property": {
@@ -5539,6 +7381,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
     "node_modules/env-ci": {
       "version": "11.2.0",
       "resolved": "https://registry.npmjs.org/env-ci/-/env-ci-11.2.0.tgz",
@@ -5708,6 +7559,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/err-code": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
+      "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
+      "license": "MIT"
+    },
     "node_modules/error-ex": {
       "version": "1.3.2",
       "dev": true,
@@ -5801,6 +7658,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.0.tgz",
+      "integrity": "sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==",
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -6709,6 +8572,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/fastq": {
       "version": "1.13.0",
       "dev": true,
@@ -7102,6 +8972,12 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/get-port-please": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/get-port-please/-/get-port-please-3.2.0.tgz",
+      "integrity": "sha512-I9QVvBw5U/hw3RmWpYKRumUeaDgxTPd401x364rLmWBJcOQ753eov1eTgzDqRG9bqFIfDc7gfzcQEWrUri3o1A==",
+      "license": "MIT"
+    },
     "node_modules/get-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
@@ -7327,6 +9203,31 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/got": {
+      "version": "11.8.6",
+      "resolved": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
+      "integrity": "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/is": "^4.0.0",
+        "@szmarczak/http-timer": "^4.0.5",
+        "@types/cacheable-request": "^6.0.1",
+        "@types/responselike": "^1.0.0",
+        "cacheable-lookup": "^5.0.3",
+        "cacheable-request": "^7.0.2",
+        "decompress-response": "^6.0.0",
+        "http2-wrapper": "^1.0.0-beta.5.2",
+        "lowercase-keys": "^2.0.0",
+        "p-cancelable": "^2.0.0",
+        "responselike": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/got?sponsor=1"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.10",
       "dev": true,
@@ -7460,6 +9361,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/help-me": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/help-me/-/help-me-5.0.0.tgz",
+      "integrity": "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/highlight.js": {
       "version": "10.7.3",
       "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
@@ -7479,6 +9387,15 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.18",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
+      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
       }
     },
     "node_modules/hook-std": {
@@ -7519,6 +9436,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/http-cache-semantics": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
@@ -7532,12 +9455,26 @@
         "node": ">= 14"
       }
     },
-    "node_modules/https-proxy-agent": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.2.tgz",
-      "integrity": "sha512-NmLNjm6ucYwtcUmL7JQC1ZQ57LmHP4lT15FQ8D61nak1rO6DH+fz5qNK2Ap5UN4ZapYICE3/0KodcLYSPsPbaA==",
+    "node_modules/http2-wrapper": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
+      "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
+      "license": "MIT",
       "dependencies": {
-        "agent-base": "^7.0.2",
+        "quick-lru": "^5.1.1",
+        "resolve-alpn": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=10.19.0"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
         "debug": "4"
       },
       "engines": {
@@ -7628,6 +9565,26 @@
         "node": ">=18.20"
       }
     },
+    "node_modules/import-in-the-middle": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.3.1.tgz",
+      "integrity": "sha512-0rymlHSFLwZ0ixx8DaQkoIyZojJPY2a0K2nEYslhKJ6jIYO/m0IcCb7iQsFPmS7WmKwISZiIrv5Icstrw/CmqA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "cjs-module-lexer": "^2.2.0",
+        "es-module-lexer": "^2.2.0",
+        "module-details-from-path": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/import-in-the-middle/node_modules/cjs-module-lexer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
+      "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
+      "license": "MIT"
+    },
     "node_modules/import-local": {
       "version": "3.1.0",
       "dev": true,
@@ -7694,7 +9651,6 @@
     },
     "node_modules/inherits": {
       "version": "2.0.4",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/ini": {
@@ -10075,7 +12031,7 @@
     },
     "node_modules/joycon": {
       "version": "3.1.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -10109,6 +12065,12 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "license": "MIT"
     },
     "node_modules/json-parse-better-errors": {
       "version": "1.0.2",
@@ -10153,12 +12115,40 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
     "node_modules/kleur": {
       "version": "3.0.3",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/klona": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/klona/-/klona-2.0.6.tgz",
+      "integrity": "sha512-dhG34DXATL5hSxJbIexCft8FChFXtmskoZYnoPWjXQuebWYCNkVeV3KkGegCK9CP1oswI/vQibS2GY7Em/sJJA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/launchdarkly-eventsource": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/launchdarkly-eventsource/-/launchdarkly-eventsource-2.2.0.tgz",
+      "integrity": "sha512-u38fYlLSq/m6oFz0MS1/76Sj2xzlYhTKZ+sf/vju6PA86PMc6fPlY5k8CdU79edLXjNwsvIQTDvDNy3llDqB8A==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.12.0"
       }
     },
     "node_modules/leven": {
@@ -10565,9 +12555,17 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/lowercase-keys": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+      "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "6.0.0",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "yallist": "^4.0.0"
@@ -10779,6 +12777,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "dev": true,
@@ -10792,7 +12799,7 @@
     },
     "node_modules/minimist": {
       "version": "1.2.6",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/minipass": {
@@ -10817,6 +12824,12 @@
         "pkg-types": "^1.3.0",
         "ufo": "^1.5.4"
       }
+    },
+    "node_modules/module-details-from-path": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
+      "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -10866,6 +12879,13 @@
         "shell-quote": "^1.4.1"
       }
     },
+    "node_modules/node-addon-api": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-6.1.0.tgz",
+      "integrity": "sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/node-emoji": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-2.2.0.tgz",
@@ -10880,6 +12900,18 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/node-gyp-build": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-3.9.0.tgz",
+      "integrity": "sha512-zLcTg6P4AbcHPq465ZMFNXx7XpKKJh+7kkN699NiQWisR2uWYOWNWqRHAmbnmKiL4e9aLSlmy5U7rEMUXV59+A==",
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
       }
     },
     "node_modules/node-int64": {
@@ -13168,9 +15200,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/on-exit-leak-free": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -13188,6 +15228,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/openapi3-ts": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/openapi3-ts/-/openapi3-ts-2.0.2.tgz",
+      "integrity": "sha512-TxhYBMoqx9frXyOgnRHufjQfPXomTIHYKhSKJ6jHfj13kS8OEIhvmE8CTuQyKtjjWttAjX5DPxM1vmalEpo8Qw==",
+      "license": "MIT",
+      "dependencies": {
+        "yaml": "^1.10.2"
       }
     },
     "node_modules/optionator": {
@@ -13354,6 +15403,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/oxc-parser": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.121.0.tgz",
+      "integrity": "sha512-ek9o58+SCv6AV7nchiAcUJy1DNE2CC5WRdBcO0mF+W4oRjNQfPO7b3pLjTHSFECpHkKGOZSQxx3hk8viIL5YCg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@oxc-project/types": "^0.121.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxc-parser/binding-android-arm-eabi": "0.121.0",
+        "@oxc-parser/binding-android-arm64": "0.121.0",
+        "@oxc-parser/binding-darwin-arm64": "0.121.0",
+        "@oxc-parser/binding-darwin-x64": "0.121.0",
+        "@oxc-parser/binding-freebsd-x64": "0.121.0",
+        "@oxc-parser/binding-linux-arm-gnueabihf": "0.121.0",
+        "@oxc-parser/binding-linux-arm-musleabihf": "0.121.0",
+        "@oxc-parser/binding-linux-arm64-gnu": "0.121.0",
+        "@oxc-parser/binding-linux-arm64-musl": "0.121.0",
+        "@oxc-parser/binding-linux-ppc64-gnu": "0.121.0",
+        "@oxc-parser/binding-linux-riscv64-gnu": "0.121.0",
+        "@oxc-parser/binding-linux-riscv64-musl": "0.121.0",
+        "@oxc-parser/binding-linux-s390x-gnu": "0.121.0",
+        "@oxc-parser/binding-linux-x64-gnu": "0.121.0",
+        "@oxc-parser/binding-linux-x64-musl": "0.121.0",
+        "@oxc-parser/binding-openharmony-arm64": "0.121.0",
+        "@oxc-parser/binding-wasm32-wasi": "0.121.0",
+        "@oxc-parser/binding-win32-arm64-msvc": "0.121.0",
+        "@oxc-parser/binding-win32-ia32-msvc": "0.121.0",
+        "@oxc-parser/binding-win32-x64-msvc": "0.121.0"
+      }
+    },
+    "node_modules/p-cancelable": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
+      "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/p-each-series": {
@@ -13649,6 +15745,88 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/pino": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-10.3.1.tgz",
+      "integrity": "sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==",
+      "license": "MIT",
+      "dependencies": {
+        "@pinojs/redact": "^0.4.0",
+        "atomic-sleep": "^1.0.0",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^3.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^4.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-3.0.0.tgz",
+      "integrity": "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-pretty": {
+      "version": "13.1.3",
+      "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-13.1.3.tgz",
+      "integrity": "sha512-ttXRkkOz6WWC95KeY9+xxWL6AtImwbyMHrL1mSwqwW9u+vLp/WIElvHvCSDg0xO/Dzrggz1zv3rN5ovTRVowKg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "colorette": "^2.0.7",
+        "dateformat": "^4.6.3",
+        "fast-copy": "^4.0.0",
+        "fast-safe-stringify": "^2.1.1",
+        "help-me": "^5.0.0",
+        "joycon": "^3.1.1",
+        "minimist": "^1.2.6",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^3.0.0",
+        "pump": "^3.0.0",
+        "secure-json-parse": "^4.0.0",
+        "sonic-boom": "^4.0.1",
+        "strip-json-comments": "^5.0.2"
+      },
+      "bin": {
+        "pino-pretty": "bin.js"
+      }
+    },
+    "node_modules/pino-pretty/node_modules/fast-copy": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-4.0.3.tgz",
+      "integrity": "sha512-58apWr0GUiDFM8+3afrO6eYwJBn9ZAhDOzG3L+/9llab/haCARS2UIfffmOurYLwbgDRs8n0rfr6qAAPEAuAQw==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pino-pretty/node_modules/strip-json-comments": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-5.0.3.tgz",
+      "integrity": "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
+      "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
+      "license": "MIT"
+    },
     "node_modules/pirates": {
       "version": "4.0.4",
       "dev": true,
@@ -13763,6 +15941,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/pprof-format": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/pprof-format/-/pprof-format-2.2.2.tgz",
+      "integrity": "sha512-hd90rHVDhNOhgHTmazVzDSVwTLOBjpZQ26AO/0j46sAFZ9uSWY0DcK2zJcwnuo2R6EzufBbOoWlPazA5nSyHcg==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "dev": true,
@@ -13823,6 +16008,35 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/process-warning": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
+      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/promise-retry": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
+      "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
+      "license": "MIT",
+      "dependencies": {
+        "err-code": "^2.0.2",
+        "retry": "^0.12.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/prompts": {
       "version": "2.4.2",
       "dev": true,
@@ -13849,6 +16063,16 @@
         "node": ">=10"
       }
     },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.0",
       "dev": true,
@@ -13873,11 +16097,13 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -13905,6 +16131,24 @@
       ],
       "license": "MIT"
     },
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
+      "license": "MIT"
+    },
+    "node_modules/quick-lru": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/rc": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
@@ -13927,6 +16171,29 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
+      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
+      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.7"
       }
     },
     "node_modules/react-is": {
@@ -14039,6 +16306,15 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0"
+      }
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -14067,6 +16343,15 @@
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
       "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
       "license": "MIT"
+    },
+    "node_modules/regexp-tree": {
+      "version": "0.1.27",
+      "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.27.tgz",
+      "integrity": "sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==",
+      "license": "MIT",
+      "bin": {
+        "regexp-tree": "bin/regexp-tree"
+      }
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",
@@ -14124,6 +16409,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/resolve-alpn": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
+      "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
+      "license": "MIT"
     },
     "node_modules/resolve-cwd": {
       "version": "3.0.0",
@@ -14185,6 +16476,18 @@
         "node": ">=10"
       }
     },
+    "node_modules/responselike": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
+      "integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
+      "license": "MIT",
+      "dependencies": {
+        "lowercase-keys": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/restore-cursor": {
       "version": "2.0.0",
       "license": "MIT",
@@ -14211,6 +16514,15 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/reusify": {
@@ -14393,6 +16705,12 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/runtypes": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/runtypes/-/runtypes-7.0.4.tgz",
+      "integrity": "sha512-fWEOLUpOlbl7zhmjDrPymCFWZIA+b+EeOFQlAbbQRYQvqcI0ys7Y/O5A09Z5IIvTf3x/DrgTN6396aXLfDRxUA==",
+      "license": "MIT"
+    },
     "node_modules/rxjs": {
       "version": "6.6.7",
       "license": "Apache-2.0",
@@ -14436,7 +16754,6 @@
     },
     "node_modules/safe-buffer": {
       "version": "5.1.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/safe-push-apply": {
@@ -14463,6 +16780,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/safe-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-2.1.1.tgz",
+      "integrity": "sha512-rx+x8AMzKb5Q5lQ95Zoi6ZbJqwCLkqi3XuJXp5P3rT8OEc6sZCJG5AE5dU3lsgRr/F4Bs31jSlVN+j5KrsGu9A==",
+      "license": "MIT",
+      "dependencies": {
+        "regexp-tree": "~0.1.1"
+      }
+    },
     "node_modules/safe-regex-test": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
@@ -14481,10 +16807,43 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/secure-json-parse": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-4.1.0.tgz",
+      "integrity": "sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause",
+      "optional": true
     },
     "node_modules/semantic-release": {
       "version": "25.0.3",
@@ -15054,14 +17413,14 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -15073,13 +17432,13 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -15188,6 +17547,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/sonic-boom": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
+      "integrity": "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "dev": true,
@@ -15205,6 +17573,13 @@
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
       }
+    },
+    "node_modules/spark-md5": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/spark-md5/-/spark-md5-3.0.2.tgz",
+      "integrity": "sha512-wcFzz9cDfbuqe0FZzfi2or1sgyIrsDwmPwfZC4hiNidPdPINjeUwNfv5kldczoEAcjl9Y1L3SM7Uz2PUEQzxQw==",
+      "license": "(WTFPL OR MIT)",
+      "optional": true
     },
     "node_modules/spawn-error-forwarder": {
       "version": "1.0.0",
@@ -15242,6 +17617,15 @@
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.22.tgz",
       "integrity": "sha512-4PRT4nh1EImPbt2jASOKHX7PB7I+e4IWNLvkKFDxNhJlfjbYlleYQh285Z/3mPTHSAK/AvdMmw5BNNuYH8ShgQ==",
       "dev": true
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
     },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
@@ -15292,7 +17676,6 @@
     },
     "node_modules/string_decoder": {
       "version": "1.1.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
@@ -15612,7 +17995,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
       "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
-      "dev": true,
       "engines": {
         "node": ">=20"
       },
@@ -15707,6 +18089,24 @@
       "engines": {
         "node": ">=0.8"
       }
+    },
+    "node_modules/thread-stream": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-4.2.0.tgz",
+      "integrity": "sha512-e2zZ96wSChazBsbENf/Pcm/4swHt2cEKQ92rhUjkL9GCKiTDJIaTBenjE/m9DXi0QBmTMDkFDdOomUy20A1tDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "real-require": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/thread-stream/node_modules/real-require": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-1.0.0.tgz",
+      "integrity": "sha512-P4nbQYQfePJxRSmY+v/KINxVucm4NF3p3s7pJveMTtom52FR4YGltUQLB8idDXwDDWW+eYrWDFbuzUnjoWHF7g==",
+      "license": "MIT"
     },
     "node_modules/through": {
       "version": "2.3.8",
@@ -15839,6 +18239,15 @@
       },
       "peerDependencies": {
         "typescript": ">=4.2.0"
+      }
+    },
+    "node_modules/ts-deepmerge": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ts-deepmerge/-/ts-deepmerge-6.2.1.tgz",
+      "integrity": "sha512-8CYSLazCyj0DJDpPIxOFzJG46r93uh6EynYjuey+bxcLltBeqZL7DMfaE5ZPzZNFlav7wx+2TDa/mBl8gkTYzw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14.13.1"
       }
     },
     "node_modules/ts-interface-checker": {
@@ -15992,8 +18401,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.3.1",
-      "dev": true,
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
     "node_modules/tsup": {
@@ -16097,20 +18507,6 @@
       "dev": true,
       "engines": {
         "node": ">= 12"
-      }
-    },
-    "node_modules/tsup/node_modules/yaml": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.5.1.tgz",
-      "integrity": "sha512-bLQOjaX/ADgQ20isPJRvF0iRUHIxVhYvr53Of7wGcWlO2jvtUlH5m87DsmulFVxRpNLOnI4tB6p/oh8D7kpn9Q==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14"
       }
     },
     "node_modules/tunnel": {
@@ -16229,6 +18625,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "license": "MIT"
     },
     "node_modules/typescript": {
       "version": "5.9.3",
@@ -16393,9 +18795,18 @@
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/uuid": {
@@ -16409,6 +18820,12 @@
       "bin": {
         "uuid": "dist/bin/uuid"
       }
+    },
+    "node_modules/uuid-random": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/uuid-random/-/uuid-random-1.3.2.tgz",
+      "integrity": "sha512-UOzej0Le/UgkbWEO8flm+0y+G+ljUon1QWTEZOq1rnMAsxo2+SckbiZdKzAHHlVh6gJqI1TjC/xwgR50MuCrBQ==",
+      "license": "MIT"
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.1.0",
@@ -16668,7 +19085,6 @@
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/write-file-atomic": {
@@ -16700,14 +19116,11 @@
     },
     "node_modules/yallist": {
       "version": "4.0.0",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/yaml": {
       "version": "1.10.2",
-      "dev": true,
       "license": "ISC",
-      "optional": true,
       "engines": {
         "node": ">= 6"
       }
@@ -16830,6 +19243,15 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
     }
   },
   "dependencies": {
@@ -16889,6 +19311,257 @@
           }
         }
       }
+    },
+    "@aws-sdk/checksums": {
+      "version": "3.1000.14",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/checksums/-/checksums-3.1000.14.tgz",
+      "integrity": "sha512-9j0TSNmYVywV+shhBXXkIhaazZwZ+nDSGfG6V47nFLqXdk6mPYk/OJkV4+uRvIg2Ju5F6HTvgM/sfsuTsbAYwg==",
+      "requires": {
+        "@aws-sdk/core": "^3.974.29",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@aws-sdk/client-s3": {
+      "version": "3.1081.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1081.0.tgz",
+      "integrity": "sha512-mHAdLBibsbFwcW2YHrH5sIQlaXjB3zha7Nkooa2gqTlXxRpVJ+ba/v/mg19B6rJeZmOEteRHFz+INOlAbCbxJg==",
+      "requires": {
+        "@aws-sdk/checksums": "^3.1000.14",
+        "@aws-sdk/core": "^3.974.29",
+        "@aws-sdk/credential-provider-node": "^3.972.64",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.60",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.38",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/fetch-http-handler": "^5.6.2",
+        "@smithy/node-http-handler": "^4.9.2",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@aws-sdk/client-sns": {
+      "version": "3.1081.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sns/-/client-sns-3.1081.0.tgz",
+      "integrity": "sha512-3W50Y0WN6XxV6QDtQxbP4oRMxIlWp6/EYkyLjxeeaLAwfTljjX0zPtWXYQaFo4kM/unf6JlePOHZn3flMUn3ZA==",
+      "requires": {
+        "@aws-sdk/core": "^3.974.29",
+        "@aws-sdk/credential-provider-node": "^3.972.64",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/fetch-http-handler": "^5.6.2",
+        "@smithy/node-http-handler": "^4.9.2",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@aws-sdk/core": {
+      "version": "3.974.29",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.29.tgz",
+      "integrity": "sha512-yqKcltLbtRh1ubzhRSldIs8jFHNZlyMlgoIccCC0aDVbrB99nXaBdmfr89mK7obWX/NVg4rAMpCpZ6dCDiVBtA==",
+      "requires": {
+        "@aws-sdk/types": "^3.973.15",
+        "@aws-sdk/xml-builder": "^3.972.33",
+        "@aws/lambda-invoke-store": "^0.3.0",
+        "@smithy/core": "^3.29.0",
+        "@smithy/signature-v4": "^5.6.1",
+        "@smithy/types": "^4.15.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@aws-sdk/credential-provider-env": {
+      "version": "3.972.55",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.55.tgz",
+      "integrity": "sha512-Ah36tYkqyaVnaHkx7VseoTYrHUmwgBps3V+wnrC1idhIIMGlviH0FtrX9EIPdAlVHvXC7FQZLhmHBRz+pLaiWg==",
+      "requires": {
+        "@aws-sdk/core": "^3.974.29",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@aws-sdk/credential-provider-http": {
+      "version": "3.972.57",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.57.tgz",
+      "integrity": "sha512-/vp6i5YEliJqRm5k/BDmYjAyRAMTdkjW6UciVRk9oh/0OfDCWeb/ih7hqte4lFvKXkIbsqe9AdK9LQK6NGardw==",
+      "requires": {
+        "@aws-sdk/core": "^3.974.29",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/fetch-http-handler": "^5.6.2",
+        "@smithy/node-http-handler": "^4.9.2",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@aws-sdk/credential-provider-ini": {
+      "version": "3.972.62",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.62.tgz",
+      "integrity": "sha512-pQIRiQQs+MUlVnJdWJ7/6KS0WxcLRVfut57OFgwC3cnM1F8mXw3Kh4gAVwj6AtvD6CWx8x6+po4ENRcqe64XrQ==",
+      "requires": {
+        "@aws-sdk/core": "^3.974.29",
+        "@aws-sdk/credential-provider-env": "^3.972.55",
+        "@aws-sdk/credential-provider-http": "^3.972.57",
+        "@aws-sdk/credential-provider-login": "^3.972.61",
+        "@aws-sdk/credential-provider-process": "^3.972.55",
+        "@aws-sdk/credential-provider-sso": "^3.972.61",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.61",
+        "@aws-sdk/nested-clients": "^3.997.29",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/credential-provider-imds": "^4.4.5",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@aws-sdk/credential-provider-login": {
+      "version": "3.972.61",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.61.tgz",
+      "integrity": "sha512-jtrxWwC7slqxh7DnAWHrwsA3UwCsnlypdYtavGT7EX5p791wxWQys7QzkCZ7JvOMAyylDtPoxyV+ic0zg3rV9g==",
+      "requires": {
+        "@aws-sdk/core": "^3.974.29",
+        "@aws-sdk/nested-clients": "^3.997.29",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@aws-sdk/credential-provider-node": {
+      "version": "3.972.64",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.64.tgz",
+      "integrity": "sha512-zyKVYDyMR9VQL/kPi03ygN2vtD9uLMuWRLoJ77KxgZZaS1VlJloI+SzleF9Zg4HWUI+AIu+ZRs8zsJFNqbrxsw==",
+      "requires": {
+        "@aws-sdk/credential-provider-env": "^3.972.55",
+        "@aws-sdk/credential-provider-http": "^3.972.57",
+        "@aws-sdk/credential-provider-ini": "^3.972.62",
+        "@aws-sdk/credential-provider-process": "^3.972.55",
+        "@aws-sdk/credential-provider-sso": "^3.972.61",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.61",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/credential-provider-imds": "^4.4.5",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@aws-sdk/credential-provider-process": {
+      "version": "3.972.55",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.55.tgz",
+      "integrity": "sha512-x0XjjF0l1WGRtK2vEhTZqCguQuAIZLep9l2+eeEmuxQQjjD3BlGQXY5xADR+l3t576UX+dxRkRtTjEu40l81Vw==",
+      "requires": {
+        "@aws-sdk/core": "^3.974.29",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@aws-sdk/credential-provider-sso": {
+      "version": "3.972.61",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.61.tgz",
+      "integrity": "sha512-d/V0VRsz73i+PHhbult/tx0Y1+de1SNQVsXkcQCmpfeBq7uODy/RTxNsOLpT9ZVHxcRNzbQFuywLKC33fUMIxA==",
+      "requires": {
+        "@aws-sdk/core": "^3.974.29",
+        "@aws-sdk/nested-clients": "^3.997.29",
+        "@aws-sdk/token-providers": "3.1081.0",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.61",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.61.tgz",
+      "integrity": "sha512-Bv4n3NOI6hPy+rmr6Bw9R6LnBVRkcp3ncj2E2IKSYJG+0UkysSitWMvbgndNvMxDw7gE1pQ/ErwkNceuKwj7zQ==",
+      "requires": {
+        "@aws-sdk/core": "^3.974.29",
+        "@aws-sdk/nested-clients": "^3.997.29",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@aws-sdk/middleware-sdk-s3": {
+      "version": "3.972.60",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.60.tgz",
+      "integrity": "sha512-f8SREKL6uQUYt8fwreiUgaAJQ31/M+UkWfJMDY/TBJC5FdHgNzxuvRFeZ9eMbnf2ydQ3p4pcKEhaLk35DDIPxw==",
+      "requires": {
+        "@aws-sdk/core": "^3.974.29",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.38",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@aws-sdk/nested-clients": {
+      "version": "3.997.29",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.29.tgz",
+      "integrity": "sha512-ot6v8J5W8P0w6ryyuIkXP1bHZHTlvwtn83mVCYaBE0GJ6tJX4vPSBx7M98w9O4wmmDruFsDBUMjhEHA+OosUFQ==",
+      "requires": {
+        "@aws-sdk/core": "^3.974.29",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.38",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/fetch-http-handler": "^5.6.2",
+        "@smithy/node-http-handler": "^4.9.2",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.38",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.38.tgz",
+      "integrity": "sha512-C379Sk+MiFZCfWZphKlMyLHKxV22OjoGM5KJjj5IJNJcOCWL4IGIpnEGzv1FQiRwhYXfq55SJMfxlqPE08JJ9g==",
+      "requires": {
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/signature-v4": "^5.6.1",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@aws-sdk/token-providers": {
+      "version": "3.1081.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1081.0.tgz",
+      "integrity": "sha512-kduAeI6cL+zqwj3gjPh9LhuX7kBZ83msYxutavaR+UPm5K8J7iThJBvNRAsFNyWTji92CSU8dogUgvi9T0BehA==",
+      "requires": {
+        "@aws-sdk/core": "^3.974.29",
+        "@aws-sdk/nested-clients": "^3.997.29",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@aws-sdk/types": {
+      "version": "3.973.15",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.15.tgz",
+      "integrity": "sha512-IULn8uBV/SMtmOIANsm4WHXIOtVPBWfOWs3WGL0j/sI+KhaYehvOw0ET+9urnn8MBpiijuU/0JOpuwKOE451PQ==",
+      "requires": {
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@aws-sdk/xml-builder": {
+      "version": "3.972.33",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.33.tgz",
+      "integrity": "sha512-ezbwz9WpuLctm6o7P2t2naDhVVPI5jFGrVefVybhcKGjU57VIyT46pQVO0RI2RYkUdhdj2Z9uSIlAzGZE9NW9A==",
+      "requires": {
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@aws/lambda-invoke-store": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz",
+      "integrity": "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ=="
     },
     "@babel/code-frame": {
       "version": "7.27.1",
@@ -17333,15 +20006,484 @@
         }
       }
     },
+    "@contentful/assemblies-management-api-contract": {
+      "version": "3.75.0",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/assemblies-management-api-contract/3.75.0/da83b371f7acc02cf9b416da4b38469f29713c10",
+      "integrity": "sha512-cA4+l/6MviPb6B/HmWvPNaHpI4qc4lscPELwKYk6G4IINSh4z5C5x0l0qKIXfFyiUJJZBWuqbUfs5anmljrsrA==",
+      "requires": {
+        "@contentful/assemblies-types": "3.68.0",
+        "@contentful/bulk-actions": "0.9.0",
+        "@contentful/query-to-constraints": "3.55.0",
+        "@contentful/service-kit": "6.10.0",
+        "zod": "4.4.3"
+      }
+    },
+    "@contentful/assemblies-types": {
+      "version": "3.68.0",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/assemblies-types/3.68.0/15da1136cd22f8fb35708282ca430abd81d6e53a",
+      "integrity": "sha512-dswBf6ALGwV2UfvAerdVgLlw0G9f6jNZwtxdw8WoYX9/yeP0vRNjuEzytVl4Gg96l4bijUmZsGNfyWGV3xKhKw==",
+      "requires": {
+        "@contentful/data-type": "0.41.0",
+        "@contentful/pointer-syntax": "0.39.0",
+        "zod": "4.4.3"
+      }
+    },
+    "@contentful/authorization-policy-service-client": {
+      "version": "10.14.3",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/authorization-policy-service-client/10.14.3/539e0b3da9af19f5e5a37462cfd52c13d8458e54",
+      "integrity": "sha512-MZyUP1uIjnRYH/U38hUk4btQL/omgIIr0FzH5LQUIzWjjapYddxKe7rEwtb4SM7qtVQOADtr0jZDRZWkbpHGkg==",
+      "requires": {
+        "@contentful/errors": "^4.14.11",
+        "@contentful/http-client": "^6.16.19",
+        "crypto-js": "^4.2.0",
+        "lodash": "^4.18.1",
+        "lru-cache": "^11.5.1",
+        "qs": "^6.15.2",
+        "runtypes": "^7.0.4",
+        "uuid-random": "^1.3.2"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "11.5.2",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+          "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g=="
+        }
+      }
+    },
+    "@contentful/aws-message-patterns-common": {
+      "version": "1.2.49",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/aws-message-patterns-common/1.2.49/b1241119090800fc6d19685b6444df0999d25c31",
+      "integrity": "sha512-zX8+Knn6rmf+nuZWs9PEqN+dkLmXRygwSGD93vzN0xmGinh0w4vZM4i550NH7nkqsp/588E0hY1dXY0DfYclVA==",
+      "requires": {
+        "@contentful/uuid": "^2.4.11"
+      }
+    },
+    "@contentful/aws-message-patterns-s3-client": {
+      "version": "1.4.49",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/aws-message-patterns-s3-client/1.4.49/593f4d114e258b7684d3e6ac8a740e77e0c77a97",
+      "integrity": "sha512-F/7bxBgkxE9cP99lqTs3ZIEvJVQtAehGzXx/sBtzEO7H0brvH/XIdh8mLbRI2jhXOC6zG5lBbGA9hWMXNL1pdw==",
+      "requires": {
+        "@aws-sdk/client-s3": "^3.1075.0",
+        "@contentful/aws-message-patterns-common": "1.2.49"
+      }
+    },
+    "@contentful/aws-message-patterns-sns-producer": {
+      "version": "1.3.49",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/aws-message-patterns-sns-producer/1.3.49/0ab136ac3175e9baf201ad3415a228f0c4955f93",
+      "integrity": "sha512-UH9YzK9/chFnymkEiddrk54eOsOcMtyUg64AFfNlYfi/LIEkwiZK9IkFDLQGjShSAknGIX3hPuevoAvhBKM9bg==",
+      "requires": {
+        "@aws-sdk/client-sns": "^3.1075.0",
+        "@contentful/aws-message-patterns-common": "1.2.49",
+        "@contentful/aws-message-patterns-s3-client": "1.4.49",
+        "p-map": "^4.0.0"
+      },
+      "dependencies": {
+        "aggregate-error": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+          "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+          "requires": {
+            "clean-stack": "^2.0.0",
+            "indent-string": "^4.0.0"
+          }
+        },
+        "clean-stack": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+          "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A=="
+        },
+        "indent-string": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+          "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="
+        },
+        "p-map": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
+          "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+          "requires": {
+            "aggregate-error": "^3.0.0"
+          }
+        }
+      }
+    },
+    "@contentful/bulk-actions": {
+      "version": "0.9.0",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/bulk-actions/0.9.0/cd06382b1c2a9549b7f8cbba72bbdf367bad46d7",
+      "integrity": "sha512-IaSY0q8x7uITAO1WdO5bIVDCr5QNRLJ9ru6LeD3QJ0c/p28AvSk922bVRBjqrbZ4/Gz0YkXioSFAr9s4wF5l8w==",
+      "requires": {
+        "@contentful/service-kit": "6.10.0",
+        "zod": "4.4.3"
+      }
+    },
+    "@contentful/content-internal-api-contract": {
+      "version": "3.62.0",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/content-internal-api-contract/3.62.0/c07b8dd4a7db1ae0cac9360fa9c77b1be40a7fd1",
+      "integrity": "sha512-iMuJejbTwTImDa5tEQrozp9zx+Ru6E1i+KL0fwGqAjnHA5Bja/iGJmK+mapXGNAYVaqJjwz/ahkrKfDvIuyptg==",
+      "requires": {
+        "@contentful/service-kit": "6.10.0",
+        "zod": "4.4.3"
+      }
+    },
+    "@contentful/data-type": {
+      "version": "0.41.0",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/data-type/0.41.0/46ec95bb1ea70037c87242e80747ee2821c6b9d3",
+      "integrity": "sha512-VxeKs1g31HYgHWYSrTmWjuDYekgzopAFrPxnbRuXXjirYYPCFDGizbVlnf+3IQzJWTZtCRZ3nv8ww+8aJR2g8A==",
+      "requires": {
+        "zod": "4.4.3"
+      }
+    },
+    "@contentful/errors": {
+      "version": "4.14.11",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/errors/4.14.11/e2b7836879dc0249034a9e134694409672b68f2f",
+      "integrity": "sha512-26IJLvq6yZ4xXIXedON4UVc4ysInRBrftnnE/DoaKnFNOCGztSyJDDZ1DIREMec/dhbBXipCSHPb1xnMePnmVw==",
+      "requires": {
+        "@contentful/mimetype": "^2.6.5"
+      }
+    },
+    "@contentful/experiences-api-schemas": {
+      "version": "4.99.0",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/experiences-api-schemas/4.99.0/6827fa298a5f5f60f03f3b6a26ab2e087a69f27f",
+      "integrity": "sha512-eFfk2mMZjFhxOpPaYvstv9u1tvx0twTW2YPLxgUFpTxWNGQcNS1a55NUC5G+uGoC45wgjUTQbK+m37Q1vxodJw==",
+      "requires": {
+        "@contentful/assemblies-types": "3.68.0",
+        "@contentful/data-type": "0.41.0",
+        "@contentful/resource-names": "^1.9.1",
+        "@contentful/service-kit": "6.10.0",
+        "zod": "4.4.3"
+      }
+    },
+    "@contentful/experiences-management-api-contract": {
+      "version": "5.140.0",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/experiences-management-api-contract/5.140.0/71e049089cc2b61e23e101b32ddd8f469528cb4d",
+      "integrity": "sha512-/5W6JJimOd1JtPUP7G5nQ9dG673TicU7nDeqvlxnwKsE9HiTDov27utV+SfSutshLo0fZkZeqAgCruRZmAn4uA==",
+      "requires": {
+        "@contentful/assemblies-management-api-contract": "3.75.0",
+        "@contentful/assemblies-types": "3.68.0",
+        "@contentful/bulk-actions": "0.9.0",
+        "@contentful/content-internal-api-contract": "3.62.0",
+        "@contentful/experiences-api-schemas": "4.99.0",
+        "@contentful/query-to-constraints": "3.55.0",
+        "@contentful/service-kit": "6.10.0",
+        "@contentful/view-delivery-contract": "3.108.0",
+        "zod": "4.4.3"
+      }
+    },
+    "@contentful/http-client": {
+      "version": "6.16.19",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/http-client/6.16.19/fd578c225956db1bb1c67b0433e7b67bc85c0419",
+      "integrity": "sha512-8ZUtniGEYkRFLoN4N9J40/VocXHaFTImQqRHyV3GEO+OAMk6H3T/7F5lx9aXH/hZFX5+6Euv61xrvUgKJUOquA==",
+      "requires": {
+        "@types/sinon": "^21.0.0",
+        "concat-stream": "^2.0.0",
+        "got": "^11.5.1",
+        "promise-retry": "^2.0.1",
+        "type-fest": "^4.0.0"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "4.41.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+          "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="
+        }
+      }
+    },
+    "@contentful/mimetype": {
+      "version": "2.6.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/mimetype/2.6.5/b4f7001ad66096a2c13b0eea62642e98e914cc98",
+      "integrity": "sha512-Raf+xYKctjzrA5/reT51AUjCpYgVKV2C20fj9l+5LrT4rx+jwp9hlhsUK2jvCN5j1t9fqgd/Q6qGMv/qBexHbQ==",
+      "requires": {
+        "lodash": "^4.18.1"
+      }
+    },
+    "@contentful/personalization-api-contract": {
+      "version": "1.49.0",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/personalization-api-contract/1.49.0/51d3145b3857f37bddaa1e46e96563d7a8afe346",
+      "integrity": "sha512-J5EDisj/1VNyIgNvDvLXceTQgqKX4htrEZ40pLhTzklFVZu7nBLu3XlYqcDCQgHzdfMuSfV1yKBUJVVsCmzh+Q==",
+      "requires": {
+        "@contentful/service-kit": "6.10.0",
+        "zod": "4.4.3"
+      }
+    },
+    "@contentful/pointer-syntax": {
+      "version": "0.39.0",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/pointer-syntax/0.39.0/14872fededcba23d9ba376259a0ebfd467e55f61",
+      "integrity": "sha512-my/ipqspPoz1jpLNtqDgZwmyrp7FdRBw+1tiSfascqbsFRPeVnIIKJjKsUpEgWPG1VF5YQPM0Dg4P3rHVxnakg==",
+      "requires": {
+        "@contentful/data-type": "0.41.0",
+        "zod": "4.4.3"
+      }
+    },
+    "@contentful/query-to-constraints": {
+      "version": "3.55.0",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/query-to-constraints/3.55.0/a0efd2576a6b8e5674d2a33f9863190fcf8bf2fd",
+      "integrity": "sha512-eJ93Hb/PBGbGbAf0QKkWJtoTfd2ZAms0ehJrjCi3Kf2/TnCb1Bf4iiMzf51l4Bn9uw3AVOjrX+G5ZW3kXUHMTA==",
+      "requires": {
+        "@contentful/spock": "^5.5.0",
+        "zod": "4.4.3"
+      }
+    },
+    "@contentful/resource-names": {
+      "version": "1.9.2",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/resource-names/1.9.2/950742d04fa70fc97b1fe443726d5ad37640b80b",
+      "integrity": "sha512-DnFA9gBT+GmFHKqNH18CteBIZKs1Gd2cnbSVM2V71th9c+DWQAKiHM1N+vWzQ2lmx0KTICdcwjnPpBY7zmRzBg=="
+    },
     "@contentful/rich-text-types": {
       "version": "16.8.3",
       "resolved": "https://registry.npmjs.org/@contentful/rich-text-types/-/rich-text-types-16.8.3.tgz",
       "integrity": "sha512-vXwXDQMDbqITCWfTkU5R/q+uvXWCc1eYNvdZyjtrs0YDIYr4L7QJ2s1r4ZheIs3iVf3AFucKIHgDSpwCAm2wKA=="
     },
+    "@contentful/service-kit": {
+      "version": "6.10.0",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/service-kit/6.10.0/00569dea72ea2bef5ab3194b7441a8dab2b4227a",
+      "integrity": "sha512-gkh+SE1dS/O8jvzDh7HdHqZstYNf7aPgj0nDfDPRutziGBMxiMlv/MqrGdxQzi8UtB5Z+jhX39m9He1OYixTjw==",
+      "requires": {
+        "@contentful/authorization-policy-service-client": "^10.13.6",
+        "@contentful/aws-message-patterns-sns-producer": "^1.3.30",
+        "@contentful/errors": "4.14.11",
+        "@hono/node-server": "1.19.14",
+        "@launchdarkly/openfeature-node-server": "^1.2.0",
+        "@openfeature/server-sdk": "^1.21.0",
+        "@opentelemetry/api": "^1.9.1",
+        "@ts-rest/core": "3.53.0-rc.1",
+        "@ts-rest/open-api": "3.53.0-rc.1",
+        "@ts-rest/react-query": "3.53.0-rc.1",
+        "dd-trace": "5.96.0",
+        "get-port-please": "^3.2.0",
+        "hono": "4.12.18",
+        "klona": "^2.0.6",
+        "openapi3-ts": "^2.0.2",
+        "pino": "10.3.1",
+        "pino-pretty": "^13.1.3",
+        "type-fest": "5.7.0",
+        "zod": "4.4.3"
+      },
+      "dependencies": {
+        "@ts-rest/core": {
+          "version": "3.53.0-rc.1",
+          "resolved": "https://registry.npmjs.org/@ts-rest/core/-/core-3.53.0-rc.1.tgz",
+          "integrity": "sha512-hDMXqKHSys6w+kXFW1Q6EvN8QgRvtXKXJ2TpYByKI4TquaPjiTOv99aLD26X4LNRzdna8Ci1PVyzr0jYZv0oNQ==",
+          "requires": {}
+        },
+        "@ts-rest/open-api": {
+          "version": "3.53.0-rc.1",
+          "resolved": "https://registry.npmjs.org/@ts-rest/open-api/-/open-api-3.53.0-rc.1.tgz",
+          "integrity": "sha512-JqmmdwFP2AHlyK9T4dwgsFL3QGNRppV9JIBh0G9mbJE7m7Kj403VsxJZ5X128E3XqwH7JIgJ4wsyGRX4Zbtqvw==",
+          "requires": {
+            "@anatine/zod-openapi": "^1.12.0",
+            "openapi3-ts": "^2.0.2"
+          },
+          "dependencies": {
+            "@anatine/zod-openapi": {
+              "version": "1.14.2",
+              "resolved": "https://registry.npmjs.org/@anatine/zod-openapi/-/zod-openapi-1.14.2.tgz",
+              "integrity": "sha512-q0qHfnuNYVKu0Swrnnvfj9971AEyW7c8v9jCOZGCl5ZbyGMNG4RPyJkRcMi/JC8CRfdOe0IDfNm1nNsi2avprg==",
+              "requires": {
+                "ts-deepmerge": "^6.0.3"
+              }
+            }
+          }
+        },
+        "@ts-rest/react-query": {
+          "version": "3.53.0-rc.1",
+          "resolved": "https://registry.npmjs.org/@ts-rest/react-query/-/react-query-3.53.0-rc.1.tgz",
+          "integrity": "sha512-wqn29MGKFhQWQsQatVH/vsBA/+faXKTXlgsR7hwbwpwABUcebuuj7JwZttxZoGWQqjNJJH+rsOQ6BQDhhyfuoQ==",
+          "requires": {}
+        },
+        "type-fest": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.7.0.tgz",
+          "integrity": "sha512-1URUxUqfHFM1c+zfSPsa3gnkO7Aq21qyH75SIduNYz4SzY964rn1X2vCMQaHSHhktiw+0kPa2iyb6PUpXqB6Vg==",
+          "requires": {
+            "tagged-tag": "^1.0.0"
+          }
+        }
+      }
+    },
+    "@contentful/spock": {
+      "version": "5.5.0",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/spock/5.5.0/544208e5cb5af942dc5e2eff833748285266e38d",
+      "integrity": "sha512-Cn30mGPm34KEfB04j0yvcebDc1s6kod9HH6vhbHQt3yvDy5LxEs2q/Kuhg4pSNxTpvpSeoLFr3PEmhmwkfoziA==",
+      "requires": {
+        "lodash": "^4.17.21",
+        "safe-regex": "^2.1.1"
+      }
+    },
+    "@contentful/uuid": {
+      "version": "2.4.11",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/uuid/2.4.11/9e7254441498e539c7d213aaddc7b6c383a7d9c1",
+      "integrity": "sha512-j4J5jY7l6/4CiOWqGnPSwMlkMvIvDSHys2SFbTzdFt1coLug7G3zUjvv4p1lMtUtZubEnvfuBNdUbi+rdZc4IA==",
+      "requires": {
+        "base-x": "^4.0.1",
+        "uuid": "^11.1.0"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "11.1.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+          "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ=="
+        }
+      }
+    },
+    "@contentful/view-delivery-contract": {
+      "version": "3.108.0",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/view-delivery-contract/3.108.0/abdc54137d78d32c54763bc1faf3c1f956391978",
+      "integrity": "sha512-Y9j0f4FfZDz98bKVuWDRes1Wt/c2gPjMfkTJ8vivoTbMXCZaEz1FuYh++p2dr+eTZ9Rb+emKzy7sglJkpOUSvg==",
+      "requires": {
+        "@contentful/assemblies-types": "3.68.0",
+        "@contentful/experiences-api-schemas": "4.99.0",
+        "@contentful/personalization-api-contract": "1.49.0",
+        "@contentful/service-kit": "6.10.0",
+        "zod": "4.4.3"
+      }
+    },
+    "@datadog/flagging-core": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@datadog/flagging-core/-/flagging-core-1.2.1.tgz",
+      "integrity": "sha512-qeDkki9fFlqyoZBrn7tneT6pZ04EKKvf3xxisYw1a74zbJihvQui/ARUsjXCurRpzpFqGGTJw/oz+HnXaKhcdw==",
+      "optional": true,
+      "requires": {
+        "spark-md5": "^3.0.2"
+      }
+    },
+    "@datadog/libdatadog": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@datadog/libdatadog/-/libdatadog-0.9.2.tgz",
+      "integrity": "sha512-grOerTYuU3wHuFIOBGg3jB144A3KEthEdVEL3meeiXYo7E7fBXXGRgAOwVE42VXFXfl0r8kDKCL7KupBc511tg==",
+      "optional": true
+    },
+    "@datadog/native-appsec": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@datadog/native-appsec/-/native-appsec-11.0.1.tgz",
+      "integrity": "sha512-Y/XfknUmmJcw4hhQVhqzgdQvfjy+EGmXuUBgtVkI1r+/qS00egYu+wD/x7pOvjdbZNqN96znVszAnXvDQAzMDQ==",
+      "optional": true,
+      "requires": {
+        "node-gyp-build": "^3.9.0"
+      }
+    },
+    "@datadog/native-iast-taint-tracking": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@datadog/native-iast-taint-tracking/-/native-iast-taint-tracking-4.1.0.tgz",
+      "integrity": "sha512-g9K9Ddx1YQfrQIC2hgtfnYUGuzAFvSvhvt2lPZOAWBPo+bkYoW5KEkMHoY5XykCigTfXBYcQicRV0xB22AMkHw==",
+      "optional": true,
+      "requires": {
+        "node-gyp-build": "^3.9.0"
+      }
+    },
+    "@datadog/native-metrics": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@datadog/native-metrics/-/native-metrics-3.1.1.tgz",
+      "integrity": "sha512-MU1gHrolwryrU4X9g+fylA1KPH3S46oqJPEtVyrO+3Kh29z80fegmtyrU22bNt8LigPUK/EdPCnSbMe88QbnxQ==",
+      "optional": true,
+      "requires": {
+        "node-addon-api": "^6.1.0",
+        "node-gyp-build": "^3.9.0"
+      }
+    },
+    "@datadog/openfeature-node-server": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@datadog/openfeature-node-server/-/openfeature-node-server-1.2.1.tgz",
+      "integrity": "sha512-iY32juuL2w07vOlrTG1Y1U0y3ehyvRxuwzJvaLqjmQE8jj2L3o2SRm2UwgmLnzh6JWzMfNxbfs66KvOmPja7dQ==",
+      "optional": true,
+      "requires": {
+        "@datadog/flagging-core": "^1.2.1"
+      }
+    },
+    "@datadog/pprof": {
+      "version": "5.14.1",
+      "resolved": "https://registry.npmjs.org/@datadog/pprof/-/pprof-5.14.1.tgz",
+      "integrity": "sha512-MlODCE9Gltmx7WChOg1BkIm7W2iE4CDW7K72BMwgzCvxFkG9rFWVsuA7/NEZL1nDvJ0qDe2du7DZZdZHTjcVPw==",
+      "optional": true,
+      "requires": {
+        "node-gyp-build": "<4.0",
+        "pprof-format": "^2.2.1",
+        "source-map": "^0.7.4"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.7.6",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+          "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+          "optional": true
+        }
+      }
+    },
+    "@datadog/wasm-js-rewriter": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@datadog/wasm-js-rewriter/-/wasm-js-rewriter-5.0.1.tgz",
+      "integrity": "sha512-EzbV3Lrdt3udQEsbDOVC5gB1y7yxfpBbrSIk4jaEsGjyj0Dbv2HGj7tZjs+qXzIzNonHc8h5El2bYZOGfC2wwg==",
+      "optional": true,
+      "requires": {
+        "js-yaml": "^4.1.0",
+        "lru-cache": "^7.14.0",
+        "module-details-from-path": "^1.0.3",
+        "node-gyp-build": "^4.5.0"
+      },
+      "dependencies": {
+        "argparse": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+          "optional": true
+        },
+        "js-yaml": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+          "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+          "optional": true,
+          "requires": {
+            "argparse": "^2.0.1"
+          }
+        },
+        "lru-cache": {
+          "version": "7.18.3",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+          "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+          "optional": true
+        },
+        "node-gyp-build": {
+          "version": "4.8.4",
+          "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+          "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+          "optional": true
+        }
+      }
+    },
     "@discoveryjs/json-ext": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.6.3.tgz",
       "integrity": "sha512-4B4OijXeVNOPZlYA2oEwWOTkzyltLao+xbotHQeqN++Rv27Y6s818+n2Qkp8q+Fxhn0t/5lA5X1Mxktud8eayQ=="
+    },
+    "@emnapi/core": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
+      "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
+      "optional": true,
+      "peer": true,
+      "requires": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "@emnapi/runtime": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
+      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+      "optional": true,
+      "peer": true,
+      "requires": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "optional": true,
+      "peer": true,
+      "requires": {
+        "tslib": "^2.4.0"
+      }
     },
     "@endemolshinegroup/cosmiconfig-typescript-loader": {
       "version": "3.0.2",
@@ -17651,6 +20793,12 @@
       "requires": {
         "@hapi/hoek": "^11.0.2"
       }
+    },
+    "@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "requires": {}
     },
     "@humanwhocodes/config-array": {
       "version": "0.13.0",
@@ -18184,6 +21332,68 @@
         "@jridgewell/sourcemap-codec": "1.4.14"
       }
     },
+    "@launchdarkly/js-sdk-common": {
+      "version": "2.25.1",
+      "resolved": "https://registry.npmjs.org/@launchdarkly/js-sdk-common/-/js-sdk-common-2.25.1.tgz",
+      "integrity": "sha512-erG2RbA8QQMKW+D9Y7Uahez1dU+TzmyTzv9qlB7b0Pr/DS2SmUg5H8pJbkLcRrSxoshczZdB1UqsuE3RAk7UYQ=="
+    },
+    "@launchdarkly/js-server-sdk-common": {
+      "version": "2.19.2",
+      "resolved": "https://registry.npmjs.org/@launchdarkly/js-server-sdk-common/-/js-server-sdk-common-2.19.2.tgz",
+      "integrity": "sha512-SZApHxn0PqYyRFfXtrJKQAGx6tlLD2sV0XvqOUkUdey1lKeObOL4hIw+70gQ3jrRAIvEH+SBC0uqlJ7uGlrRyA==",
+      "peer": true,
+      "requires": {
+        "@launchdarkly/js-sdk-common": "2.25.1",
+        "semver": "7.5.4"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "7.5.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+          "peer": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
+      }
+    },
+    "@launchdarkly/node-server-sdk": {
+      "version": "9.12.0",
+      "resolved": "https://registry.npmjs.org/@launchdarkly/node-server-sdk/-/node-server-sdk-9.12.0.tgz",
+      "integrity": "sha512-tbiRBnEln0Bvf0ZkukElGoGEVhB8A3kwnC7QRa9HzHA0gvpnYnL+JjoDWAIL0+EMLlEpFl7EJMwCfi/488yHZQ==",
+      "peer": true,
+      "requires": {
+        "@launchdarkly/js-server-sdk-common": "2.19.2",
+        "https-proxy-agent": "^7.0.6",
+        "launchdarkly-eventsource": "2.2.0"
+      }
+    },
+    "@launchdarkly/openfeature-js-server-common": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@launchdarkly/openfeature-js-server-common/-/openfeature-js-server-common-1.0.0.tgz",
+      "integrity": "sha512-aCJUn4d/pkjCICqzQVXlL3Q4d3OvZmt7dgOya9aawXxZv8G5ooedkFNjEecmsWhScjORLHzTU0UdaNDwP6XhFA==",
+      "requires": {
+        "@launchdarkly/js-sdk-common": "2.25.1"
+      }
+    },
+    "@launchdarkly/openfeature-node-server": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@launchdarkly/openfeature-node-server/-/openfeature-node-server-1.3.2.tgz",
+      "integrity": "sha512-Y4K9U2aZimup3IIL68s/j3swcJUFfBVBVZCF/UIVal5nrTDtTEAiEQjMaI3Knxu6/rQyXvyIUpMhWPyXlUOx/Q==",
+      "requires": {
+        "@launchdarkly/openfeature-js-server-common": "1.0.0"
+      }
+    },
+    "@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "optional": true,
+      "requires": {
+        "@tybys/wasm-util": "^0.10.3"
+      }
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "dev": true,
@@ -18312,6 +21522,166 @@
       "requires": {
         "@octokit/openapi-types": "^26.0.0"
       }
+    },
+    "@openfeature/core": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@openfeature/core/-/core-1.11.0.tgz",
+      "integrity": "sha512-P0u3/ht/oZCQT89fOed+laLk0kZR529a825cS02uPDglxXbE97irWYpDAeRGGVETIzKfuy+H2g8c3Ccv/tXJNQ==",
+      "peer": true
+    },
+    "@openfeature/server-sdk": {
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@openfeature/server-sdk/-/server-sdk-1.22.0.tgz",
+      "integrity": "sha512-YBrf6SQkn0FNB/dRAtLEs41dvFMUE8CrQTwI+iLaMFUIqWlqGNJfGnulKSneEKS+2OgKTAC6DdmKcZ6tK7kBcg==",
+      "requires": {}
+    },
+    "@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="
+    },
+    "@opentelemetry/api-logs": {
+      "version": "0.220.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.220.0.tgz",
+      "integrity": "sha512-CmVa4ImJ+ynfrPMNaAXHET6Bhb44SwzmfyVJFq9ni2jgXJR/l7C6gfVFddNmHP+ZOkP9cf4f9DBe68qVLTHc9w==",
+      "optional": true,
+      "requires": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "@oxc-parser/binding-android-arm-eabi": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm-eabi/-/binding-android-arm-eabi-0.121.0.tgz",
+      "integrity": "sha512-n07FQcySwOlzap424/PLMtOkbS7xOu8nsJduKL8P3COGHKgKoDYXwoAHCbChfgFpHnviehrLWIPX0lKGtbEk/A==",
+      "optional": true
+    },
+    "@oxc-parser/binding-android-arm64": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.121.0.tgz",
+      "integrity": "sha512-/Dd1xIXboYAicw+twT2utxPD7bL8qh7d3ej0qvaYIMj3/EgIrGR+tSnjCUkiCT6g6uTC0neSS4JY8LxhdSU/sA==",
+      "optional": true
+    },
+    "@oxc-parser/binding-darwin-arm64": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.121.0.tgz",
+      "integrity": "sha512-A0jNEvv7QMtCO1yk205t3DWU9sWUjQ2KNF0hSVO5W9R9r/R1BIvzG01UQAfmtC0dQm7sCrs5puixurKSfr2bRQ==",
+      "optional": true
+    },
+    "@oxc-parser/binding-darwin-x64": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.121.0.tgz",
+      "integrity": "sha512-SsHzipdxTKUs3I9EOAPmnIimEeJOemqRlRDOp9LIj+96wtxZejF51gNibmoGq8KoqbT1ssAI5po/E3J+vEtXGA==",
+      "optional": true
+    },
+    "@oxc-parser/binding-freebsd-x64": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.121.0.tgz",
+      "integrity": "sha512-v1APOTkCp+RWOIDAHRoaeW/UoaHF15a60E8eUL6kUQXh+i4K7PBwq2Wi7jm8p0ymID5/m/oC1w3W31Z/+r7HQw==",
+      "optional": true
+    },
+    "@oxc-parser/binding-linux-arm-gnueabihf": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.121.0.tgz",
+      "integrity": "sha512-PmqPQuqHZyFVWA4ycr0eu4VnTMmq9laOHZd+8R359w6kzuNZPvmmunmNJ8ybkm769A0nCoVp3TJ6dUz7B3FYIQ==",
+      "optional": true
+    },
+    "@oxc-parser/binding-linux-arm-musleabihf": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.121.0.tgz",
+      "integrity": "sha512-vF24htj+MOH+Q7y9A8NuC6pUZu8t/C2Fr/kDOi2OcNf28oogr2xadBPXAbml802E8wRAVfbta6YLDQTearz+jw==",
+      "optional": true
+    },
+    "@oxc-parser/binding-linux-arm64-gnu": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.121.0.tgz",
+      "integrity": "sha512-wjH8cIG2Lu/3d64iZpbYr73hREMgKAfu7fqpXjgM2S16y2zhTfDIp8EQjxO8vlDtKP5Rc7waZW72lh8nZtWrpA==",
+      "optional": true
+    },
+    "@oxc-parser/binding-linux-arm64-musl": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.121.0.tgz",
+      "integrity": "sha512-qT663J/W8yQFw3dtscbEi9LKJevr20V7uWs2MPGTnvNZ3rm8anhhE16gXGpxDOHeg9raySaSHKhd4IGa3YZvuw==",
+      "optional": true
+    },
+    "@oxc-parser/binding-linux-ppc64-gnu": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.121.0.tgz",
+      "integrity": "sha512-mYNe4NhVvDBbPkAP8JaVS8lC1dsoJZWH5WCjpw5E+sjhk1R08wt3NnXYUzum7tIiWPfgQxbCMcoxgeemFASbRw==",
+      "optional": true
+    },
+    "@oxc-parser/binding-linux-riscv64-gnu": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.121.0.tgz",
+      "integrity": "sha512-+QiFoGxhAbaI/amqX567784cDyyuZIpinBrJNxUzb+/L2aBRX67mN6Jv40pqduHf15yYByI+K5gUEygCuv0z9w==",
+      "optional": true
+    },
+    "@oxc-parser/binding-linux-riscv64-musl": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.121.0.tgz",
+      "integrity": "sha512-9ykEgyTa5JD/Uhv2sttbKnCfl2PieUfOjyxJC/oDL2UO0qtXOtjPLl7H8Kaj5G7p3hIvFgu3YWvAxvE0sqY+hQ==",
+      "optional": true
+    },
+    "@oxc-parser/binding-linux-s390x-gnu": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.121.0.tgz",
+      "integrity": "sha512-DB1EW5VHZdc1lIRjOI3bW/wV6R6y0xlfvdVrqj6kKi7Ayu2U3UqUBdq9KviVkcUGd5Oq+dROqvUEEFRXGAM7EQ==",
+      "optional": true
+    },
+    "@oxc-parser/binding-linux-x64-gnu": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.121.0.tgz",
+      "integrity": "sha512-s4lfobX9p4kPTclvMiH3gcQUd88VlnkMTF6n2MTMDAyX5FPNRhhRSFZK05Ykhf8Zy5NibV4PbGR6DnK7FGNN6A==",
+      "optional": true
+    },
+    "@oxc-parser/binding-linux-x64-musl": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.121.0.tgz",
+      "integrity": "sha512-P9KlyTpuBuMi3NRGpJO8MicuGZfOoqZVRP1WjOecwx8yk4L/+mrCRNc5egSi0byhuReblBF2oVoDSMgV9Bj4Hw==",
+      "optional": true
+    },
+    "@oxc-parser/binding-openharmony-arm64": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-openharmony-arm64/-/binding-openharmony-arm64-0.121.0.tgz",
+      "integrity": "sha512-R+4jrWOfF2OAPPhj3Eb3U5CaKNAH9/btMveMULIrcNW/hjfysFQlF8wE0GaVBr81dWz8JLgQlsxwctoL78JwXw==",
+      "optional": true
+    },
+    "@oxc-parser/binding-wasm32-wasi": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-wasm32-wasi/-/binding-wasm32-wasi-0.121.0.tgz",
+      "integrity": "sha512-5TFISkPTymKvsmIlKasPVTPuWxzCcrT8pM+p77+mtQbIZDd1UC8zww4CJcRI46kolmgrEX6QpKO8AvWMVZ+ifw==",
+      "optional": true,
+      "requires": {
+        "@napi-rs/wasm-runtime": "^1.1.1"
+      }
+    },
+    "@oxc-parser/binding-win32-arm64-msvc": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.121.0.tgz",
+      "integrity": "sha512-V0pxh4mql4XTt3aiEtRNUeBAUFOw5jzZNxPABLaOKAWrVzSr9+XUaB095lY7jqMf5t8vkfh8NManGB28zanYKw==",
+      "optional": true
+    },
+    "@oxc-parser/binding-win32-ia32-msvc": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.121.0.tgz",
+      "integrity": "sha512-4Ob1qvYMPnlF2N9rdmKdkQFdrq16QVcQwBsO8yiPZXof0fHKFF+LmQV501XFbi7lHyrKm8rlJRfQ/M8bZZPVLw==",
+      "optional": true
+    },
+    "@oxc-parser/binding-win32-x64-msvc": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.121.0.tgz",
+      "integrity": "sha512-BOp1KCzdboB1tPqoCPXgntgFs0jjeSyOXHzgxVFR7B/qfr3F8r4YDacHkTOUNXtDgM8YwKnkf3rE5gwALYX7NA==",
+      "optional": true
+    },
+    "@oxc-project/types": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.121.0.tgz",
+      "integrity": "sha512-CGtOARQb9tyv7ECgdAlFxi0Fv7lmzvmlm2rpD/RdijOO9rfk/JvB1CjT8EnoD+tjna/IYgKKw3IV7objRb+aYw==",
+      "optional": true
+    },
+    "@pinojs/redact": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
+      "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg=="
     },
     "@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -18801,8 +22171,7 @@
     "@sindresorhus/is": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
-      "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
-      "dev": true
+      "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw=="
     },
     "@sindresorhus/merge-streams": {
       "version": "4.0.0",
@@ -18824,10 +22193,100 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
+    "@smithy/core": {
+      "version": "3.29.2",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.29.2.tgz",
+      "integrity": "sha512-DXUk6yU0C1Q1tYvJh1VCtl8QOBcSoZpKwjTPkxT6A4MUQYHvgeKGByL8mrEdxnvhdf9nq5GyzmRb5n/vPgu3Lw==",
+      "requires": {
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/credential-provider-imds": {
+      "version": "4.4.7",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.7.tgz",
+      "integrity": "sha512-UEMLOoA0Fl4uYBxh6l0uN0H6EJe/A89OGeDNTteQeXpJ20BcpfIr4wlCY9pel1jEAUHAxaYwuqrYlrKdXE1GKQ==",
+      "requires": {
+        "@smithy/core": "^3.29.2",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/fetch-http-handler": {
+      "version": "5.6.4",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.4.tgz",
+      "integrity": "sha512-psnst7NZWdAEvJvyW8YZEE7xNVMyLrQFfHtyrVFrxNyy+dKWkQ+rqC6oI5ZhxThpUy9RSfEshgm34zqbOxzsRw==",
+      "requires": {
+        "@smithy/core": "^3.29.2",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/node-http-handler": {
+      "version": "4.9.4",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.4.tgz",
+      "integrity": "sha512-BNTop/fSOptmoVk8g+efwHCofFh37g70OWGAFES1TeAAJja1K5aAI8rTE26ETSc5k8IQuWY2kAIoPla01NgYrA==",
+      "requires": {
+        "@smithy/core": "^3.29.2",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/signature-v4": {
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.3.tgz",
+      "integrity": "sha512-8qVKKzqh7naF27ePmx0SkUfnGP/wBI9dyaeAmhHvopnbIlItUAmB/e6PkPCU3rRb2v9BY8D4EZXSoydSibatvw==",
+      "requires": {
+        "@smithy/core": "^3.29.2",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/types": {
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.16.0.tgz",
+      "integrity": "sha512-aVUabzlBBmY0PfvVgLKQSOGFIL5/7R54JE3uD9a5Ay/jSED61SkuAcCYENNXJzYUvJ1NPrWO0P+rAXHCkbBUKw==",
+      "requires": {
+        "tslib": "^2.6.2"
+      }
+    },
     "@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="
+    },
+    "@szmarczak/http-timer": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
+      "integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
+      "requires": {
+        "defer-to-connect": "^2.0.0"
+      }
+    },
+    "@tanstack/query-core": {
+      "version": "4.44.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-4.44.0.tgz",
+      "integrity": "sha512-swSgb7OiPRR3UuIL7NuDrZNSMGmQD+wdtHxPD7j60SvBEnxbXurl5XOirtGEX2gm2hbK6mC8kMV1I+uO3l0UOw==",
+      "peer": true
+    },
+    "@tanstack/react-query": {
+      "version": "4.44.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-4.44.0.tgz",
+      "integrity": "sha512-RuIqHYrS98LrK/8kJJOJMMSQ/BCpojwsXDh7p0fBmp38ZOz6dlk+uyFRRusH+V+t3POoCsDOQ2zhomEYOeReXw==",
+      "peer": true,
+      "requires": {
+        "@tanstack/query-core": "4.44.0",
+        "use-sync-external-store": "^1.6.0"
+      }
+    },
+    "@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "optional": true,
+      "requires": {
+        "tslib": "^2.4.0"
+      }
     },
     "@types/babel__core": {
       "version": "7.20.1",
@@ -18862,6 +22321,17 @@
         "@babel/types": "^7.20.7"
       }
     },
+    "@types/cacheable-request": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
+      "integrity": "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==",
+      "requires": {
+        "@types/http-cache-semantics": "*",
+        "@types/keyv": "^3.1.4",
+        "@types/node": "*",
+        "@types/responselike": "^1.0.0"
+      }
+    },
     "@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -18874,6 +22344,11 @@
       "requires": {
         "@types/node": "*"
       }
+    },
+    "@types/http-cache-semantics": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q=="
     },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.3",
@@ -18909,6 +22384,14 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
     },
+    "@types/keyv": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
+      "integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/lodash": {
       "version": "4.17.24",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.24.tgz",
@@ -18916,8 +22399,7 @@
       "dev": true
     },
     "@types/node": {
-      "version": "20.6.3",
-      "dev": true
+      "version": "20.6.3"
     },
     "@types/normalize-package-data": {
       "version": "2.4.4",
@@ -18929,6 +22411,27 @@
       "version": "4.0.0",
       "dev": true,
       "optional": true
+    },
+    "@types/responselike": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
+      "integrity": "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/sinon": {
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-21.0.1.tgz",
+      "integrity": "sha512-5yoJSqLbjH8T9V2bksgRayuhpZy+723/z6wBOR+Soe4ZlXC0eW8Na71TeaZPUWDQvM7LYKa9UGFc6LRqxiR5fQ==",
+      "requires": {
+        "@types/sinonjs__fake-timers": "*"
+      }
+    },
+    "@types/sinonjs__fake-timers": {
+      "version": "15.0.1",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-15.0.1.tgz",
+      "integrity": "sha512-Ko2tjWJq8oozHzHV+reuvS5KYIRAokHnGbDwGh/J64LntgpbuylF74ipEL24HCyRjf9FOlBiBHWBR1RlVKsI1w=="
     },
     "@types/stack-utils": {
       "version": "2.0.1",
@@ -19095,12 +22598,9 @@
       "requires": {}
     },
     "agent-base": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
-      "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
-      "requires": {
-        "debug": "^4.3.4"
-      }
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="
     },
     "aggregate-error": {
       "version": "5.0.0",
@@ -19288,6 +22788,11 @@
       "version": "1.0.0",
       "dev": true
     },
+    "atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ=="
+    },
     "available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -19410,6 +22915,11 @@
       "version": "1.0.2",
       "dev": true
     },
+    "base-x": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.1.tgz",
+      "integrity": "sha512-uAZ8x6r6S3aUM9rbHGVOIsR15U/ZSc82b3ymnCPsT45Gk1DDvhDPdIgB5MrhirZWt+5K0EEPQH985kNqZgNPFw=="
+    },
     "base64-js": {
       "version": "1.5.1",
       "dev": true
@@ -19448,6 +22958,11 @@
       "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
       "integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==",
       "dev": true
+    },
+    "bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg=="
     },
     "brace-expansion": {
       "version": "1.1.12",
@@ -19501,8 +23016,7 @@
       }
     },
     "buffer-from": {
-      "version": "1.1.2",
-      "dev": true
+      "version": "1.1.2"
     },
     "builtin-modules": {
       "version": "3.3.0",
@@ -19538,6 +23052,40 @@
     "cac": {
       "version": "6.7.14",
       "dev": true
+    },
+    "cacheable-lookup": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
+      "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA=="
+    },
+    "cacheable-request": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.4.tgz",
+      "integrity": "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==",
+      "requires": {
+        "clone-response": "^1.0.2",
+        "get-stream": "^5.1.0",
+        "http-cache-semantics": "^4.0.0",
+        "keyv": "^4.0.0",
+        "lowercase-keys": "^2.0.0",
+        "normalize-url": "^6.0.1",
+        "responselike": "^2.0.0"
+      },
+      "dependencies": {
+        "get-stream": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+          "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
+        "normalize-url": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
+          "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A=="
+        }
+      }
     },
     "cachedir": {
       "version": "2.3.0",
@@ -19822,6 +23370,14 @@
       "version": "1.0.4",
       "dev": true
     },
+    "clone-response": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
+      "integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
+      "requires": {
+        "mimic-response": "^1.0.0"
+      }
+    },
     "co": {
       "version": "4.6.0",
       "dev": true
@@ -19841,6 +23397,12 @@
     },
     "color-name": {
       "version": "1.1.3"
+    },
+    "colorette": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+      "optional": true
     },
     "combined-stream": {
       "version": "1.0.8",
@@ -19897,6 +23459,29 @@
     "concat-map": {
       "version": "0.0.1",
       "dev": true
+    },
+    "concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.2",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+          "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
     },
     "confbox": {
       "version": "0.1.8",
@@ -20109,6 +23694,11 @@
         "which": "^2.0.1"
       }
     },
+    "crypto-js": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q=="
+    },
     "crypto-random-string": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-4.0.0.tgz",
@@ -20178,12 +23768,57 @@
         "@babel/runtime": "^7.21.0"
       }
     },
+    "dateformat": {
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
+      "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==",
+      "optional": true
+    },
+    "dc-polyfill": {
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/dc-polyfill/-/dc-polyfill-0.1.11.tgz",
+      "integrity": "sha512-TyyeGcjx0YeThAI9fTFtgsvj5qd4R+aGfVmXiUhevbgzWFDr7IK4tv4YjE6jaGzLHQTchk4h7DHdr5q4WGgaZw=="
+    },
+    "dd-trace": {
+      "version": "5.96.0",
+      "resolved": "https://registry.npmjs.org/dd-trace/-/dd-trace-5.96.0.tgz",
+      "integrity": "sha512-L6GeXM86dMR/tK5AgweMR5hJDtW+Nm0WQXe79Ff/j+dogChGdDZ/oP4ohQ26ZKni6xv5Ci4SAcAMoqprSHE4Pw==",
+      "requires": {
+        "@datadog/libdatadog": "0.9.2",
+        "@datadog/native-appsec": "11.0.1",
+        "@datadog/native-iast-taint-tracking": "4.1.0",
+        "@datadog/native-metrics": "3.1.1",
+        "@datadog/openfeature-node-server": "^1.1.1",
+        "@datadog/pprof": "5.14.1",
+        "@datadog/wasm-js-rewriter": "5.0.1",
+        "@opentelemetry/api": ">=1.0.0 <1.10.0",
+        "@opentelemetry/api-logs": "<1.0.0",
+        "dc-polyfill": "^0.1.10",
+        "import-in-the-middle": "^3.0.1",
+        "oxc-parser": "^0.121.0"
+      }
+    },
     "debug": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
       "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
       "requires": {
         "ms": "^2.1.3"
+      }
+    },
+    "decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "requires": {
+        "mimic-response": "^3.1.0"
+      },
+      "dependencies": {
+        "mimic-response": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+          "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ=="
+        }
       }
     },
     "dedent": {
@@ -20210,6 +23845,11 @@
       "requires": {
         "clone": "^1.0.2"
       }
+    },
+    "defer-to-connect": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+      "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg=="
     },
     "define-data-property": {
       "version": "1.1.4",
@@ -20323,6 +23963,14 @@
       "integrity": "sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw==",
       "dev": true
     },
+    "end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "requires": {
+        "once": "^1.4.0"
+      }
+    },
     "env-ci": {
       "version": "11.2.0",
       "resolved": "https://registry.npmjs.org/env-ci/-/env-ci-11.2.0.tgz",
@@ -20424,6 +24072,11 @@
       "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
       "dev": true
     },
+    "err-code": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
+      "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA=="
+    },
     "error-ex": {
       "version": "1.3.2",
       "dev": true,
@@ -20502,6 +24155,11 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="
+    },
+    "es-module-lexer": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.0.tgz",
+      "integrity": "sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw=="
     },
     "es-object-atoms": {
       "version": "1.1.1",
@@ -21066,6 +24724,12 @@
       "version": "2.0.6",
       "dev": true
     },
+    "fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "optional": true
+    },
     "fastq": {
       "version": "1.13.0",
       "dev": true,
@@ -21318,6 +24982,11 @@
       "version": "0.1.0",
       "dev": true
     },
+    "get-port-please": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/get-port-please/-/get-port-please-3.2.0.tgz",
+      "integrity": "sha512-I9QVvBw5U/hw3RmWpYKRumUeaDgxTPd401x364rLmWBJcOQ753eov1eTgzDqRG9bqFIfDc7gfzcQEWrUri3o1A=="
+    },
     "get-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
@@ -21471,6 +25140,24 @@
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="
     },
+    "got": {
+      "version": "11.8.6",
+      "resolved": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
+      "integrity": "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==",
+      "requires": {
+        "@sindresorhus/is": "^4.0.0",
+        "@szmarczak/http-timer": "^4.0.5",
+        "@types/cacheable-request": "^6.0.1",
+        "@types/responselike": "^1.0.0",
+        "cacheable-lookup": "^5.0.3",
+        "cacheable-request": "^7.0.2",
+        "decompress-response": "^6.0.0",
+        "http2-wrapper": "^1.0.0-beta.5.2",
+        "lowercase-keys": "^2.0.0",
+        "p-cancelable": "^2.0.0",
+        "responselike": "^2.0.0"
+      }
+    },
     "graceful-fs": {
       "version": "4.2.10",
       "dev": true
@@ -21551,6 +25238,12 @@
         "function-bind": "^1.1.2"
       }
     },
+    "help-me": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/help-me/-/help-me-5.0.0.tgz",
+      "integrity": "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==",
+      "optional": true
+    },
     "highlight.js": {
       "version": "10.7.3",
       "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
@@ -21563,6 +25256,11 @@
       "requires": {
         "parse-passwd": "^1.0.0"
       }
+    },
+    "hono": {
+      "version": "4.12.18",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
+      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ=="
     },
     "hook-std": {
       "version": "4.0.0",
@@ -21591,6 +25289,11 @@
       "version": "2.0.2",
       "dev": true
     },
+    "http-cache-semantics": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ=="
+    },
     "http-proxy-agent": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
@@ -21601,12 +25304,21 @@
         "debug": "^4.3.4"
       }
     },
-    "https-proxy-agent": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.2.tgz",
-      "integrity": "sha512-NmLNjm6ucYwtcUmL7JQC1ZQ57LmHP4lT15FQ8D61nak1rO6DH+fz5qNK2Ap5UN4ZapYICE3/0KodcLYSPsPbaA==",
+    "http2-wrapper": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
+      "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
       "requires": {
-        "agent-base": "^7.0.2",
+        "quick-lru": "^5.1.1",
+        "resolve-alpn": "^1.0.0"
+      }
+    },
+    "https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "requires": {
+        "agent-base": "^7.1.2",
         "debug": "4"
       }
     },
@@ -21655,6 +25367,23 @@
         "import-meta-resolve": "^4.0.0"
       }
     },
+    "import-in-the-middle": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.3.1.tgz",
+      "integrity": "sha512-0rymlHSFLwZ0ixx8DaQkoIyZojJPY2a0K2nEYslhKJ6jIYO/m0IcCb7iQsFPmS7WmKwISZiIrv5Icstrw/CmqA==",
+      "requires": {
+        "cjs-module-lexer": "^2.2.0",
+        "es-module-lexer": "^2.2.0",
+        "module-details-from-path": "^1.0.4"
+      },
+      "dependencies": {
+        "cjs-module-lexer": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
+          "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ=="
+        }
+      }
+    },
     "import-local": {
       "version": "3.1.0",
       "dev": true,
@@ -21691,8 +25420,7 @@
       }
     },
     "inherits": {
-      "version": "2.0.4",
-      "dev": true
+      "version": "2.0.4"
     },
     "ini": {
       "version": "1.3.8",
@@ -23182,7 +26910,7 @@
     },
     "joycon": {
       "version": "3.1.1",
-      "dev": true
+      "devOptional": true
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -23201,6 +26929,11 @@
     "jsesc": {
       "version": "2.5.2",
       "dev": true
+    },
+    "json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="
     },
     "json-parse-better-errors": {
       "version": "1.0.2",
@@ -23232,9 +26965,28 @@
         "universalify": "^2.0.0"
       }
     },
+    "keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "requires": {
+        "json-buffer": "3.0.1"
+      }
+    },
     "kleur": {
       "version": "3.0.3",
       "dev": true
+    },
+    "klona": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/klona/-/klona-2.0.6.tgz",
+      "integrity": "sha512-dhG34DXATL5hSxJbIexCft8FChFXtmskoZYnoPWjXQuebWYCNkVeV3KkGegCK9CP1oswI/vQibS2GY7Em/sJJA=="
+    },
+    "launchdarkly-eventsource": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/launchdarkly-eventsource/-/launchdarkly-eventsource-2.2.0.tgz",
+      "integrity": "sha512-u38fYlLSq/m6oFz0MS1/76Sj2xzlYhTKZ+sf/vju6PA86PMc6fPlY5k8CdU79edLXjNwsvIQTDvDNy3llDqB8A==",
+      "peer": true
     },
     "leven": {
       "version": "3.1.0",
@@ -23519,9 +27271,13 @@
       "version": "2.0.1",
       "dev": true
     },
+    "lowercase-keys": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+      "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA=="
+    },
     "lru-cache": {
       "version": "6.0.0",
-      "dev": true,
       "requires": {
         "yallist": "^4.0.0"
       }
@@ -23656,6 +27412,11 @@
       "version": "2.1.0",
       "dev": true
     },
+    "mimic-response": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="
+    },
     "minimatch": {
       "version": "3.1.2",
       "dev": true,
@@ -23665,7 +27426,7 @@
     },
     "minimist": {
       "version": "1.2.6",
-      "dev": true
+      "devOptional": true
     },
     "minipass": {
       "version": "7.1.3",
@@ -23684,6 +27445,11 @@
         "pkg-types": "^1.3.0",
         "ufo": "^1.5.4"
       }
+    },
+    "module-details-from-path": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
+      "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w=="
     },
     "ms": {
       "version": "2.1.3",
@@ -23730,6 +27496,12 @@
         "shell-quote": "^1.4.1"
       }
     },
+    "node-addon-api": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-6.1.0.tgz",
+      "integrity": "sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==",
+      "optional": true
+    },
     "node-emoji": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-2.2.0.tgz",
@@ -23741,6 +27513,12 @@
         "emojilib": "^2.4.0",
         "skin-tone": "^2.0.0"
       }
+    },
+    "node-gyp-build": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-3.9.0.tgz",
+      "integrity": "sha512-zLcTg6P4AbcHPq465ZMFNXx7XpKKJh+7kkN699NiQWisR2uWYOWNWqRHAmbnmKiL4e9aLSlmy5U7rEMUXV59+A==",
+      "optional": true
     },
     "node-int64": {
       "version": "0.4.0",
@@ -25252,9 +29030,13 @@
         "es-object-atoms": "^1.0.0"
       }
     },
+    "on-exit-leak-free": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA=="
+    },
     "once": {
       "version": "1.4.0",
-      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -25264,6 +29046,14 @@
       "dev": true,
       "requires": {
         "mimic-fn": "^2.1.0"
+      }
+    },
+    "openapi3-ts": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/openapi3-ts/-/openapi3-ts-2.0.2.tgz",
+      "integrity": "sha512-TxhYBMoqx9frXyOgnRHufjQfPXomTIHYKhSKJ6jHfj13kS8OEIhvmE8CTuQyKtjjWttAjX5DPxM1vmalEpo8Qw==",
+      "requires": {
+        "yaml": "^1.10.2"
       }
     },
     "optionator": {
@@ -25369,6 +29159,40 @@
         "object-keys": "^1.1.1",
         "safe-push-apply": "^1.0.0"
       }
+    },
+    "oxc-parser": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.121.0.tgz",
+      "integrity": "sha512-ek9o58+SCv6AV7nchiAcUJy1DNE2CC5WRdBcO0mF+W4oRjNQfPO7b3pLjTHSFECpHkKGOZSQxx3hk8viIL5YCg==",
+      "optional": true,
+      "requires": {
+        "@oxc-parser/binding-android-arm-eabi": "0.121.0",
+        "@oxc-parser/binding-android-arm64": "0.121.0",
+        "@oxc-parser/binding-darwin-arm64": "0.121.0",
+        "@oxc-parser/binding-darwin-x64": "0.121.0",
+        "@oxc-parser/binding-freebsd-x64": "0.121.0",
+        "@oxc-parser/binding-linux-arm-gnueabihf": "0.121.0",
+        "@oxc-parser/binding-linux-arm-musleabihf": "0.121.0",
+        "@oxc-parser/binding-linux-arm64-gnu": "0.121.0",
+        "@oxc-parser/binding-linux-arm64-musl": "0.121.0",
+        "@oxc-parser/binding-linux-ppc64-gnu": "0.121.0",
+        "@oxc-parser/binding-linux-riscv64-gnu": "0.121.0",
+        "@oxc-parser/binding-linux-riscv64-musl": "0.121.0",
+        "@oxc-parser/binding-linux-s390x-gnu": "0.121.0",
+        "@oxc-parser/binding-linux-x64-gnu": "0.121.0",
+        "@oxc-parser/binding-linux-x64-musl": "0.121.0",
+        "@oxc-parser/binding-openharmony-arm64": "0.121.0",
+        "@oxc-parser/binding-wasm32-wasi": "0.121.0",
+        "@oxc-parser/binding-win32-arm64-msvc": "0.121.0",
+        "@oxc-parser/binding-win32-ia32-msvc": "0.121.0",
+        "@oxc-parser/binding-win32-x64-msvc": "0.121.0",
+        "@oxc-project/types": "^0.121.0"
+      }
+    },
+    "p-cancelable": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
+      "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg=="
     },
     "p-each-series": {
       "version": "3.0.0",
@@ -25554,6 +29378,72 @@
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "dev": true
     },
+    "pino": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-10.3.1.tgz",
+      "integrity": "sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==",
+      "requires": {
+        "@pinojs/redact": "^0.4.0",
+        "atomic-sleep": "^1.0.0",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^3.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^4.0.0"
+      }
+    },
+    "pino-abstract-transport": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-3.0.0.tgz",
+      "integrity": "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==",
+      "requires": {
+        "split2": "^4.0.0"
+      }
+    },
+    "pino-pretty": {
+      "version": "13.1.3",
+      "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-13.1.3.tgz",
+      "integrity": "sha512-ttXRkkOz6WWC95KeY9+xxWL6AtImwbyMHrL1mSwqwW9u+vLp/WIElvHvCSDg0xO/Dzrggz1zv3rN5ovTRVowKg==",
+      "optional": true,
+      "requires": {
+        "colorette": "^2.0.7",
+        "dateformat": "^4.6.3",
+        "fast-copy": "^4.0.0",
+        "fast-safe-stringify": "^2.1.1",
+        "help-me": "^5.0.0",
+        "joycon": "^3.1.1",
+        "minimist": "^1.2.6",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^3.0.0",
+        "pump": "^3.0.0",
+        "secure-json-parse": "^4.0.0",
+        "sonic-boom": "^4.0.1",
+        "strip-json-comments": "^5.0.2"
+      },
+      "dependencies": {
+        "fast-copy": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-4.0.3.tgz",
+          "integrity": "sha512-58apWr0GUiDFM8+3afrO6eYwJBn9ZAhDOzG3L+/9llab/haCARS2UIfffmOurYLwbgDRs8n0rfr6qAAPEAuAQw==",
+          "optional": true
+        },
+        "strip-json-comments": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-5.0.3.tgz",
+          "integrity": "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==",
+          "optional": true
+        }
+      }
+    },
+    "pino-std-serializers": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
+      "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw=="
+    },
     "pirates": {
       "version": "4.0.4",
       "dev": true
@@ -25629,6 +29519,12 @@
       "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
       "dev": true
     },
+    "pprof-format": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/pprof-format/-/pprof-format-2.2.2.tgz",
+      "integrity": "sha512-hd90rHVDhNOhgHTmazVzDSVwTLOBjpZQ26AO/0j46sAFZ9uSWY0DcK2zJcwnuo2R6EzufBbOoWlPazA5nSyHcg==",
+      "optional": true
+    },
     "prelude-ls": {
       "version": "1.2.1",
       "dev": true
@@ -25666,6 +29562,20 @@
       "version": "2.0.1",
       "dev": true
     },
+    "process-warning": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
+      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA=="
+    },
+    "promise-retry": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
+      "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
+      "requires": {
+        "err-code": "^2.0.2",
+        "retry": "^0.12.0"
+      }
+    },
     "prompts": {
       "version": "2.4.2",
       "dev": true,
@@ -25685,6 +29595,15 @@
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
       "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA=="
     },
+    "pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "requires": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "punycode": {
       "version": "2.3.0",
       "dev": true
@@ -25694,16 +29613,27 @@
       "dev": true
     },
     "qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
       "requires": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       }
     },
     "queue-microtask": {
       "version": "1.2.3",
       "dev": true
+    },
+    "quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="
+    },
+    "quick-lru": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA=="
     },
     "rc": {
       "version": "1.2.8",
@@ -25723,6 +29653,21 @@
           "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
           "dev": true
         }
+      }
+    },
+    "react": {
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
+      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
+      "peer": true
+    },
+    "react-dom": {
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
+      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
+      "peer": true,
+      "requires": {
+        "scheduler": "^0.27.0"
       }
     },
     "react-is": {
@@ -25799,6 +29744,11 @@
       "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
       "dev": true
     },
+    "real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg=="
+    },
     "reflect.getprototypeof": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -25819,6 +29769,11 @@
       "version": "0.14.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
       "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
+    },
+    "regexp-tree": {
+      "version": "0.1.27",
+      "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.27.tgz",
+      "integrity": "sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA=="
     },
     "regexp.prototype.flags": {
       "version": "1.5.4",
@@ -25857,6 +29812,11 @@
         "supports-preserve-symlinks-flag": "^1.0.0"
       }
     },
+    "resolve-alpn": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
+      "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g=="
+    },
     "resolve-cwd": {
       "version": "3.0.0",
       "dev": true,
@@ -25894,6 +29854,14 @@
       "version": "2.0.2",
       "dev": true
     },
+    "responselike": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
+      "integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
+      "requires": {
+        "lowercase-keys": "^2.0.0"
+      }
+    },
     "restore-cursor": {
       "version": "2.0.0",
       "requires": {
@@ -25911,6 +29879,11 @@
           }
         }
       }
+    },
+    "retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow=="
     },
     "reusify": {
       "version": "1.0.4",
@@ -26025,6 +29998,11 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "runtypes": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/runtypes/-/runtypes-7.0.4.tgz",
+      "integrity": "sha512-fWEOLUpOlbl7zhmjDrPymCFWZIA+b+EeOFQlAbbQRYQvqcI0ys7Y/O5A09Z5IIvTf3x/DrgTN6396aXLfDRxUA=="
+    },
     "rxjs": {
       "version": "6.6.7",
       "requires": {
@@ -26058,8 +30036,7 @@
       }
     },
     "safe-buffer": {
-      "version": "5.1.2",
-      "dev": true
+      "version": "5.1.2"
     },
     "safe-push-apply": {
       "version": "1.0.0",
@@ -26079,6 +30056,14 @@
         }
       }
     },
+    "safe-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-2.1.1.tgz",
+      "integrity": "sha512-rx+x8AMzKb5Q5lQ95Zoi6ZbJqwCLkqi3XuJXp5P3rT8OEc6sZCJG5AE5dU3lsgRr/F4Bs31jSlVN+j5KrsGu9A==",
+      "requires": {
+        "regexp-tree": "~0.1.1"
+      }
+    },
     "safe-regex-test": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
@@ -26090,9 +30075,26 @@
         "is-regex": "^1.2.1"
       }
     },
+    "safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA=="
+    },
     "safer-buffer": {
       "version": "2.1.2",
       "dev": true
+    },
+    "scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "peer": true
+    },
+    "secure-json-parse": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-4.1.0.tgz",
+      "integrity": "sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==",
+      "optional": true
     },
     "semantic-release": {
       "version": "25.0.3",
@@ -26471,24 +30473,24 @@
       "dev": true
     },
     "side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "requires": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       }
     },
     "side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "requires": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       }
     },
     "side-channel-map": {
@@ -26557,6 +30559,14 @@
     "slice-ansi": {
       "version": "0.0.4"
     },
+    "sonic-boom": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
+      "integrity": "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==",
+      "requires": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
     "source-map": {
       "version": "0.6.1",
       "dev": true
@@ -26569,6 +30579,12 @@
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
       }
+    },
+    "spark-md5": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/spark-md5/-/spark-md5-3.0.2.tgz",
+      "integrity": "sha512-wcFzz9cDfbuqe0FZzfi2or1sgyIrsDwmPwfZC4hiNidPdPINjeUwNfv5kldczoEAcjl9Y1L3SM7Uz2PUEQzxQw==",
+      "optional": true
     },
     "spawn-error-forwarder": {
       "version": "1.0.0",
@@ -26605,6 +30621,11 @@
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.22.tgz",
       "integrity": "sha512-4PRT4nh1EImPbt2jASOKHX7PB7I+e4IWNLvkKFDxNhJlfjbYlleYQh285Z/3mPTHSAK/AvdMmw5BNNuYH8ShgQ==",
       "dev": true
+    },
+    "split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="
     },
     "sprintf-js": {
       "version": "1.0.3",
@@ -26643,7 +30664,6 @@
     },
     "string_decoder": {
       "version": "1.1.1",
-      "dev": true,
       "requires": {
         "safe-buffer": "~5.1.0"
       }
@@ -26848,8 +30868,7 @@
     "tagged-tag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
-      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
-      "dev": true
+      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng=="
     },
     "temp-dir": {
       "version": "3.0.0",
@@ -26908,6 +30927,21 @@
       "dev": true,
       "requires": {
         "thenify": ">= 3.1.0 < 4"
+      }
+    },
+    "thread-stream": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-4.2.0.tgz",
+      "integrity": "sha512-e2zZ96wSChazBsbENf/Pcm/4swHt2cEKQ92rhUjkL9GCKiTDJIaTBenjE/m9DXi0QBmTMDkFDdOomUy20A1tDQ==",
+      "requires": {
+        "real-require": "^1.0.0"
+      },
+      "dependencies": {
+        "real-require": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/real-require/-/real-require-1.0.0.tgz",
+          "integrity": "sha512-P4nbQYQfePJxRSmY+v/KINxVucm4NF3p3s7pJveMTtom52FR4YGltUQLB8idDXwDDWW+eYrWDFbuzUnjoWHF7g=="
+        }
       }
     },
     "through": {
@@ -26992,6 +31026,11 @@
       "integrity": "sha512-UQMIo7pb8WRomKR1/+MFVLTroIvDVtMX3K6OUir8ynLyzB8Jeriont2bTAtmNPa1ekAgN7YPDyf6V+ygrdU+eQ==",
       "dev": true,
       "requires": {}
+    },
+    "ts-deepmerge": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ts-deepmerge/-/ts-deepmerge-6.2.1.tgz",
+      "integrity": "sha512-8CYSLazCyj0DJDpPIxOFzJG46r93uh6EynYjuey+bxcLltBeqZL7DMfaE5ZPzZNFlav7wx+2TDa/mBl8gkTYzw=="
     },
     "ts-interface-checker": {
       "version": "0.1.13",
@@ -27079,8 +31118,9 @@
       }
     },
     "tslib": {
-      "version": "2.3.1",
-      "dev": true
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "tsup": {
       "version": "8.5.1",
@@ -27121,14 +31161,6 @@
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
           "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
           "dev": true
-        },
-        "yaml": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.5.1.tgz",
-          "integrity": "sha512-bLQOjaX/ADgQ20isPJRvF0iRUHIxVhYvr53Of7wGcWlO2jvtUlH5m87DsmulFVxRpNLOnI4tB6p/oh8D7kpn9Q==",
-          "dev": true,
-          "optional": true,
-          "peer": true
         }
       }
     },
@@ -27205,6 +31237,11 @@
         "possible-typed-array-names": "^1.0.0",
         "reflect.getprototypeof": "^1.0.6"
       }
+    },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="
     },
     "typescript": {
       "version": "5.9.3",
@@ -27302,14 +31339,25 @@
       "integrity": "sha512-n2huDr9h9yzd6exQVnH/jU5mr+Pfx08LRXXZhkLLetAMESRj+anQsTAh940iMrIetKAmry9coFuZQ2jY8/p3WA==",
       "dev": true
     },
+    "use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "peer": true,
+      "requires": {}
+    },
     "util-deprecate": {
-      "version": "1.0.2",
-      "dev": true
+      "version": "1.0.2"
     },
     "uuid": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
       "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="
+    },
+    "uuid-random": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/uuid-random/-/uuid-random-1.3.2.tgz",
+      "integrity": "sha512-UOzej0Le/UgkbWEO8flm+0y+G+ljUon1QWTEZOq1rnMAsxo2+SckbiZdKzAHHlVh6gJqI1TjC/xwgR50MuCrBQ=="
     },
     "v8-to-istanbul": {
       "version": "9.1.0",
@@ -27488,8 +31536,7 @@
       }
     },
     "wrappy": {
-      "version": "1.0.2",
-      "dev": true
+      "version": "1.0.2"
     },
     "write-file-atomic": {
       "version": "4.0.2",
@@ -27507,13 +31554,10 @@
       "version": "5.0.8"
     },
     "yallist": {
-      "version": "4.0.0",
-      "dev": true
+      "version": "4.0.0"
     },
     "yaml": {
-      "version": "1.10.2",
-      "dev": true,
-      "optional": true
+      "version": "1.10.2"
     },
     "yargs": {
       "version": "17.7.2",
@@ -27583,6 +31627,11 @@
       "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.1.tgz",
       "integrity": "sha512-GQHQqAopRhwU8Kt1DDM8NjibDXHC8eoh1erhGAJPEyveY9qqVeXvVikNKrDz69sHowPMorbPUrH/mx8c50eiBQ==",
       "dev": true
+    },
+    "zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -60,6 +60,8 @@
     "dts": true
   },
   "dependencies": {
+    "@contentful/experiences-api-schemas": "^4.99.0",
+    "@contentful/experiences-management-api-contract": "^5.140.0",
     "@discoveryjs/json-ext": "^0.6.3",
     "bluebird": "^3.7.2",
     "cli-table3": "^0.6.5",


### PR DESCRIPTION
## Summary

- Adds `--include-experience-orchestration` CLI flag (opt-in, defaults to false)
- Initializes a plain CMA client alongside the legacy client — required since ExO entity namespaces (`experience`, `componentType`, etc.) only exist on the plain client
- Adds ExO entity types to `SUPPORTED_ENTITY_TYPES` in `parseOptions` so they pass through the content file filter
- Adds 5 Listr import tasks to `push-to-space` in dependency order:
  1. **Component Types** — `upsert`
  2. **Templates** — `upsert`
  3. **Fragments** — `upsert`
  4. **Data Assemblies** — `create` or `update` (no `upsert` on this entity)
  5. **Experiences** — `upsert`

## Status

🚧 Draft — blocked on `contentful-management` `feat/exo` being released to npm (AIS-135). Testing locally with a packed `.tgz` build.

Related tickets: AIS-119 (CLI flag), AIS-126–132 (import tasks)

## Test plan

- [ ] Install local `contentful-management` `feat/exo` pack
- [ ] Export an experience from a space using `contentful-export@exo`
- [ ] Import that file with `--include-experience-orchestration` into a target space
- [ ] Verify all 5 entity types round-trip correctly
- [ ] Verify graceful no-op when `--include-experience-orchestration` is omitted

🤖 Generated with [Claude Code](https://claude.ai/claude-code)