### PR TITLE
fix: remove private preset, inline renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,9 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "local>contentful/renovate-config",
+    "config:recommended",
+    ":automergeRequireAllStatusChecks",
+    ":automergeAll",
     ":semanticCommitTypeAll(build)"
   ],
   "timezone": "UTC",


### PR DESCRIPTION
## Summary

- Removes `local>contentful/renovate-config` from the `extends` list — this is a **private** repo and Renovate can't access it from a public repo, which is exactly what broke in #1581 and was fixed in #1582
- Restores the three inlined presets (`config:recommended`, `:automergeRequireAllStatusChecks`, `:automergeAll`) that the automated MEC-3447 rollout (#1651) replaced

## Root Cause

The org-wide Renovate rollout bot (MEC-3447) re-introduced the private preset reference, undoing the fix from [#1582](https://github.com/contentful/contentful-import/pull/1582). Same error, same fix.

Closes #1656

## Test plan

- [ ] Verify Renovate closes issue #1656 after merging
- [ ] Verify Renovate resumes opening dependency PRs

🤖 Generated with [Claude Code](https://claude.ai/claude-code)