### PR TITLE
chore: improve logging and error handling [AIS-168]

### DIFF
--- a/lib/tasks/push-to-space/assets.ts
+++ b/lib/tasks/push-to-space/assets.ts
@@ -92,7 +92,7 @@ export async function processAssets ({
         })
       )
     } catch (err) {
-      // Handle any error that arises during the processing of any locale
+      logEmitter.emit('warning', `Asset ${getEntityName(asset)} processing failed and will be skipped`)
       return null
     }
     return latestAssetVersion

--- a/lib/tasks/push-to-space/creation.ts
+++ b/lib/tasks/push-to-space/creation.ts
@@ -192,8 +192,9 @@ function createTagInDestination (context, sourceEntity) {
 
 /**
  * Handles entity creation errors.
- * If the error is a VersionMismatch the error is thrown and a message is returned
- * instructing the user on what this situation probably means.
+ * VersionMismatch errors are logged as warnings with guidance, since the entity
+ * already exists at a different version — the update is skipped but import continues.
+ * Other errors are logged as errors and the entity is excluded from further steps.
  */
 function handleCreationErrors (entity, err) {
   // Handle the case where a locale already exists and skip it
@@ -203,6 +204,12 @@ function handleCreationErrors (entity, err) {
       return entity
     }
   }
+
+  if (get(err, 'error.sys.id') === 'VersionMismatch') {
+    logEmitter.emit('warning', `Version mismatch for entity ${getEntityName(entity.original)}: the destination has a newer version. This entity was skipped.`)
+    return null
+  }
+
   err.entity = entity.original
   logEmitter.emit('error', err)
 

--- a/test/unit/tasks/push/assets.test.ts
+++ b/test/unit/tasks/push/assets.test.ts
@@ -145,13 +145,16 @@ test('Process assets fails', async () => {
   // We expect two calls for the first asset (one for each locale)
   // and two for the second asset of which one fails
   expect(processStub.mock.calls).toHaveLength(4)
-  expect(mockEmit.mock.calls).toHaveLength(3)
+  expect(mockEmit.mock.calls).toHaveLength(4)
   expect(mockEmit.mock.calls[0][0]).toBe('info')
   expect(mockEmit.mock.calls[0][1]).toBe('Processing Asset 123')
   expect(mockEmit.mock.calls[1][0]).toBe('info')
   expect(mockEmit.mock.calls[1][1]).toBe('Processing Asset 456')
   expect(mockEmit.mock.calls[2][0]).toBe('error')
   expect(mockEmit.mock.calls[2][1]).toBe(failedError)
+  expect(mockEmit.mock.calls[3][0]).toBe('warning')
+  expect(mockEmit.mock.calls[3][1]).toContain('456')
+  expect(mockEmit.mock.calls[3][1]).toContain('skipped')
 })
 
 test('Get asset stream for url: Throw error if filePath does not exist', async () => {

--- a/test/unit/tasks/push/creation.test.ts
+++ b/test/unit/tasks/push/creation.test.ts
@@ -363,6 +363,41 @@ test('Create public tags', () => {
     })
 })
 
+test('Create entities handles VersionMismatch as a warning', () => {
+  const updateStub = jest.fn()
+  const target = {}
+  const versionMismatchError = new Error('Version mismatch')
+  ;(versionMismatchError as any).error = { sys: { id: 'VersionMismatch' } }
+  updateStub.mockImplementationOnce(() => Promise.reject(versionMismatchError))
+
+  const entities = [{
+    original: { sys: { id: '123', type: 'Entry' } },
+    transformed: { sys: { id: '123' } }
+  }] as any[]
+
+  const destinationEntities = new Map([
+    ['123', { sys: { id: '123', version: 6 }, update: updateStub }]
+  ])
+
+  return createEntities({
+    context: { target, type: 'Entry' },
+    entities,
+    destinationEntitiesById: destinationEntities,
+    requestQueue
+  })
+    .then((result) => {
+      expect(updateStub.mock.calls).toHaveLength(1)
+      expect(result).toHaveLength(0)
+      const warningCount = mockEmit.mock.calls.filter((args) => args[0] === 'warning').length
+      const errorCount = mockEmit.mock.calls.filter((args) => args[0] === 'error').length
+      expect(warningCount).toBe(1)
+      expect(errorCount).toBe(0)
+      const warningCall = mockEmit.mock.calls.find((args) => args[0] === 'warning')
+      expect(warningCall).toBeDefined()
+      expect(warningCall![1]).toContain('skipped')
+    })
+})
+
 test('Fails to create locale if it already exists', () => {
   const target = {
     createLocale: jest.fn(() => Promise.reject(errorValidationFailed))


### PR DESCRIPTION
## Summary
1. raise/log a message when asset processing fails - see `lib/tasks/push-to-space/assets.ts`
  - was previously failing silently 🫢 
3. specifically handle VersionMismatch errors - see `lib/tasks/push-to-space/creation.ts`
  - was previous being treated like a generic error.

