### PR TITLE
Logging error handling rate limiting [AIS-175]

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -8,7 +8,7 @@ import { startCase } from 'lodash'
 import PQueue from 'p-queue'
 
 import { displayErrorLog, setupLogging, writeErrorLogFile } from 'contentful-batch-libs/dist/logging'
-import { wrapTask } from 'contentful-batch-libs/dist/listr'
+import { wrapTaskWithRateLimitStatus as wrapTask } from './utils/rate-limit-status'
 
 import initClient from './tasks/init-client'
 import getDestinationData from './tasks/get-destination-data'

--- a/lib/tasks/init-client.ts
+++ b/lib/tasks/init-client.ts
@@ -2,8 +2,16 @@ import { createClient } from 'contentful-management'
 
 import { logEmitter } from 'contentful-batch-libs/dist/logging'
 
+const RATE_LIMIT_PATTERN = /^Rate limit error occurred\. Waiting for (\d+) ms before retrying\.\.\./
+
 function logHandler (level, data) {
   logEmitter.emit(level, data)
+  if (level === 'warning' && typeof data === 'string') {
+    const match = RATE_LIMIT_PATTERN.exec(data)
+    if (match) {
+      logEmitter.emit('rateLimit', { waitMs: parseInt(match[1], 10) })
+    }
+  }
 }
 
 export default function initClient (opts) {

--- a/lib/tasks/push-to-space/creation.ts
+++ b/lib/tasks/push-to-space/creation.ts
@@ -22,7 +22,7 @@ type CreateEntitiesParams = {
  * Applies to all entities except Entries, as the CMA API for those is slightly different
  * See handleCreationErrors for details on what errors reject the promise or not.
  */
-export function createEntities ({ context, entities, destinationEntitiesById, skipUpdates, requestQueue }: CreateEntitiesParams) {
+export function createEntities({ context, entities, destinationEntitiesById, skipUpdates, requestQueue }: CreateEntitiesParams) {
   return createEntitiesWithConcurrency({ context, entities, destinationEntitiesById, skipUpdates, requestQueue })
 }
 
@@ -35,11 +35,11 @@ type CreateLocalesParams = {
   requestQueue: PQueue
 }
 
-export function createLocales ({ context, entities, destinationEntitiesById, requestQueue }: CreateLocalesParams) {
+export function createLocales({ context, entities, destinationEntitiesById, requestQueue }: CreateLocalesParams) {
   return createEntitiesInSequence({ context, entities, destinationEntitiesById, requestQueue })
 }
 
-async function createEntitiesWithConcurrency ({ context, entities, destinationEntitiesById, skipUpdates, requestQueue }) {
+async function createEntitiesWithConcurrency({ context, entities, destinationEntitiesById, skipUpdates, requestQueue }) {
   const pendingCreatedEntities = entities.map((entity) => {
     const destinationEntity = getDestinationEntityForSourceEntity(destinationEntitiesById, entity.transformed)
     const updateOperation = skipUpdates ? 'skip' : 'update'
@@ -71,7 +71,7 @@ async function createEntitiesWithConcurrency ({ context, entities, destinationEn
   return createdEntities.filter((entity) => entity)
 }
 
-async function createEntitiesInSequence ({ context, entities, destinationEntitiesById, requestQueue }: CreateLocalesParams) {
+async function createEntitiesInSequence({ context, entities, destinationEntitiesById, requestQueue }: CreateLocalesParams) {
   const createdEntities: LocaleProps[] = []
 
   for (const entity of entities) {
@@ -105,7 +105,7 @@ async function createEntitiesInSequence ({ context, entities, destinationEntitie
 /**
  * Creates a list of entries
  */
-export async function createEntries ({ context, entities, destinationEntitiesById, skipUpdates, requestQueue }) {
+export async function createEntries({ context, entities, destinationEntitiesById, skipUpdates, requestQueue }) {
   const createdEntries = await Promise.all(entities.map((entry) => {
     return createEntry({ entry, target: context.target, skipContentModel: context.skipContentModel, destinationEntitiesById, skipUpdates, requestQueue })
   }))
@@ -113,7 +113,7 @@ export async function createEntries ({ context, entities, destinationEntitiesByI
   return createdEntries.filter((entry) => entry)
 }
 
-async function createEntry ({ entry, target, skipContentModel, destinationEntitiesById, skipUpdates, requestQueue }) {
+async function createEntry({ entry, target, skipContentModel, destinationEntitiesById, skipUpdates, requestQueue }) {
   const contentTypeId = entry.original.sys.contentType.sys.id
   const destinationEntry = getDestinationEntityForSourceEntity(
     destinationEntitiesById, entry.transformed)
@@ -125,8 +125,8 @@ async function createEntry ({ entry, target, skipContentModel, destinationEntiti
   }
   try {
     const createdOrUpdatedEntry = await requestQueue.add(() => {
-      return destinationEntry 
-        ? updateDestinationWithSourceData(destinationEntry, entry.transformed) 
+      return destinationEntry
+        ? updateDestinationWithSourceData(destinationEntry, entry.transformed)
         : createEntryInDestination(target, contentTypeId, entry.transformed)
     })
 
@@ -154,13 +154,13 @@ async function createEntry ({ entry, target, skipContentModel, destinationEntiti
   }
 }
 
-function updateDestinationWithSourceData (destinationEntity, sourceEntity) {
+function updateDestinationWithSourceData(destinationEntity, sourceEntity) {
   const plainData = getPlainData(sourceEntity)
   assign(destinationEntity, plainData)
   return destinationEntity.update()
 }
 
-function createInDestination (context, sourceEntity) {
+function createInDestination(context, sourceEntity) {
   const { type, target } = context
   if (type === 'Tag') {
     // tags are created with a different signature
@@ -175,7 +175,7 @@ function createInDestination (context, sourceEntity) {
     : target[`create${type}`](plainData)
 }
 
-function createEntryInDestination (space, contentTypeId, sourceEntity) {
+function createEntryInDestination(space, contentTypeId, sourceEntity) {
   const id = sourceEntity.sys.id
   const plainData = getPlainData(sourceEntity)
   return id
@@ -183,7 +183,7 @@ function createEntryInDestination (space, contentTypeId, sourceEntity) {
     : space.createEntry(contentTypeId, plainData)
 }
 
-function createTagInDestination (context, sourceEntity) {
+function createTagInDestination(context, sourceEntity) {
   const id = sourceEntity.sys.id
   const visibility = sourceEntity.sys.visibility || 'private'
   const name = sourceEntity.name
@@ -196,7 +196,7 @@ function createTagInDestination (context, sourceEntity) {
  * already exists at a different version — the update is skipped but import continues.
  * Other errors are logged as errors and the entity is excluded from further steps.
  */
-function handleCreationErrors (entity, err) {
+function handleCreationErrors(entity, err) {
   // Handle the case where a locale already exists and skip it
   if (get(err, 'error.sys.id') === 'ValidationFailed') {
     const errors = get(err, 'error.details.errors')
@@ -217,7 +217,7 @@ function handleCreationErrors (entity, err) {
   return null
 }
 
-function cleanupUnknownFields (fields, errors) {
+function cleanupUnknownFields(fields, errors) {
   return omitBy(fields, (field, fieldId) => {
     return find(errors, (error) => {
       const [, errorFieldId] = error.path
@@ -226,16 +226,16 @@ function cleanupUnknownFields (fields, errors) {
   })
 }
 
-function getDestinationEntityForSourceEntity (destinationEntitiesById, sourceEntity) {
+function getDestinationEntityForSourceEntity(destinationEntitiesById, sourceEntity) {
   return destinationEntitiesById.get(get(sourceEntity, 'sys.id')) || null
 }
 
-function creationSuccessNotifier (method, createdEntity) {
+function creationSuccessNotifier(method, createdEntity) {
   logEmitter.emit('info', `${method.toUpperCase()} ${createdEntity.sys.type} ${getEntityName(createdEntity)}`)
   return createdEntity
 }
 
-function getPlainData (entity) {
+function getPlainData(entity) {
   const data = entity.toPlainObject ? entity.toPlainObject() : entity
   return omit(data, 'sys')
 }

--- a/lib/tasks/push-to-space/creation.ts
+++ b/lib/tasks/push-to-space/creation.ts
@@ -22,7 +22,7 @@ type CreateEntitiesParams = {
  * Applies to all entities except Entries, as the CMA API for those is slightly different
  * See handleCreationErrors for details on what errors reject the promise or not.
  */
-export function createEntities({ context, entities, destinationEntitiesById, skipUpdates, requestQueue }: CreateEntitiesParams) {
+export function createEntities ({ context, entities, destinationEntitiesById, skipUpdates, requestQueue }: CreateEntitiesParams) {
   return createEntitiesWithConcurrency({ context, entities, destinationEntitiesById, skipUpdates, requestQueue })
 }
 
@@ -35,11 +35,11 @@ type CreateLocalesParams = {
   requestQueue: PQueue
 }
 
-export function createLocales({ context, entities, destinationEntitiesById, requestQueue }: CreateLocalesParams) {
+export function createLocales ({ context, entities, destinationEntitiesById, requestQueue }: CreateLocalesParams) {
   return createEntitiesInSequence({ context, entities, destinationEntitiesById, requestQueue })
 }
 
-async function createEntitiesWithConcurrency({ context, entities, destinationEntitiesById, skipUpdates, requestQueue }) {
+async function createEntitiesWithConcurrency ({ context, entities, destinationEntitiesById, skipUpdates, requestQueue }) {
   const pendingCreatedEntities = entities.map((entity) => {
     const destinationEntity = getDestinationEntityForSourceEntity(destinationEntitiesById, entity.transformed)
     const updateOperation = skipUpdates ? 'skip' : 'update'
@@ -71,7 +71,7 @@ async function createEntitiesWithConcurrency({ context, entities, destinationEnt
   return createdEntities.filter((entity) => entity)
 }
 
-async function createEntitiesInSequence({ context, entities, destinationEntitiesById, requestQueue }: CreateLocalesParams) {
+async function createEntitiesInSequence ({ context, entities, destinationEntitiesById, requestQueue }: CreateLocalesParams) {
   const createdEntities: LocaleProps[] = []
 
   for (const entity of entities) {
@@ -105,7 +105,7 @@ async function createEntitiesInSequence({ context, entities, destinationEntities
 /**
  * Creates a list of entries
  */
-export async function createEntries({ context, entities, destinationEntitiesById, skipUpdates, requestQueue }) {
+export async function createEntries ({ context, entities, destinationEntitiesById, skipUpdates, requestQueue }) {
   const createdEntries = await Promise.all(entities.map((entry) => {
     return createEntry({ entry, target: context.target, skipContentModel: context.skipContentModel, destinationEntitiesById, skipUpdates, requestQueue })
   }))
@@ -113,7 +113,7 @@ export async function createEntries({ context, entities, destinationEntitiesById
   return createdEntries.filter((entry) => entry)
 }
 
-async function createEntry({ entry, target, skipContentModel, destinationEntitiesById, skipUpdates, requestQueue }) {
+async function createEntry ({ entry, target, skipContentModel, destinationEntitiesById, skipUpdates, requestQueue }) {
   const contentTypeId = entry.original.sys.contentType.sys.id
   const destinationEntry = getDestinationEntityForSourceEntity(
     destinationEntitiesById, entry.transformed)
@@ -125,8 +125,8 @@ async function createEntry({ entry, target, skipContentModel, destinationEntitie
   }
   try {
     const createdOrUpdatedEntry = await requestQueue.add(() => {
-      return destinationEntry
-        ? updateDestinationWithSourceData(destinationEntry, entry.transformed)
+      return destinationEntry 
+        ? updateDestinationWithSourceData(destinationEntry, entry.transformed) 
         : createEntryInDestination(target, contentTypeId, entry.transformed)
     })
 
@@ -154,13 +154,13 @@ async function createEntry({ entry, target, skipContentModel, destinationEntitie
   }
 }
 
-function updateDestinationWithSourceData(destinationEntity, sourceEntity) {
+function updateDestinationWithSourceData (destinationEntity, sourceEntity) {
   const plainData = getPlainData(sourceEntity)
   assign(destinationEntity, plainData)
   return destinationEntity.update()
 }
 
-function createInDestination(context, sourceEntity) {
+function createInDestination (context, sourceEntity) {
   const { type, target } = context
   if (type === 'Tag') {
     // tags are created with a different signature
@@ -175,7 +175,7 @@ function createInDestination(context, sourceEntity) {
     : target[`create${type}`](plainData)
 }
 
-function createEntryInDestination(space, contentTypeId, sourceEntity) {
+function createEntryInDestination (space, contentTypeId, sourceEntity) {
   const id = sourceEntity.sys.id
   const plainData = getPlainData(sourceEntity)
   return id
@@ -183,7 +183,7 @@ function createEntryInDestination(space, contentTypeId, sourceEntity) {
     : space.createEntry(contentTypeId, plainData)
 }
 
-function createTagInDestination(context, sourceEntity) {
+function createTagInDestination (context, sourceEntity) {
   const id = sourceEntity.sys.id
   const visibility = sourceEntity.sys.visibility || 'private'
   const name = sourceEntity.name
@@ -196,7 +196,7 @@ function createTagInDestination(context, sourceEntity) {
  * already exists at a different version — the update is skipped but import continues.
  * Other errors are logged as errors and the entity is excluded from further steps.
  */
-function handleCreationErrors(entity, err) {
+function handleCreationErrors (entity, err) {
   // Handle the case where a locale already exists and skip it
   if (get(err, 'error.sys.id') === 'ValidationFailed') {
     const errors = get(err, 'error.details.errors')
@@ -217,7 +217,7 @@ function handleCreationErrors(entity, err) {
   return null
 }
 
-function cleanupUnknownFields(fields, errors) {
+function cleanupUnknownFields (fields, errors) {
   return omitBy(fields, (field, fieldId) => {
     return find(errors, (error) => {
       const [, errorFieldId] = error.path
@@ -226,16 +226,16 @@ function cleanupUnknownFields(fields, errors) {
   })
 }
 
-function getDestinationEntityForSourceEntity(destinationEntitiesById, sourceEntity) {
+function getDestinationEntityForSourceEntity (destinationEntitiesById, sourceEntity) {
   return destinationEntitiesById.get(get(sourceEntity, 'sys.id')) || null
 }
 
-function creationSuccessNotifier(method, createdEntity) {
+function creationSuccessNotifier (method, createdEntity) {
   logEmitter.emit('info', `${method.toUpperCase()} ${createdEntity.sys.type} ${getEntityName(createdEntity)}`)
   return createdEntity
 }
 
-function getPlainData(entity) {
+function getPlainData (entity) {
   const data = entity.toPlainObject ? entity.toPlainObject() : entity
   return omit(data, 'sys')
 }

--- a/lib/tasks/push-to-space/push-to-space.ts
+++ b/lib/tasks/push-to-space/push-to-space.ts
@@ -2,7 +2,7 @@ import Listr from 'listr'
 import verboseRenderer from 'listr-verbose-renderer'
 
 import { logEmitter } from 'contentful-batch-libs/dist/logging'
-import { wrapTask } from 'contentful-batch-libs/dist/listr'
+import { wrapTaskWithRateLimitStatus as wrapTask } from '../../utils/rate-limit-status'
 
 import * as assets from './assets'
 import * as creation from './creation'

--- a/lib/utils/rate-limit-status.ts
+++ b/lib/utils/rate-limit-status.ts
@@ -1,0 +1,54 @@
+import { logEmitter } from 'contentful-batch-libs/dist/logging'
+import { wrapTask } from 'contentful-batch-libs/dist/listr'
+
+type RateLimitEvent = { waitMs: number }
+
+/**
+ * Drop-in replacement for `wrapTask` that adds a persistent rate-limit status
+ * line in the task title.
+ *
+ * When the SDK hits a 429 it emits a `rateLimit` event via logEmitter.  This
+ * wrapper intercepts that event and updates `task.title` with a human-readable
+ * message ("rate limited, retrying in Xs") so the user can tell the import is
+ * waiting rather than stalled.  The title is restored before `wrapTask`'s own
+ * teardown appends its `(Xs)` elapsed-time suffix, so the final completed task
+ * title remains clean.
+ *
+ * Ordering guarantee: the cleanup `finally` block runs inside the async
+ * function body that is passed to `wrapTask`.  `wrapTask` appends `(Xs)` in
+ * its own `.then()` handler, which executes after the inner async function
+ * resolves — so cleanup always fires first.
+ */
+export function wrapTaskWithRateLimitStatus (func: (ctx: any, task: any) => Promise<any>) {
+  return wrapTask(async (ctx, task) => {
+    const baseTitle: string = task.title
+    let retryCount = 0
+    let clearTimer: ReturnType<typeof setTimeout> | null = null
+
+    function onRateLimit ({ waitMs }: RateLimitEvent) {
+      retryCount++
+      const waitSec = Math.ceil(waitMs / 1000)
+      task.title = `${baseTitle} — rate limited, retrying in ${waitSec}s (attempt ${retryCount})`
+
+      if (clearTimer) clearTimeout(clearTimer)
+      // Auto-clear once the wait elapses so the title resets if the retry
+      // succeeds without a subsequent rate-limit event.
+      clearTimer = setTimeout(() => {
+        task.title = baseTitle
+        retryCount = 0
+      }, waitMs + 500)
+    }
+
+    logEmitter.on('rateLimit', onRateLimit)
+
+    try {
+      return await func(ctx, task)
+    } finally {
+      // Runs before wrapTask's .then(teardown) so the `(Xs)` suffix is
+      // appended to the clean base title, not the rate-limit status string.
+      if (clearTimer) clearTimeout(clearTimer)
+      logEmitter.removeListener('rateLimit', onRateLimit)
+      task.title = baseTitle
+    }
+  })
+}

--- a/test/unit/tasks/init-client.test.ts
+++ b/test/unit/tasks/init-client.test.ts
@@ -10,10 +10,11 @@ jest.mock('contentful-management', () => {
 })
 
 jest.mock('contentful-batch-libs/dist/logging', () => {
+  const EventEmitter = require('events')
+  const emitter = new EventEmitter()
+  emitter.emit = jest.fn(emitter.emit.bind(emitter))
   return {
-    logEmitter: {
-      emit: jest.fn()
-    }
+    logEmitter: emitter
   }
 })
 
@@ -57,4 +58,33 @@ test('does create clients and passes custom logHandler', () => {
 
   expect(mockEmit.mock.calls[0][0]).toBe('level')
   expect(mockEmit.mock.calls[0][1]).toBe('logMessage')
+})
+
+test('logHandler emits rateLimit event for 429 retry warnings', () => {
+  initClient({})
+
+  const rateLimitListener = jest.fn()
+  logEmitter.on('rateLimit', rateLimitListener)
+
+  const logHandler = (contentfulManagement.createClient as jest.Mock).mock.calls[0][0].logHandler
+  logHandler('warning', 'Rate limit error occurred. Waiting for 10500 ms before retrying...')
+
+  expect(rateLimitListener).toHaveBeenCalledTimes(1)
+  expect(rateLimitListener).toHaveBeenCalledWith({ waitMs: 10500 })
+
+  logEmitter.removeListener('rateLimit', rateLimitListener)
+})
+
+test('logHandler does not emit rateLimit event for unrelated warnings', () => {
+  initClient({})
+
+  const rateLimitListener = jest.fn()
+  logEmitter.on('rateLimit', rateLimitListener)
+
+  const logHandler = (contentfulManagement.createClient as jest.Mock).mock.calls[0][0].logHandler
+  logHandler('warning', 'Some other warning')
+
+  expect(rateLimitListener).not.toHaveBeenCalled()
+
+  logEmitter.removeListener('rateLimit', rateLimitListener)
 })

--- a/test/unit/utils/rate-limit-status.test.ts
+++ b/test/unit/utils/rate-limit-status.test.ts
@@ -1,0 +1,110 @@
+import { wrapTaskWithRateLimitStatus } from '../../../lib/utils/rate-limit-status'
+import { logEmitter } from 'contentful-batch-libs/dist/logging'
+
+jest.mock('contentful-batch-libs/dist/listr', () => ({
+  wrapTask: (func) => (ctx, task) => func(ctx, task)
+}))
+
+jest.mock('contentful-batch-libs/dist/logging', () => {
+  const EventEmitter = require('events')
+  return {
+    logEmitter: new EventEmitter(),
+    logToTaskOutput: jest.fn(() => () => {})
+  }
+})
+
+function makeTask (title: string) {
+  return { title }
+}
+
+beforeEach(() => {
+  jest.useFakeTimers()
+})
+
+afterEach(() => {
+  jest.useRealTimers()
+  logEmitter.removeAllListeners('rateLimit')
+})
+
+test('updates task title on rateLimit event', async () => {
+  const task = makeTask('Importing Entries')
+  const func = jest.fn().mockResolvedValue(undefined)
+  const wrappedTask = wrapTaskWithRateLimitStatus(func)
+
+  const p = wrappedTask({}, task)
+  logEmitter.emit('rateLimit', { waitMs: 10000 })
+
+  expect(task.title).toBe('Importing Entries — rate limited, retrying in 10s (attempt 1)')
+
+  await p
+})
+
+test('increments attempt counter on repeated rateLimit events', async () => {
+  const task = makeTask('Importing Entries')
+  let resolve: () => void
+  const func = jest.fn(() => new Promise<void>((r) => { resolve = r }))
+  const wrappedTask = wrapTaskWithRateLimitStatus(func)
+
+  const p = wrappedTask({}, task)
+
+  logEmitter.emit('rateLimit', { waitMs: 5000 })
+  expect(task.title).toContain('attempt 1')
+
+  logEmitter.emit('rateLimit', { waitMs: 5000 })
+  expect(task.title).toContain('attempt 2')
+
+  resolve!()
+  await p
+})
+
+test('restores base title after task completes', async () => {
+  const task = makeTask('Importing Entries')
+  const func = jest.fn().mockResolvedValue(undefined)
+  const wrappedTask = wrapTaskWithRateLimitStatus(func)
+
+  const p = wrappedTask({}, task)
+  logEmitter.emit('rateLimit', { waitMs: 10000 })
+  await p
+
+  expect(task.title).toBe('Importing Entries')
+})
+
+test('auto-clears status after wait elapses when retry succeeds without further events', async () => {
+  const task = makeTask('Importing Entries')
+  let resolve: () => void
+  const func = jest.fn(() => new Promise<void>((r) => { resolve = r }))
+  const wrappedTask = wrapTaskWithRateLimitStatus(func)
+
+  const p = wrappedTask({}, task)
+
+  logEmitter.emit('rateLimit', { waitMs: 5000 })
+  expect(task.title).toContain('rate limited')
+
+  jest.advanceTimersByTime(5500)
+  expect(task.title).toBe('Importing Entries')
+
+  resolve!()
+  await p
+})
+
+test('removes rateLimit listener after task completes', async () => {
+  const task = makeTask('Importing Entries')
+  const func = jest.fn().mockResolvedValue(undefined)
+  const wrappedTask = wrapTaskWithRateLimitStatus(func)
+
+  await wrappedTask({}, task)
+
+  // After task is done, emitting rateLimit must not affect title
+  logEmitter.emit('rateLimit', { waitMs: 5000 })
+  expect(task.title).toBe('Importing Entries')
+})
+
+test('restores base title even when task throws', async () => {
+  const task = makeTask('Importing Entries')
+  const func = jest.fn().mockRejectedValue(new Error('boom'))
+  const wrappedTask = wrapTaskWithRateLimitStatus(func)
+
+  await expect(wrappedTask({}, task)).rejects.toThrow('boom')
+
+  expect(task.title).toBe('Importing Entries')
+})


### PR DESCRIPTION
## Summary
Non-functional improvements to logging 429 (rate limit reached) errors.

### Before - during the wait, the warning briefly flashes as task.output (the subtitle), then gets immediately overwritten by the next info log.   The rate limit message is gone. If you blink you miss it, and the spinner just looks stalled for the next 10 seconds with no explanation.
```
  ✔ Importing Content Types (3s)
  ⠋ Importing Content Entries
    ⚠ Rate limit error occurred. Waiting for 10500 ms before retrying...
  → half a second later, replaced by:
  ✔ Importing Content Types (3s)
  ⠋ Importing Content Entries
    ✔ CREATE Entry Hero Banner
```
###  After  the task title itself changes for the full duration of the wait:
```
  ✔ Importing Content Types (3s)
  ⠋ Importing Content Entries — rate limited, retrying in 10s (attempt 1)
    ✔ CREATE Entry Hero Banner

# That title line holds for the entire 10 seconds regardless of how many other log messages scroll through task.output below it. Once the SDK retries successfully, it resets to:

  ✔ Importing Content Types (3s)
  ⠋ Importing Content Entries
    ✔ CREATE Entry Hero Banner
```

## Changes
1. `lib/tasks/init-client.ts`
  The SDK's logHandler callback already receives a warning log when a 429 retry occurs (message like "Rate limit error occurred. Waiting for 10500 ms before retrying..."). The new code parses
  that message with a regex and re-emits a structured rateLimit event on logEmitter with { waitMs: number }.

2. `lib/utils/rate-limit-status.ts` (new file)
  A drop-in wrapper around wrapTask called wrapTaskWithRateLimitStatus. It:
  1. Subscribes to logEmitter's rateLimit event for the lifetime of a task
  2. On each event, updates task.title to something like "Importing Entries — rate limited, retrying in 10s (attempt 2)" so the Listr display shows a human-readable status
  3. Sets a setTimeout to auto-clear the title once the wait elapses (handles the case where the retry succeeds with no further 429s)
  4. In a finally block: cancels the timer, removes the listener, and restores the original title — so the elapsed-time suffix wrapTask appends ((Xs)) lands on the clean title, not the
  rate-limit string

3. `lib/index.ts + lib/tasks/push-to-space/push-to-space.ts`
  Both swap their wrapTask import from contentful-batch-libs for the new wrapTaskWithRateLimitStatus. Since it's a drop-in, no other call sites change.

4. `lib/tasks/push-to-space/creation.ts`
  Cosmetic only — removes spaces before ( in function signatures (whitespace formatting).

### Tests
- `test/unit/tasks/init-client.test.ts`: two new tests verifying the regex fires on rate-limit warnings and is silent on unrelated warnings. Also upgrades the logEmitter mock from a plain {
  emit: jest.fn() } to a real EventEmitter so event listeners actually work.
- `test/unit/utils/rate-limit-status.test.ts` (new): 6 tests covering title update, attempt counter increment, title restoration on success/throw, auto-clear via fake timers, and listener cleanup.


## Description

<!-- Describe your changes in detail -->

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

## PR Checklist

- [ ] I have read the `CONTRIBUTING.md` file
- [ ] All commits follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Documentation is updated (if necessary)
- [ ] PR doesn't contain any sensitive information
- [ ] There are no breaking changes
