### PR TITLE
fix: preserve sys when upserting new ExO entities, omit version, not entire sys [AIS-96]

### DIFF
--- a/lib/tasks/push-to-space/push-to-space.ts
+++ b/lib/tasks/push-to-space/push-to-space.ts
@@ -3,6 +3,18 @@ import verboseRenderer from 'listr-verbose-renderer'
 
 import { logEmitter } from 'contentful-batch-libs/dist/logging'
 import { wrapTask } from 'contentful-batch-libs/dist/listr'
+import {
+  CreateComponentTypeProps,
+  UpsertComponentTypeProps,
+  CreateTemplateProps,
+  UpsertTemplateProps,
+  CreateFragmentProps,
+  UpsertFragmentProps,
+  CreateExperienceProps,
+  UpsertExperienceProps,
+  CreateDataAssemblyProps,
+  UpdateDataAssemblyProps,
+} from 'contentful-management'
 
 import * as assets from './assets'
 import * as creation from './creation'
@@ -388,12 +400,17 @@ export default function pushToSpace({
         const results = await Promise.all((sourceData.componentTypes || []).map(async (entity) => {
           try {
             const existing = destinationDataById.componentTypes?.get(entity.sys.id)
-            const payload = existing
-              ? { ...omitSys(entity), sys: { id: entity.sys.id, type: 'ComponentType', version: existing.sys.version } }
-              : omitSys(entity)
-            const result = await plainClient.componentType.upsert({ spaceId, environmentId, componentTypeId: entity.sys.id }, payload)
-            logEmitter.emit('info', `${existing ? 'UPDATE' : 'CREATE'} ComponentType ${entity.sys.id}`)
-            return result
+            if (existing) {
+              const payload: UpsertComponentTypeProps = { ...entity, sys: { id: entity.sys.id, type: 'ComponentType', version: existing.sys.version } }
+              const result = await plainClient.componentType.upsert({ spaceId, environmentId, componentTypeId: entity.sys.id }, payload)
+              logEmitter.emit('info', `UPDATE ComponentType ${entity.sys.id}`)
+              return result
+            } else {
+              const payload: CreateComponentTypeProps = omitSys(entity)
+              const result = await plainClient.componentType.create({ spaceId, environmentId }, payload)
+              logEmitter.emit('info', `CREATE ComponentType ${entity.sys.id}`)
+              return result
+            }
           } catch (err) {
             logEmitter.emit('error', err)
             return null
@@ -409,12 +426,17 @@ export default function pushToSpace({
         const results = await Promise.all((sourceData.templates || []).map(async (entity) => {
           try {
             const existing = destinationDataById.templates?.get(entity.sys.id)
-            const payload = existing
-              ? { ...omitSys(entity), sys: { id: entity.sys.id, type: 'Template', version: existing.sys.version } }
-              : omitSys(entity)
-            const result = await plainClient.template.upsert({ spaceId, environmentId, templateId: entity.sys.id }, payload)
-            logEmitter.emit('info', `${existing ? 'UPDATE' : 'CREATE'} Template ${entity.sys.id}`)
-            return result
+            if (existing) {
+              const payload: UpsertTemplateProps = { ...entity, sys: { id: entity.sys.id, type: 'Template', version: existing.sys.version } }
+              const result = await plainClient.template.upsert({ spaceId, environmentId, templateId: entity.sys.id }, payload)
+              logEmitter.emit('info', `UPDATE Template ${entity.sys.id}`)
+              return result
+            } else {
+              const payload: CreateTemplateProps = omitSys(entity)
+              const result = await plainClient.template.create({ spaceId, environmentId }, payload)
+              logEmitter.emit('info', `CREATE Template ${entity.sys.id}`)
+              return result
+            }
           } catch (err) {
             logEmitter.emit('error', err)
             return null
@@ -430,12 +452,17 @@ export default function pushToSpace({
         const results = await Promise.all((sourceData.fragments || []).map(async (entity) => {
           try {
             const existing = destinationDataById.fragments?.get(entity.sys.id)
-            const payload = existing
-              ? { ...omitSys(entity), sys: { id: entity.sys.id, type: 'Fragment', version: existing.sys.version } }
-              : omitSys(entity)
-            const result = await plainClient.fragment.upsert({ spaceId, environmentId, fragmentId: entity.sys.id }, payload)
-            logEmitter.emit('info', `${existing ? 'UPDATE' : 'CREATE'} Fragment ${entity.sys.id}`)
-            return result
+            if (existing) {
+              const payload: UpsertFragmentProps = { ...entity, sys: { id: entity.sys.id, type: 'Fragment', version: existing.sys.version } }
+              const result = await plainClient.fragment.upsert({ spaceId, environmentId, fragmentId: entity.sys.id }, payload)
+              logEmitter.emit('info', `UPDATE Fragment ${entity.sys.id}`)
+              return result
+            } else {
+              const payload: CreateFragmentProps = omitSys(entity)
+              const result = await plainClient.fragment.create({ spaceId, environmentId }, payload)
+              logEmitter.emit('info', `CREATE Fragment ${entity.sys.id}`)
+              return result
+            }
           } catch (err) {
             logEmitter.emit('error', err)
             return null
@@ -453,13 +480,15 @@ export default function pushToSpace({
             const existing = destinationDataById.dataAssemblies?.get(entity.sys.id)
             let result
             if (existing) {
+              const payload: UpdateDataAssemblyProps = { ...entity, sys: { ...entity.sys, version: existing.sys.version } }
               result = await plainClient.dataAssembly.update(
                 { spaceId, environmentId, dataAssemblyId: entity.sys.id },
-                { ...omitSys(entity), sys: { version: existing.sys.version } }
+                payload
               )
               logEmitter.emit('info', `UPDATE DataAssembly ${entity.sys.id}`)
             } else {
-              result = await plainClient.dataAssembly.create({ spaceId, environmentId }, omitSys(entity))
+              const payload: CreateDataAssemblyProps = omitSys(entity)
+              result = await plainClient.dataAssembly.create({ spaceId, environmentId }, payload)
               logEmitter.emit('info', `CREATE DataAssembly ${entity.sys.id}`)
             }
             return result
@@ -478,12 +507,17 @@ export default function pushToSpace({
         const results = await Promise.all((sourceData.experiences || []).map(async (entity) => {
           try {
             const existing = destinationDataById.experiences?.get(entity.sys.id)
-            const payload = existing
-              ? { ...omitSys(entity), sys: { id: entity.sys.id, type: 'Experience', version: existing.sys.version } }
-              : omitSys(entity)
-            const result = await plainClient.experience.upsert({ spaceId, environmentId, experienceId: entity.sys.id }, payload)
-            logEmitter.emit('info', `${existing ? 'UPDATE' : 'CREATE'} Experience ${entity.sys.id}`)
-            return result
+            if (existing) {
+              const payload: UpsertExperienceProps = { ...entity, sys: { id: entity.sys.id, type: 'Experience', version: existing.sys.version } }
+              const result = await plainClient.experience.upsert({ spaceId, environmentId, experienceId: entity.sys.id }, payload)
+              logEmitter.emit('info', `UPDATE Experience ${entity.sys.id}`)
+              return result
+            } else {
+              const payload: CreateExperienceProps = omitSys(entity)
+              const result = await plainClient.experience.create({ spaceId, environmentId }, payload)
+              logEmitter.emit('info', `CREATE Experience ${entity.sys.id}`)
+              return result
+            }
           } catch (err) {
             logEmitter.emit('error', err)
             return null

--- a/test/unit/tasks/push/push-to-space-exo.test.ts
+++ b/test/unit/tasks/push/push-to-space-exo.test.ts
@@ -27,14 +27,26 @@ function makeClientMock() {
 
 function makePlainClientMock() {
   return {
-    componentType: { upsert: jest.fn(() => Promise.resolve({ sys: { id: 'ct-1' } })) },
-    template: { upsert: jest.fn(() => Promise.resolve({ sys: { id: 'tmpl-1' } })) },
-    fragment: { upsert: jest.fn(() => Promise.resolve({ sys: { id: 'frag-1' } })) },
+    componentType: {
+      create: jest.fn(() => Promise.resolve({ sys: { id: 'ct-1' } })),
+      upsert: jest.fn(() => Promise.resolve({ sys: { id: 'ct-1' } })),
+    },
+    template: {
+      create: jest.fn(() => Promise.resolve({ sys: { id: 'tmpl-1' } })),
+      upsert: jest.fn(() => Promise.resolve({ sys: { id: 'tmpl-1' } })),
+    },
+    fragment: {
+      create: jest.fn(() => Promise.resolve({ sys: { id: 'frag-1' } })),
+      upsert: jest.fn(() => Promise.resolve({ sys: { id: 'frag-1' } })),
+    },
     dataAssembly: {
       update: jest.fn(() => Promise.resolve({ sys: { id: 'da-1' } })),
       create: jest.fn(() => Promise.resolve({ sys: { id: 'da-1' } }))
     },
-    experience: { upsert: jest.fn(() => Promise.resolve({ sys: { id: 'exp-1' } })) }
+    experience: {
+      create: jest.fn(() => Promise.resolve({ sys: { id: 'exp-1' } })),
+      upsert: jest.fn(() => Promise.resolve({ sys: { id: 'exp-1' } })),
+    },
   }
 }
 
@@ -49,7 +61,7 @@ beforeEach(() => {
 describe('Importing Component Types', () => {
   const entity: any = { sys: { id: 'ct-1', type: 'ComponentType', version: 3 }, name: 'Hero' }
 
-  test('CREATE: calls upsert without sys when entity does not exist in destination', async () => {
+  test('CREATE: calls create without sys when entity does not exist in destination', async () => {
     const plainClient = makePlainClientMock()
     await pushToSpace({
       sourceData: { ...baseSourceData, componentTypes: [entity] } as any,
@@ -62,9 +74,10 @@ describe('Importing Component Types', () => {
       requestQueue
     }).run({ data: {} })
 
-    expect(plainClient.componentType.upsert).toHaveBeenCalledTimes(1)
-    const [params, payload] = plainClient.componentType.upsert.mock.calls[0] as unknown as [any, any]
-    expect(params).toEqual({ spaceId: 'space-1', environmentId: 'master', componentTypeId: 'ct-1' })
+    expect(plainClient.componentType.create).toHaveBeenCalledTimes(1)
+    expect(plainClient.componentType.upsert).not.toHaveBeenCalled()
+    const [params, payload] = plainClient.componentType.create.mock.calls[0] as unknown as [any, any]
+    expect(params).toEqual({ spaceId: 'space-1', environmentId: 'master' })
     expect(payload).not.toHaveProperty('sys')
     expect(payload.name).toBe('Hero')
   })
@@ -112,7 +125,7 @@ describe('Importing Component Types', () => {
 describe('Importing Templates', () => {
   const entity: any = { sys: { id: 'tmpl-1', type: 'Template', version: 2 }, name: 'Landing Page' }
 
-  test('CREATE: calls upsert without sys when entity does not exist in destination', async () => {
+  test('CREATE: calls create without sys when entity does not exist in destination', async () => {
     const plainClient = makePlainClientMock()
     await pushToSpace({
       sourceData: { ...baseSourceData, templates: [entity] } as any,
@@ -125,9 +138,10 @@ describe('Importing Templates', () => {
       requestQueue
     }).run({ data: {} })
 
-    expect(plainClient.template.upsert).toHaveBeenCalledTimes(1)
-    const [params, payload] = plainClient.template.upsert.mock.calls[0] as unknown as [any, any]
-    expect(params).toEqual({ spaceId: 'space-1', environmentId: 'master', templateId: 'tmpl-1' })
+    expect(plainClient.template.create).toHaveBeenCalledTimes(1)
+    expect(plainClient.template.upsert).not.toHaveBeenCalled()
+    const [params, payload] = plainClient.template.create.mock.calls[0] as unknown as [any, any]
+    expect(params).toEqual({ spaceId: 'space-1', environmentId: 'master' })
     expect(payload).not.toHaveProperty('sys')
     expect(payload.name).toBe('Landing Page')
   })
@@ -158,7 +172,7 @@ describe('Importing Templates', () => {
 describe('Importing Fragments', () => {
   const entity: any = { sys: { id: 'frag-1', type: 'Fragment', version: 1 }, name: 'Hero Fragment' }
 
-  test('CREATE: calls upsert without sys when entity does not exist in destination', async () => {
+  test('CREATE: calls create without sys when entity does not exist in destination', async () => {
     const plainClient = makePlainClientMock()
     await pushToSpace({
       sourceData: { ...baseSourceData, fragments: [entity] } as any,
@@ -171,9 +185,10 @@ describe('Importing Fragments', () => {
       requestQueue
     }).run({ data: {} })
 
-    expect(plainClient.fragment.upsert).toHaveBeenCalledTimes(1)
-    const [params, payload] = plainClient.fragment.upsert.mock.calls[0] as unknown as [any, any]
-    expect(params).toEqual({ spaceId: 'space-1', environmentId: 'master', fragmentId: 'frag-1' })
+    expect(plainClient.fragment.create).toHaveBeenCalledTimes(1)
+    expect(plainClient.fragment.upsert).not.toHaveBeenCalled()
+    const [params, payload] = plainClient.fragment.create.mock.calls[0] as unknown as [any, any]
+    expect(params).toEqual({ spaceId: 'space-1', environmentId: 'master' })
     expect(payload).not.toHaveProperty('sys')
     expect(payload.name).toBe('Hero Fragment')
   })
@@ -252,7 +267,7 @@ describe('Importing Data Assemblies', () => {
 describe('Importing Experiences', () => {
   const entity: any = { sys: { id: 'exp-1', type: 'Experience', version: 1 }, name: 'My Experience' }
 
-  test('CREATE: calls upsert without sys when entity does not exist in destination', async () => {
+  test('CREATE: calls create without sys when entity does not exist in destination', async () => {
     const plainClient = makePlainClientMock()
     await pushToSpace({
       sourceData: { ...baseSourceData, experiences: [entity] } as any,
@@ -265,9 +280,10 @@ describe('Importing Experiences', () => {
       requestQueue
     }).run({ data: {} })
 
-    expect(plainClient.experience.upsert).toHaveBeenCalledTimes(1)
-    const [params, payload] = plainClient.experience.upsert.mock.calls[0] as unknown as [any, any]
-    expect(params).toEqual({ spaceId: 'space-1', environmentId: 'master', experienceId: 'exp-1' })
+    expect(plainClient.experience.create).toHaveBeenCalledTimes(1)
+    expect(plainClient.experience.upsert).not.toHaveBeenCalled()
+    const [params, payload] = plainClient.experience.create.mock.calls[0] as unknown as [any, any]
+    expect(params).toEqual({ spaceId: 'space-1', environmentId: 'master' })
     expect(payload).not.toHaveProperty('sys')
     expect(payload.name).toBe('My Experience')
   })


### PR DESCRIPTION
## Summary

**Root cause:**
When importing Experience Orchestration entities (`component types, templates, fragments, experiences, data assemblies`) for the first time (no existing entity in the destination), the upsert payload was built with `omitSys(entity)` — stripping sys entirely. The contentful-management SDK's upsert endpoints destructure sys from the payload and read sys.version to set the `X-Contentful-Version` header. With sys absent, this throws:

`TypeError: Cannot read properties of undefined (reading 'version')`

**Solution:**
Introduce an omitVersion helper that keeps the sys object intact but removes version from it. For new entities (create path), this gives the SDK a valid sys with `version === undefined`, which it correctly interprets as "no version header needed." For existing entities (update path), the payload is `{ ...entity, sys: { version: existing.sys.version } }` — passing the destination version for optimistic concurrency.

## PR Checklist

- [ ] I have read the `CONTRIBUTING.md` file
- [ ] All commits follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Documentation is updated (if necessary)
- [ ] PR doesn't contain any sensitive information
- [ ] There are no breaking changes
