### PR TITLE
fix: exo - Added destination data prefetching for ExO entities, use version-aware create-or-update instead of blind upserts [AIS-130]

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -121,11 +121,13 @@ async function runContentfulImport (params: RunContentfulImportParams) {
       task: wrapTask(async (ctx) => {
         const destinationData = await getDestinationData({
           client: ctx.client,
+          plainClient: ctx.plainClient,
           spaceId: options.spaceId,
           environmentId: options.environmentId,
           sourceData: options.content,
           skipLocales: options.skipLocales,
           skipContentModel: options.skipContentModel,
+          includeExperienceOrchestration: options.includeExperienceOrchestration,
           requestQueue
         })
 

--- a/lib/tasks/get-destination-data.ts
+++ b/lib/tasks/get-destination-data.ts
@@ -1,7 +1,7 @@
 import Promise from 'bluebird'
 
 import { logEmitter } from 'contentful-batch-libs/dist/logging'
-import type { AssetProps, ContentTypeProps, EntryProps, LocaleProps, TagProps, WebhookProps } from 'contentful-management'
+import type { AssetProps, ComponentTypeProps, ContentTypeProps, DataAssemblyProps, EntryProps, ExperienceProps, FragmentProps, LocaleProps, TagProps, TemplateProps, WebhookProps } from 'contentful-management'
 import { OriginalSourceData } from '../types'
 import PQueue from 'p-queue'
 
@@ -119,6 +119,21 @@ function getPagedBatches(totalFetched: number, total: number) {
   return batches
 }
 
+async function fetchAllExoEntities<T>(
+  fetchPage: (pageNext?: string) => Promise<{ items: T[], pages: { next?: string } }>
+): Promise<T[]> {
+  const all: T[] = []
+  let pageNext: string | undefined = undefined
+
+  do {
+    const response = await fetchPage(pageNext)
+    all.push(...response.items)
+    pageNext = response.pages?.next
+  } while (pageNext)
+
+  return all
+}
+
 type AllDestinationData = {
   contentTypes: Promise<ContentTypeProps[]>
   tags: Promise<TagProps[]>
@@ -127,16 +142,24 @@ type AllDestinationData = {
   assets: Promise<AssetProps[]>
   // TODO Why are webhooks optional?
   webhooks?: Promise<WebhookProps[]>
+  componentTypes?: Promise<ComponentTypeProps[]>
+  templates?: Promise<TemplateProps[]>
+  fragments?: Promise<FragmentProps[]>
+  dataAssemblies?: Promise<DataAssemblyProps[]>
+  experiences?: Promise<ExperienceProps[]>
+  // TODO: add designTokens once the contentful-management SDK exposes a designToken plain client API
 }
 
 type GetDestinationDataParams = {
   client: any
+  plainClient?: any
   spaceId: string
   environmentId: string
   sourceData: OriginalSourceData
   contentModelOnly?: boolean
   skipLocales?: boolean
   skipContentModel?: boolean
+  includeExperienceOrchestration?: boolean
   requestQueue: PQueue
 }
 
@@ -151,12 +174,14 @@ type GetDestinationDataParams = {
 
 export default async function getDestinationData ({
   client,
+  plainClient,
   spaceId,
   environmentId,
   sourceData,
   contentModelOnly,
   skipLocales,
   skipContentModel,
+  includeExperienceOrchestration,
   requestQueue
 }: GetDestinationDataParams) {
   const space = await client.getSpace(spaceId)
@@ -231,6 +256,45 @@ export default async function getDestinationData ({
   }
 
   result.webhooks = []
+
+  if (includeExperienceOrchestration && plainClient) {
+    result.componentTypes = fetchAllExoEntities((pageNext) =>
+      plainClient.componentType.getMany({ spaceId, environmentId, query: { limit: BATCH_SIZE_LIMIT, ...(pageNext && { pageNext }) } })
+    ).then((items) => {
+      logEmitter.emit('info', `Fetched ${items.length} destination component types`)
+      return items
+    })
+
+    result.templates = fetchAllExoEntities((pageNext) =>
+      plainClient.template.getMany({ spaceId, environmentId, query: { limit: BATCH_SIZE_LIMIT, ...(pageNext && { pageNext }) } })
+    ).then((items) => {
+      logEmitter.emit('info', `Fetched ${items.length} destination templates`)
+      return items
+    })
+
+    result.fragments = fetchAllExoEntities((pageNext) =>
+      plainClient.fragment.getMany({ spaceId, environmentId, query: { limit: BATCH_SIZE_LIMIT, ...(pageNext && { pageNext }) } })
+    ).then((items) => {
+      logEmitter.emit('info', `Fetched ${items.length} destination fragments`)
+      return items
+    })
+
+    result.dataAssemblies = fetchAllExoEntities((pageNext) =>
+      plainClient.dataAssembly.getMany({ spaceId, environmentId, query: { limit: BATCH_SIZE_LIMIT, ...(pageNext && { pageNext }) } })
+    ).then((items) => {
+      logEmitter.emit('info', `Fetched ${items.length} destination data assemblies`)
+      return items
+    })
+
+    result.experiences = fetchAllExoEntities((pageNext) =>
+      plainClient.experience.getMany({ spaceId, environmentId, query: { limit: BATCH_SIZE_LIMIT, ...(pageNext && { pageNext }) } })
+    ).then((items) => {
+      logEmitter.emit('info', `Fetched ${items.length} destination experiences`)
+      return items
+    })
+
+    // TODO: fetch destination designTokens here once the contentful-management SDK exposes a designToken plain client API
+  }
 
   return Promise.props(result)
 }

--- a/lib/tasks/get-destination-data.ts
+++ b/lib/tasks/get-destination-data.ts
@@ -8,7 +8,7 @@ import PQueue from 'p-queue'
 const BATCH_CHAR_LIMIT = 1990
 const BATCH_SIZE_LIMIT = 100
 
-const METHODS = {
+const OFFSET_QUERY_METHODS = {
   contentTypes: { name: 'content types', method: 'getContentTypes' },
   locales: { name: 'locales', method: 'getLocales' },
   entries: { name: 'entries', method: 'getEntries' },
@@ -16,18 +16,35 @@ const METHODS = {
   tags: { name: 'tags', method: 'getTags' }
 }
 
+const CURSOR_QUERY_METHODS = {
+  componentTypes: { name: 'component types', namespace: 'componentType' },
+  templates: { name: 'templates', namespace: 'template' },
+  fragments: { name: 'fragments', namespace: 'fragment' },
+  dataAssemblies: { name: 'data assemblies', namespace: 'dataAssembly' },
+  experiences: { name: 'experiences', namespace: 'experience' }
+  // TODO: add designTokens once the contentful-management SDK exposes a designToken plain client API
+}
+
 type BatchedIdQueryParams = {
   requestQueue: PQueue
   environment: any
-  type: keyof typeof METHODS
+  type: keyof typeof OFFSET_QUERY_METHODS
   ids: string[]
 }
 
 type BatchedPageQueryParams = Omit<BatchedIdQueryParams, 'ids'>
 
-async function batchedIdQuery ({ environment, type, ids, requestQueue }: BatchedIdQueryParams) {
-  const method = METHODS[type].method
-  const entityTypeName = METHODS[type].name
+type CursorPaginatedQueryParams = {
+  requestQueue: PQueue
+  plainClient: any
+  spaceId: string
+  environmentId: string
+  type: keyof typeof CURSOR_QUERY_METHODS
+}
+
+async function batchedIdQuery({ environment, type, ids, requestQueue }: BatchedIdQueryParams) {
+  const method = OFFSET_QUERY_METHODS[type].method
+  const entityTypeName = OFFSET_QUERY_METHODS[type].name
   const batches = getIdBatches(ids)
 
   let totalFetched = 0
@@ -51,9 +68,9 @@ async function batchedIdQuery ({ environment, type, ids, requestQueue }: Batched
   return responses.flat()
 }
 
-async function batchedPageQuery ({ environment, type, requestQueue }: BatchedPageQueryParams) {
-  const method = METHODS[type].method
-  const entityTypeName = METHODS[type].name
+async function batchedPageQuery({ environment, type, requestQueue }: BatchedPageQueryParams) {
+  const method = OFFSET_QUERY_METHODS[type].method
+  const entityTypeName = OFFSET_QUERY_METHODS[type].name
 
   let totalFetched = 0
   const { items, total } = await requestQueue.add(async () => {
@@ -86,7 +103,7 @@ async function batchedPageQuery ({ environment, type, requestQueue }: BatchedPag
   return items.concat(remainingResponses.flat())
 }
 
-function getIdBatches (ids) {
+function getIdBatches(ids) {
   const batches: string[] = []
   let currentBatch = ''
   let currentSize = 0
@@ -119,19 +136,29 @@ function getPagedBatches(totalFetched: number, total: number) {
   return batches
 }
 
-async function fetchAllExoEntities<T>(
-  fetchPage: (pageNext?: string) => Promise<{ items: T[], pages: { next?: string } }>
-): Promise<T[]> {
-  const all: T[] = []
+async function cursorPaginatedQuery ({ plainClient, spaceId, environmentId, type, requestQueue }: CursorPaginatedQueryParams) {
+  const { name: entityTypeName, namespace } = CURSOR_QUERY_METHODS[type]
+
+  let totalFetched = 0
   let pageNext: string | undefined = undefined
+  const allItems: any[] = []
 
   do {
-    const response = await fetchPage(pageNext)
-    all.push(...response.items)
-    pageNext = response.pages?.next
+    const items: any[] = await requestQueue.add(async () => {
+      const response = await plainClient[namespace].getMany({
+        spaceId,
+        environmentId,
+        query: { limit: BATCH_SIZE_LIMIT, ...(pageNext && { pageNext }) }
+      })
+      totalFetched += response.items.length
+      logEmitter.emit('info', `Fetched ${totalFetched} ${entityTypeName}`)
+      pageNext = response.pages?.next
+      return response.items
+    })
+    allItems.push(...items)
   } while (pageNext)
 
-  return all
+  return allItems
 }
 
 type AllDestinationData = {
@@ -140,7 +167,6 @@ type AllDestinationData = {
   locales: Promise<LocaleProps[]>
   entries: Promise<EntryProps[]>
   assets: Promise<AssetProps[]>
-  // TODO Why are webhooks optional?
   webhooks?: Promise<WebhookProps[]>
   componentTypes?: Promise<ComponentTypeProps[]>
   templates?: Promise<TemplateProps[]>
@@ -172,7 +198,7 @@ type GetDestinationDataParams = {
  *
  */
 
-export default async function getDestinationData ({
+export default async function getDestinationData({
   client,
   plainClient,
   spaceId,
@@ -191,7 +217,14 @@ export default async function getDestinationData ({
     tags: [],
     locales: [],
     entries: [],
-    assets: []
+    assets: [],
+    experiences: [],
+    templates: [],
+    componentTypes: [],
+    fragments: [],
+    dataAssemblies: [],
+    // designTokens: [], // TODO: add designTokens once the contentful-management SDK exposes a designToken plain client API
+    webhooks: [],
   }
 
   // Make sure all required properties are available and at least an empty array
@@ -238,7 +271,7 @@ export default async function getDestinationData ({
 
   const entryIds = sourceData.entries?.map((e) => e.sys.id)
   const assetIds = sourceData.assets?.map((e) => e.sys.id)
-  if (entryIds) {
+  if (entryIds && entryIds.length) {
     result.entries = batchedIdQuery({
       environment,
       type: 'entries',
@@ -246,7 +279,7 @@ export default async function getDestinationData ({
       requestQueue
     })
   }
-  if (assetIds) {
+  if (assetIds && assetIds.length) {
     result.assets = batchedIdQuery({
       environment,
       type: 'assets',
@@ -255,44 +288,12 @@ export default async function getDestinationData ({
     })
   }
 
-  result.webhooks = []
-
   if (includeExperienceOrchestration && plainClient) {
-    result.componentTypes = fetchAllExoEntities((pageNext) =>
-      plainClient.componentType.getMany({ spaceId, environmentId, query: { limit: BATCH_SIZE_LIMIT, ...(pageNext && { pageNext }) } })
-    ).then((items) => {
-      logEmitter.emit('info', `Fetched ${items.length} destination component types`)
-      return items
-    })
-
-    result.templates = fetchAllExoEntities((pageNext) =>
-      plainClient.template.getMany({ spaceId, environmentId, query: { limit: BATCH_SIZE_LIMIT, ...(pageNext && { pageNext }) } })
-    ).then((items) => {
-      logEmitter.emit('info', `Fetched ${items.length} destination templates`)
-      return items
-    })
-
-    result.fragments = fetchAllExoEntities((pageNext) =>
-      plainClient.fragment.getMany({ spaceId, environmentId, query: { limit: BATCH_SIZE_LIMIT, ...(pageNext && { pageNext }) } })
-    ).then((items) => {
-      logEmitter.emit('info', `Fetched ${items.length} destination fragments`)
-      return items
-    })
-
-    result.dataAssemblies = fetchAllExoEntities((pageNext) =>
-      plainClient.dataAssembly.getMany({ spaceId, environmentId, query: { limit: BATCH_SIZE_LIMIT, ...(pageNext && { pageNext }) } })
-    ).then((items) => {
-      logEmitter.emit('info', `Fetched ${items.length} destination data assemblies`)
-      return items
-    })
-
-    result.experiences = fetchAllExoEntities((pageNext) =>
-      plainClient.experience.getMany({ spaceId, environmentId, query: { limit: BATCH_SIZE_LIMIT, ...(pageNext && { pageNext }) } })
-    ).then((items) => {
-      logEmitter.emit('info', `Fetched ${items.length} destination experiences`)
-      return items
-    })
-
+    result.componentTypes = cursorPaginatedQuery({ plainClient, spaceId, environmentId, type: 'componentTypes', requestQueue })
+    result.templates = cursorPaginatedQuery({ plainClient, spaceId, environmentId, type: 'templates', requestQueue })
+    result.fragments = cursorPaginatedQuery({ plainClient, spaceId, environmentId, type: 'fragments', requestQueue })
+    result.dataAssemblies = cursorPaginatedQuery({ plainClient, spaceId, environmentId, type: 'dataAssemblies', requestQueue })
+    result.experiences = cursorPaginatedQuery({ plainClient, spaceId, environmentId, type: 'experiences', requestQueue })
     // TODO: fetch destination designTokens here once the contentful-management SDK exposes a designToken plain client API
   }
 

--- a/lib/tasks/push-to-space/push-to-space.ts
+++ b/lib/tasks/push-to-space/push-to-space.ts
@@ -69,11 +69,11 @@ type PushToSpaceParams = {
  */
 
 export type PushToSpaceContext = {
-    type: string,
-    target: any,
+  type: string,
+  target: any,
 }
 
-export default function pushToSpace ({
+export default function pushToSpace({
   sourceData,
   destinationData = {},
   client,
@@ -286,7 +286,7 @@ export default function pushToSpace ({
           return
         }
         const assetsToProcess = await creation.createEntities({
-          context: { target: ctx.environment, type: 'Asset'},
+          context: { target: ctx.environment, type: 'Asset' },
           entities: sourceData.assets,
           destinationEntitiesById: destinationDataById.assets,
           skipUpdates: skipAssetUpdates,
@@ -387,8 +387,12 @@ export default function pushToSpace ({
       task: wrapTask(async (ctx) => {
         const results = await Promise.all((sourceData.componentTypes || []).map(async (entity) => {
           try {
-            const result = await plainClient.componentType.upsert({ spaceId, environmentId, componentTypeId: entity.sys.id }, omitSys(entity))
-            logEmitter.emit('info', `UPSERT ComponentType ${entity.sys.id}`)
+            const existing = destinationDataById.componentTypes?.get(entity.sys.id)
+            const payload = existing
+              ? { ...omitSys(entity), sys: { id: entity.sys.id, type: 'ComponentType', version: existing.sys.version } }
+              : omitSys(entity)
+            const result = await plainClient.componentType.upsert({ spaceId, environmentId, componentTypeId: entity.sys.id }, payload)
+            logEmitter.emit('info', `${existing ? 'UPDATE' : 'CREATE'} ComponentType ${entity.sys.id}`)
             return result
           } catch (err) {
             logEmitter.emit('error', err)
@@ -404,8 +408,12 @@ export default function pushToSpace ({
       task: wrapTask(async (ctx) => {
         const results = await Promise.all((sourceData.templates || []).map(async (entity) => {
           try {
-            const result = await plainClient.template.upsert({ spaceId, environmentId, templateId: entity.sys.id }, omitSys(entity))
-            logEmitter.emit('info', `UPSERT Template ${entity.sys.id}`)
+            const existing = destinationDataById.templates?.get(entity.sys.id)
+            const payload = existing
+              ? { ...omitSys(entity), sys: { id: entity.sys.id, type: 'Template', version: existing.sys.version } }
+              : omitSys(entity)
+            const result = await plainClient.template.upsert({ spaceId, environmentId, templateId: entity.sys.id }, payload)
+            logEmitter.emit('info', `${existing ? 'UPDATE' : 'CREATE'} Template ${entity.sys.id}`)
             return result
           } catch (err) {
             logEmitter.emit('error', err)
@@ -421,8 +429,12 @@ export default function pushToSpace ({
       task: wrapTask(async (ctx) => {
         const results = await Promise.all((sourceData.fragments || []).map(async (entity) => {
           try {
-            const result = await plainClient.fragment.upsert({ spaceId, environmentId, fragmentId: entity.sys.id }, omitSys(entity))
-            logEmitter.emit('info', `UPSERT Fragment ${entity.sys.id}`)
+            const existing = destinationDataById.fragments?.get(entity.sys.id)
+            const payload = existing
+              ? { ...omitSys(entity), sys: { id: entity.sys.id, type: 'Fragment', version: existing.sys.version } }
+              : omitSys(entity)
+            const result = await plainClient.fragment.upsert({ spaceId, environmentId, fragmentId: entity.sys.id }, payload)
+            logEmitter.emit('info', `${existing ? 'UPDATE' : 'CREATE'} Fragment ${entity.sys.id}`)
             return result
           } catch (err) {
             logEmitter.emit('error', err)
@@ -438,18 +450,18 @@ export default function pushToSpace ({
       task: wrapTask(async (ctx) => {
         const results = await Promise.all((sourceData.dataAssemblies || []).map(async (entity) => {
           try {
+            const existing = destinationDataById.dataAssemblies?.get(entity.sys.id)
             let result
-            try {
-              const existing = await plainClient.dataAssembly.get({ spaceId, environmentId, dataAssemblyId: entity.sys.id })
-              result = await plainClient.dataAssembly.update({ spaceId, environmentId, dataAssemblyId: entity.sys.id }, { ...omitSys(entity), sys: { version: existing.sys.version } })
-            } catch (getErr: any) {
-              if (getErr.status === 404) {
-                result = await plainClient.dataAssembly.create({ spaceId, environmentId }, omitSys(entity))
-              } else {
-                throw getErr
-              }
+            if (existing) {
+              result = await plainClient.dataAssembly.update(
+                { spaceId, environmentId, dataAssemblyId: entity.sys.id },
+                { ...omitSys(entity), sys: { version: existing.sys.version } }
+              )
+              logEmitter.emit('info', `UPDATE DataAssembly ${entity.sys.id}`)
+            } else {
+              result = await plainClient.dataAssembly.create({ spaceId, environmentId }, omitSys(entity))
+              logEmitter.emit('info', `CREATE DataAssembly ${entity.sys.id}`)
             }
-            logEmitter.emit('info', `UPSERT DataAssembly ${entity.sys.id}`)
             return result
           } catch (err) {
             logEmitter.emit('error', err)
@@ -465,8 +477,12 @@ export default function pushToSpace ({
       task: wrapTask(async (ctx) => {
         const results = await Promise.all((sourceData.experiences || []).map(async (entity) => {
           try {
-            const result = await plainClient.experience.upsert({ spaceId, environmentId, experienceId: entity.sys.id }, omitSys(entity))
-            logEmitter.emit('info', `UPSERT Experience ${entity.sys.id}`)
+            const existing = destinationDataById.experiences?.get(entity.sys.id)
+            const payload = existing
+              ? { ...omitSys(entity), sys: { id: entity.sys.id, type: 'Experience', version: existing.sys.version } }
+              : omitSys(entity)
+            const result = await plainClient.experience.upsert({ spaceId, environmentId, experienceId: entity.sys.id }, payload)
+            logEmitter.emit('info', `${existing ? 'UPDATE' : 'CREATE'} Experience ${entity.sys.id}`)
             return result
           } catch (err) {
             logEmitter.emit('error', err)
@@ -477,16 +493,17 @@ export default function pushToSpace ({
       }),
       skip: () => !includeExperienceOrchestration || !(sourceData.experiences || []).length
     }
+    // TODO: add 'Importing Design Tokens' task once the contentful-management SDK exposes a designToken plain client API
   ], listrOptions)
 }
 
-function omitSys (entity) {
+function omitSys(entity) {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { sys: _sys, ...rest } = entity
   return rest
 }
 
-function archiveEntities ({ entities, sourceEntities, requestQueue }) {
+function archiveEntities({ entities, sourceEntities, requestQueue }) {
   const entityIdsToArchive = sourceEntities
     .filter(({ original }) => original.sys.archivedVersion)
     .map(({ original }) => original.sys.id)
@@ -497,7 +514,7 @@ function archiveEntities ({ entities, sourceEntities, requestQueue }) {
   return publishing.archiveEntities({ entities: entitiesToArchive, requestQueue })
 }
 
-function publishEntities ({ entities, sourceEntities, requestQueue }) {
+function publishEntities({ entities, sourceEntities, requestQueue }) {
   // Find all entities in source content which are published
   const entityIdsToPublish = sourceEntities
     .filter(({ original }) => original.sys.publishedVersion)

--- a/test/unit/tasks/get-destination-data-exo.test.ts
+++ b/test/unit/tasks/get-destination-data-exo.test.ts
@@ -1,0 +1,255 @@
+import PQueue from 'p-queue'
+
+import getDestinationData from '../../../lib/tasks/get-destination-data'
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeEntity(id: string) {
+  return { sys: { id, version: 1 } }
+}
+
+// Simulates a cursor-paginated ExO endpoint: returns items in pages of `pageSize`,
+// encoding a `pageNext` token when more pages exist.
+function makeCursorResolver(items: any[], pageSize = 100) {
+  return jest.fn(({ query }: { query: any }) => {
+    const token = query?.pageNext ? parseInt(query.pageNext, 10) : 0
+    const page = items.slice(token, token + pageSize)
+    const next = token + pageSize < items.length ? String(token + pageSize) : undefined
+    return Promise.resolve({ items: page, pages: next ? { next } : undefined })
+  })
+}
+
+function makeOffsetResolver(items: any[]) {
+  return jest.fn((query: any) => {
+    const skip = query?.skip ?? 0
+    const limit = query?.limit ?? 100
+    return Promise.resolve({ items: items.slice(skip, skip + limit), total: items.length })
+  })
+}
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const exoItems = {
+  componentTypes: Array.from({ length: 5 }, (_, i) => makeEntity(`ct-${i}`)),
+  templates: Array.from({ length: 3 }, (_, i) => makeEntity(`tmpl-${i}`)),
+  fragments: Array.from({ length: 4 }, (_, i) => makeEntity(`frag-${i}`)),
+  dataAssemblies: Array.from({ length: 2 }, (_, i) => makeEntity(`da-${i}`)),
+  experiences: Array.from({ length: 6 }, (_, i) => makeEntity(`exp-${i}`))
+}
+
+function makePlainClientMock() {
+  return {
+    componentType: { getMany: makeCursorResolver(exoItems.componentTypes) },
+    template: { getMany: makeCursorResolver(exoItems.templates) },
+    fragment: { getMany: makeCursorResolver(exoItems.fragments) },
+    dataAssembly: { getMany: makeCursorResolver(exoItems.dataAssemblies) },
+    experience: { getMany: makeCursorResolver(exoItems.experiences) }
+  }
+}
+
+const mockEnvironment = {
+  getContentTypes: jest.fn((q: any) =>
+    Promise.resolve({ items: (q['sys.id[in]'] as string).split(',').map((id) => ({ sys: { id } })) })
+  ),
+  getEntries: jest.fn(() => Promise.resolve({ items: [] })),
+  getAssets: jest.fn(() => Promise.resolve({ items: [] })),
+  getLocales: jest.fn(makeOffsetResolver([])),
+  getTags: jest.fn(makeOffsetResolver([]))
+}
+
+const mockSpace = {
+  getEnvironment: jest.fn(() => Promise.resolve(mockEnvironment))
+}
+
+const mockClient = {
+  getSpace: jest.fn(() => Promise.resolve(mockSpace))
+}
+
+let requestQueue: PQueue
+
+beforeEach(() => {
+  requestQueue = new PQueue({ interval: 1000, intervalCap: 1000 })
+  jest.clearAllMocks()
+  mockEnvironment.getContentTypes.mockImplementation((q: any) =>
+    Promise.resolve({ items: (q['sys.id[in]'] as string).split(',').map((id) => ({ sys: { id } })) })
+  )
+  mockEnvironment.getEntries.mockResolvedValue({ items: [] })
+  mockEnvironment.getAssets.mockResolvedValue({ items: [] })
+  mockEnvironment.getLocales.mockImplementation(makeOffsetResolver([]))
+  mockEnvironment.getTags.mockImplementation(makeOffsetResolver([]))
+  mockSpace.getEnvironment.mockResolvedValue(mockEnvironment)
+  mockClient.getSpace.mockResolvedValue(mockSpace)
+})
+
+// ─── Cursor pagination is only used for ExO entities ─────────────────────────
+
+test('uses cursor pagination for ExO entities, not for standard entities', async () => {
+  const plainClient = makePlainClientMock()
+  await getDestinationData({
+    client: mockClient,
+    plainClient,
+    spaceId: 'space-1',
+    environmentId: 'master',
+    sourceData: { contentTypes: [makeEntity('ct-x') as any] },
+    includeExperienceOrchestration: true,
+    requestQueue
+  })
+
+  // Standard entity: environment method was called (offset-based)
+  expect(mockEnvironment.getContentTypes).toHaveBeenCalled()
+  // ExO entity: plainClient cursor method was called, NOT an environment method
+  expect(plainClient.componentType.getMany).toHaveBeenCalled()
+  // Cursor query shape: must include a `limit`, never a `skip`
+  const callArg = plainClient.componentType.getMany.mock.calls[0][0] as any
+  expect(callArg.query).toHaveProperty('limit')
+  expect(callArg.query).not.toHaveProperty('skip')
+})
+
+test('does NOT call plainClient ExO methods when includeExperienceOrchestration is false', async () => {
+  const plainClient = makePlainClientMock()
+  await getDestinationData({
+    client: mockClient,
+    plainClient,
+    spaceId: 'space-1',
+    environmentId: 'master',
+    sourceData: {},
+    includeExperienceOrchestration: false,
+    requestQueue
+  })
+
+  expect(plainClient.componentType.getMany).not.toHaveBeenCalled()
+  expect(plainClient.template.getMany).not.toHaveBeenCalled()
+  expect(plainClient.fragment.getMany).not.toHaveBeenCalled()
+  expect(plainClient.dataAssembly.getMany).not.toHaveBeenCalled()
+  expect(plainClient.experience.getMany).not.toHaveBeenCalled()
+})
+
+test('follows pageNext cursor across multiple pages', async () => {
+  // 150 items, page size 100 → 2 pages
+  const manyItems = Array.from({ length: 150 }, (_, i) => makeEntity(`ct-${i}`))
+  const plainClient = {
+    ...makePlainClientMock(),
+    componentType: { getMany: makeCursorResolver(manyItems, 100) }
+  }
+
+  const result = await getDestinationData({
+    client: mockClient,
+    plainClient,
+    spaceId: 'space-1',
+    environmentId: 'master',
+    sourceData: {},
+    includeExperienceOrchestration: true,
+    requestQueue
+  })
+
+  expect(plainClient.componentType.getMany).toHaveBeenCalledTimes(2)
+  expect(result.componentTypes).toHaveLength(150)
+})
+
+// ─── Returns destination data for all ExO entities ───────────────────────────
+
+test('returns destination componentTypes fetched via cursor pagination', async () => {
+  const plainClient = makePlainClientMock()
+  const result = await getDestinationData({
+    client: mockClient,
+    plainClient,
+    spaceId: 'space-1',
+    environmentId: 'master',
+    sourceData: {},
+    includeExperienceOrchestration: true,
+    requestQueue
+  })
+
+  expect(result.componentTypes).toHaveLength(exoItems.componentTypes.length)
+  expect(result.componentTypes![0].sys.id).toBe('ct-0')
+})
+
+test('returns destination templates fetched via cursor pagination', async () => {
+  const plainClient = makePlainClientMock()
+  const result = await getDestinationData({
+    client: mockClient,
+    plainClient,
+    spaceId: 'space-1',
+    environmentId: 'master',
+    sourceData: {},
+    includeExperienceOrchestration: true,
+    requestQueue
+  })
+
+  expect(result.templates).toHaveLength(exoItems.templates.length)
+  expect(result.templates![0].sys.id).toBe('tmpl-0')
+})
+
+test('returns destination fragments fetched via cursor pagination', async () => {
+  const plainClient = makePlainClientMock()
+  const result = await getDestinationData({
+    client: mockClient,
+    plainClient,
+    spaceId: 'space-1',
+    environmentId: 'master',
+    sourceData: {},
+    includeExperienceOrchestration: true,
+    requestQueue
+  })
+
+  expect(result.fragments).toHaveLength(exoItems.fragments.length)
+  expect(result.fragments![0].sys.id).toBe('frag-0')
+})
+
+test('returns destination dataAssemblies fetched via cursor pagination', async () => {
+  const plainClient = makePlainClientMock()
+  const result = await getDestinationData({
+    client: mockClient,
+    plainClient,
+    spaceId: 'space-1',
+    environmentId: 'master',
+    sourceData: {},
+    includeExperienceOrchestration: true,
+    requestQueue
+  })
+
+  expect(result.dataAssemblies).toHaveLength(exoItems.dataAssemblies.length)
+  expect(result.dataAssemblies![0].sys.id).toBe('da-0')
+})
+
+test('returns destination experiences fetched via cursor pagination', async () => {
+  const plainClient = makePlainClientMock()
+  const result = await getDestinationData({
+    client: mockClient,
+    plainClient,
+    spaceId: 'space-1',
+    environmentId: 'master',
+    sourceData: {},
+    includeExperienceOrchestration: true,
+    requestQueue
+  })
+
+  expect(result.experiences).toHaveLength(exoItems.experiences.length)
+  expect(result.experiences![0].sys.id).toBe('exp-0')
+})
+
+test('returns empty arrays for all ExO entities when none exist in destination', async () => {
+  const emptyPlainClient = {
+    componentType: { getMany: jest.fn(() => Promise.resolve({ items: [] })) },
+    template: { getMany: jest.fn(() => Promise.resolve({ items: [] })) },
+    fragment: { getMany: jest.fn(() => Promise.resolve({ items: [] })) },
+    dataAssembly: { getMany: jest.fn(() => Promise.resolve({ items: [] })) },
+    experience: { getMany: jest.fn(() => Promise.resolve({ items: [] })) }
+  }
+
+  const result = await getDestinationData({
+    client: mockClient,
+    plainClient: emptyPlainClient,
+    spaceId: 'space-1',
+    environmentId: 'master',
+    sourceData: {},
+    includeExperienceOrchestration: true,
+    requestQueue
+  })
+
+  expect(result.componentTypes).toHaveLength(0)
+  expect(result.templates).toHaveLength(0)
+  expect(result.fragments).toHaveLength(0)
+  expect(result.dataAssemblies).toHaveLength(0)
+  expect(result.experiences).toHaveLength(0)
+})

--- a/test/unit/tasks/push/push-to-space-exo.test.ts
+++ b/test/unit/tasks/push/push-to-space-exo.test.ts
@@ -1,0 +1,294 @@
+import PQueue from 'p-queue'
+
+import pushToSpace from '../../../../lib/tasks/push-to-space/push-to-space'
+
+// Minimal base source data needed to satisfy the Listr tasks that always run
+const baseSourceData = {
+  locales: [],
+  contentTypes: [],
+  assets: [],
+  editorInterfaces: [],
+  entries: [],
+  tags: [],
+  webhooks: []
+}
+
+const baseDestinationData = {}
+
+function makeClientMock() {
+  return {
+    getSpace: jest.fn(() => Promise.resolve({
+      getEnvironment: jest.fn(() => Promise.resolve({
+        getEditorInterfaceForContentType: jest.fn(() => Promise.resolve({ update: jest.fn() }))
+      }))
+    }))
+  }
+}
+
+function makePlainClientMock() {
+  return {
+    componentType: { upsert: jest.fn(() => Promise.resolve({ sys: { id: 'ct-1' } })) },
+    template: { upsert: jest.fn(() => Promise.resolve({ sys: { id: 'tmpl-1' } })) },
+    fragment: { upsert: jest.fn(() => Promise.resolve({ sys: { id: 'frag-1' } })) },
+    dataAssembly: {
+      update: jest.fn(() => Promise.resolve({ sys: { id: 'da-1' } })),
+      create: jest.fn(() => Promise.resolve({ sys: { id: 'da-1' } }))
+    },
+    experience: { upsert: jest.fn(() => Promise.resolve({ sys: { id: 'exp-1' } })) }
+  }
+}
+
+let requestQueue: PQueue
+
+beforeEach(() => {
+  requestQueue = new PQueue({ interval: 1000, intervalCap: 1000 })
+})
+
+// ─── ComponentType ────────────────────────────────────────────────────────────
+
+describe('Importing Component Types', () => {
+  const entity: any = { sys: { id: 'ct-1', type: 'ComponentType', version: 3 }, name: 'Hero' }
+
+  test('CREATE: calls upsert without sys when entity does not exist in destination', async () => {
+    const plainClient = makePlainClientMock()
+    await pushToSpace({
+      sourceData: { ...baseSourceData, componentTypes: [entity] } as any,
+      destinationData: { ...baseDestinationData, componentTypes: [] },
+      client: makeClientMock(),
+      plainClient,
+      spaceId: 'space-1',
+      environmentId: 'master',
+      includeExperienceOrchestration: true,
+      requestQueue
+    }).run({ data: {} })
+
+    expect(plainClient.componentType.upsert).toHaveBeenCalledTimes(1)
+    const [params, payload] = plainClient.componentType.upsert.mock.calls[0] as unknown as [any, any]
+    expect(params).toEqual({ spaceId: 'space-1', environmentId: 'master', componentTypeId: 'ct-1' })
+    expect(payload).not.toHaveProperty('sys')
+    expect(payload.name).toBe('Hero')
+  })
+
+  test('UPDATE: calls upsert with destination sys.version when entity exists in destination', async () => {
+    const plainClient = makePlainClientMock()
+    const destinationEntity: any = { sys: { id: 'ct-1', type: 'ComponentType', version: 7 } }
+    await pushToSpace({
+      sourceData: { ...baseSourceData, componentTypes: [entity] } as any,
+      destinationData: { ...baseDestinationData, componentTypes: [destinationEntity] },
+      client: makeClientMock(),
+      plainClient,
+      spaceId: 'space-1',
+      environmentId: 'master',
+      includeExperienceOrchestration: true,
+      requestQueue
+    }).run({ data: {} })
+
+    expect(plainClient.componentType.upsert).toHaveBeenCalledTimes(1)
+    const [params, payload] = plainClient.componentType.upsert.mock.calls[0] as unknown as [any, any]
+    expect(params).toEqual({ spaceId: 'space-1', environmentId: 'master', componentTypeId: 'ct-1' })
+    expect(payload.sys.version).toBe(7)
+    expect(payload.name).toBe('Hero')
+  })
+
+  test('skips task when includeExperienceOrchestration is false', async () => {
+    const plainClient = makePlainClientMock()
+    await pushToSpace({
+      sourceData: { ...baseSourceData, componentTypes: [entity] } as any,
+      destinationData: baseDestinationData,
+      client: makeClientMock(),
+      plainClient,
+      spaceId: 'space-1',
+      environmentId: 'master',
+      includeExperienceOrchestration: false,
+      requestQueue
+    }).run({ data: {} })
+
+    expect(plainClient.componentType.upsert).not.toHaveBeenCalled()
+  })
+})
+
+// ─── Template ─────────────────────────────────────────────────────────────────
+
+describe('Importing Templates', () => {
+  const entity: any = { sys: { id: 'tmpl-1', type: 'Template', version: 2 }, name: 'Landing Page' }
+
+  test('CREATE: calls upsert without sys when entity does not exist in destination', async () => {
+    const plainClient = makePlainClientMock()
+    await pushToSpace({
+      sourceData: { ...baseSourceData, templates: [entity] } as any,
+      destinationData: { ...baseDestinationData, templates: [] },
+      client: makeClientMock(),
+      plainClient,
+      spaceId: 'space-1',
+      environmentId: 'master',
+      includeExperienceOrchestration: true,
+      requestQueue
+    }).run({ data: {} })
+
+    expect(plainClient.template.upsert).toHaveBeenCalledTimes(1)
+    const [params, payload] = plainClient.template.upsert.mock.calls[0] as unknown as [any, any]
+    expect(params).toEqual({ spaceId: 'space-1', environmentId: 'master', templateId: 'tmpl-1' })
+    expect(payload).not.toHaveProperty('sys')
+    expect(payload.name).toBe('Landing Page')
+  })
+
+  test('UPDATE: calls upsert with destination sys.version when entity exists in destination', async () => {
+    const plainClient = makePlainClientMock()
+    const destinationEntity: any = { sys: { id: 'tmpl-1', type: 'Template', version: 5 } }
+    await pushToSpace({
+      sourceData: { ...baseSourceData, templates: [entity] } as any,
+      destinationData: { ...baseDestinationData, templates: [destinationEntity] },
+      client: makeClientMock(),
+      plainClient,
+      spaceId: 'space-1',
+      environmentId: 'master',
+      includeExperienceOrchestration: true,
+      requestQueue
+    }).run({ data: {} })
+
+    const [params, payload] = plainClient.template.upsert.mock.calls[0] as unknown as [any, any]
+    expect(params).toEqual({ spaceId: 'space-1', environmentId: 'master', templateId: 'tmpl-1' })
+    expect(payload.sys.version).toBe(5)
+    expect(payload.name).toBe('Landing Page')
+  })
+})
+
+// ─── Fragment ─────────────────────────────────────────────────────────────────
+
+describe('Importing Fragments', () => {
+  const entity: any = { sys: { id: 'frag-1', type: 'Fragment', version: 1 }, name: 'Hero Fragment' }
+
+  test('CREATE: calls upsert without sys when entity does not exist in destination', async () => {
+    const plainClient = makePlainClientMock()
+    await pushToSpace({
+      sourceData: { ...baseSourceData, fragments: [entity] } as any,
+      destinationData: { ...baseDestinationData, fragments: [] },
+      client: makeClientMock(),
+      plainClient,
+      spaceId: 'space-1',
+      environmentId: 'master',
+      includeExperienceOrchestration: true,
+      requestQueue
+    }).run({ data: {} })
+
+    expect(plainClient.fragment.upsert).toHaveBeenCalledTimes(1)
+    const [params, payload] = plainClient.fragment.upsert.mock.calls[0] as unknown as [any, any]
+    expect(params).toEqual({ spaceId: 'space-1', environmentId: 'master', fragmentId: 'frag-1' })
+    expect(payload).not.toHaveProperty('sys')
+    expect(payload.name).toBe('Hero Fragment')
+  })
+
+  test('UPDATE: calls upsert with destination sys.version when entity exists in destination', async () => {
+    const plainClient = makePlainClientMock()
+    const destinationEntity: any = { sys: { id: 'frag-1', type: 'Fragment', version: 4 } }
+    await pushToSpace({
+      sourceData: { ...baseSourceData, fragments: [entity] } as any,
+      destinationData: { ...baseDestinationData, fragments: [destinationEntity] },
+      client: makeClientMock(),
+      plainClient,
+      spaceId: 'space-1',
+      environmentId: 'master',
+      includeExperienceOrchestration: true,
+      requestQueue
+    }).run({ data: {} })
+
+    const [params, payload] = plainClient.fragment.upsert.mock.calls[0] as unknown as [any, any]
+    expect(params).toEqual({ spaceId: 'space-1', environmentId: 'master', fragmentId: 'frag-1' })
+    expect(payload.sys.version).toBe(4)
+  })
+})
+
+// ─── DataAssembly ─────────────────────────────────────────────────────────────
+
+describe('Importing Data Assemblies', () => {
+  const entity: any = { sys: { id: 'da-1', type: 'DataAssembly', version: 2 }, name: 'My Assembly' }
+
+  test('CREATE: calls dataAssembly.create (not update) when entity does not exist in destination', async () => {
+    const plainClient = makePlainClientMock()
+    await pushToSpace({
+      sourceData: { ...baseSourceData, dataAssemblies: [entity] } as any,
+      destinationData: { ...baseDestinationData, dataAssemblies: [] },
+      client: makeClientMock(),
+      plainClient,
+      spaceId: 'space-1',
+      environmentId: 'master',
+      includeExperienceOrchestration: true,
+      requestQueue
+    }).run({ data: {} })
+
+    expect(plainClient.dataAssembly.create).toHaveBeenCalledTimes(1)
+    expect(plainClient.dataAssembly.update).not.toHaveBeenCalled()
+    const [params, payload] = plainClient.dataAssembly.create.mock.calls[0] as unknown as [any, any]
+    expect(params).toEqual({ spaceId: 'space-1', environmentId: 'master' })
+    expect(payload).not.toHaveProperty('sys')
+    expect(payload.name).toBe('My Assembly')
+  })
+
+  test('UPDATE: calls dataAssembly.update (not create) with destination sys.version when entity exists', async () => {
+    const plainClient = makePlainClientMock()
+    const destinationEntity: any = { sys: { id: 'da-1', type: 'DataAssembly', version: 9 } }
+    await pushToSpace({
+      sourceData: { ...baseSourceData, dataAssemblies: [entity] } as any,
+      destinationData: { ...baseDestinationData, dataAssemblies: [destinationEntity] },
+      client: makeClientMock(),
+      plainClient,
+      spaceId: 'space-1',
+      environmentId: 'master',
+      includeExperienceOrchestration: true,
+      requestQueue
+    }).run({ data: {} })
+
+    expect(plainClient.dataAssembly.update).toHaveBeenCalledTimes(1)
+    expect(plainClient.dataAssembly.create).not.toHaveBeenCalled()
+    const [params, payload] = plainClient.dataAssembly.update.mock.calls[0] as unknown as [any, any]
+    expect(params).toEqual({ spaceId: 'space-1', environmentId: 'master', dataAssemblyId: 'da-1' })
+    expect(payload.sys.version).toBe(9)
+    expect(payload.name).toBe('My Assembly')
+  })
+})
+
+// ─── Experience ───────────────────────────────────────────────────────────────
+
+describe('Importing Experiences', () => {
+  const entity: any = { sys: { id: 'exp-1', type: 'Experience', version: 1 }, name: 'My Experience' }
+
+  test('CREATE: calls upsert without sys when entity does not exist in destination', async () => {
+    const plainClient = makePlainClientMock()
+    await pushToSpace({
+      sourceData: { ...baseSourceData, experiences: [entity] } as any,
+      destinationData: { ...baseDestinationData, experiences: [] },
+      client: makeClientMock(),
+      plainClient,
+      spaceId: 'space-1',
+      environmentId: 'master',
+      includeExperienceOrchestration: true,
+      requestQueue
+    }).run({ data: {} })
+
+    expect(plainClient.experience.upsert).toHaveBeenCalledTimes(1)
+    const [params, payload] = plainClient.experience.upsert.mock.calls[0] as unknown as [any, any]
+    expect(params).toEqual({ spaceId: 'space-1', environmentId: 'master', experienceId: 'exp-1' })
+    expect(payload).not.toHaveProperty('sys')
+    expect(payload.name).toBe('My Experience')
+  })
+
+  test('UPDATE: calls upsert with destination sys.version when entity exists in destination', async () => {
+    const plainClient = makePlainClientMock()
+    const destinationEntity: any = { sys: { id: 'exp-1', type: 'Experience', version: 6 } }
+    await pushToSpace({
+      sourceData: { ...baseSourceData, experiences: [entity] } as any,
+      destinationData: { ...baseDestinationData, experiences: [destinationEntity] },
+      client: makeClientMock(),
+      plainClient,
+      spaceId: 'space-1',
+      environmentId: 'master',
+      includeExperienceOrchestration: true,
+      requestQueue
+    }).run({ data: {} })
+
+    const [params, payload] = plainClient.experience.upsert.mock.calls[0] as unknown as [any, any]
+    expect(params).toEqual({ spaceId: 'space-1', environmentId: 'master', experienceId: 'exp-1' })
+    expect(payload.sys.version).toBe(6)
+    expect(payload.name).toBe('My Experience')
+  })
+})


### PR DESCRIPTION
`get-destination-data.ts:`
- Added ComponentTypeProps, DataAssemblyProps, ExperienceProps, FragmentProps, TemplateProps to the import
- Added fetchAllExoEntities — a cursor-paginated fetch helper for the ExO APIs (which use pages.next rather than offset/limit)
- Extended AllDestinationData with optional fields for all 5 ExO entity types, plus a TODO comment for DesignTokens
- Added plainClient, includeExperienceOrchestration to GetDestinationDataParams
- When includeExperienceOrchestration is true, fetches all destination componentTypes, templates, fragments, dataAssemblies, and experiences via plainClient, with a TODO for designTokens

`index.ts:`
- Threads plainClient and includeExperienceOrchestration through to getDestinationData

`push-to-space.ts:`
- All 5 ExO entity tasks now look up destinationDataById before acting: if the entity exists in the destination, passes the destination sys.version in the payload (satisfying the API's
optimistic concurrency requirement); if not, passes the payload without sys
- Removed the debug console.log statements from the ComponentTypes task
- Removed the inner try/get-then-create for DataAssemblies (now handled uniformly via the pre-fetched map)
- Added a TODO comment for the DesignTokens task

### Unit tests

  test/unit/tasks/push/push-to-space-exo.test.ts — 11 tests across 5 entity types (CT, Template, Fragment, DataAssembly, Experience):
  - CREATE path: verifies upsert/create is called with no sys in the payload when the entity is absent from the destination map
  - UPDATE path: verifies the destination entity's sys.version is threaded into the payload (the optimistic concurrency value), and that DataAssembly specifically uses update not create
  - Skip guard: verifies no calls are made when includeExperienceOrchestration: false

  test/unit/tasks/get-destination-data-exo.test.ts — 9 tests:
  - Verifies cursor pagination (pageNext) is used for ExO entities, offset pagination is used for standard entities
  - Verifies ExO methods are not called when the flag is off
  - Verifies multi-page cursor traversal (150 items across 2 pages → 2 getMany calls)
  - One test per entity type confirming the returned data is populated from the mock
  - Empty-destination case (all arrays come back length 0)
