### PR TITLE
fix: import DataAssemblies before Templates and Fragments [AIS-96]

### DIFF
--- a/lib/tasks/push-to-space/push-to-space.ts
+++ b/lib/tasks/push-to-space/push-to-space.ts
@@ -395,32 +395,6 @@ export default function pushToSpace({
         contentModelOnly || (environmentId !== 'master' && 'Webhooks can only be imported in master environment')
     },
     {
-      title: 'Importing Component Types',
-      task: wrapTask(async (ctx) => {
-        const results = await Promise.all((sourceData.componentTypes || []).map(async (entity) => {
-          try {
-            const existing = destinationDataById.componentTypes?.get(entity.sys.id)
-            if (existing) {
-              const payload: UpsertComponentTypeProps = { ...entity, sys: { id: entity.sys.id, type: 'ComponentType', version: existing.sys.version } }
-              const result = await plainClient.componentType.upsert({ spaceId, environmentId, componentTypeId: entity.sys.id }, payload)
-              logEmitter.emit('info', `UPDATE ComponentType ${entity.sys.id}`)
-              return result
-            } else {
-              const payload: CreateComponentTypeProps = omitSys(entity)
-              const result = await plainClient.componentType.create({ spaceId, environmentId }, payload)
-              logEmitter.emit('info', `CREATE ComponentType ${entity.sys.id}`)
-              return result
-            }
-          } catch (err) {
-            logEmitter.emit('error', err)
-            return null
-          }
-        }))
-        ctx.data.componentTypes = results.filter(Boolean)
-      }),
-      skip: () => !includeExperienceOrchestration || !(sourceData.componentTypes || []).length
-    },
-    {
       title: 'Importing Data Assemblies',
       task: wrapTask(async (ctx) => {
         const results = await Promise.all((sourceData.dataAssemblies || []).map(async (entity) => {
@@ -448,6 +422,32 @@ export default function pushToSpace({
         ctx.data.dataAssemblies = results.filter(Boolean)
       }),
       skip: () => !includeExperienceOrchestration || !(sourceData.dataAssemblies || []).length
+    },
+    {
+      title: 'Importing Component Types',
+      task: wrapTask(async (ctx) => {
+        const results = await Promise.all((sourceData.componentTypes || []).map(async (entity) => {
+          try {
+            const existing = destinationDataById.componentTypes?.get(entity.sys.id)
+            if (existing) {
+              const payload: UpsertComponentTypeProps = { ...entity, sys: { id: entity.sys.id, type: 'ComponentType', version: existing.sys.version } }
+              const result = await plainClient.componentType.upsert({ spaceId, environmentId, componentTypeId: entity.sys.id }, payload)
+              logEmitter.emit('info', `UPDATE ComponentType ${entity.sys.id}`)
+              return result
+            } else {
+              const payload: CreateComponentTypeProps = omitSys(entity)
+              const result = await plainClient.componentType.create({ spaceId, environmentId }, payload)
+              logEmitter.emit('info', `CREATE ComponentType ${entity.sys.id}`)
+              return result
+            }
+          } catch (err) {
+            logEmitter.emit('error', err)
+            return null
+          }
+        }))
+        ctx.data.componentTypes = results.filter(Boolean)
+      }),
+      skip: () => !includeExperienceOrchestration || !(sourceData.componentTypes || []).length
     },
     {
       title: 'Importing Templates',

--- a/lib/tasks/push-to-space/push-to-space.ts
+++ b/lib/tasks/push-to-space/push-to-space.ts
@@ -421,6 +421,35 @@ export default function pushToSpace({
       skip: () => !includeExperienceOrchestration || !(sourceData.componentTypes || []).length
     },
     {
+      title: 'Importing Data Assemblies',
+      task: wrapTask(async (ctx) => {
+        const results = await Promise.all((sourceData.dataAssemblies || []).map(async (entity) => {
+          try {
+            const existing = destinationDataById.dataAssemblies?.get(entity.sys.id)
+            let result
+            if (existing) {
+              const payload: UpdateDataAssemblyProps = { ...entity, sys: { ...entity.sys, version: existing.sys.version } }
+              result = await plainClient.dataAssembly.update(
+                { spaceId, environmentId, dataAssemblyId: entity.sys.id },
+                payload
+              )
+              logEmitter.emit('info', `UPDATE DataAssembly ${entity.sys.id}`)
+            } else {
+              const payload: CreateDataAssemblyProps = omitSys(entity)
+              result = await plainClient.dataAssembly.create({ spaceId, environmentId }, payload)
+              logEmitter.emit('info', `CREATE DataAssembly ${entity.sys.id}`)
+            }
+            return result
+          } catch (err) {
+            logEmitter.emit('error', err)
+            return null
+          }
+        }))
+        ctx.data.dataAssemblies = results.filter(Boolean)
+      }),
+      skip: () => !includeExperienceOrchestration || !(sourceData.dataAssemblies || []).length
+    },
+    {
       title: 'Importing Templates',
       task: wrapTask(async (ctx) => {
         const results = await Promise.all((sourceData.templates || []).map(async (entity) => {
@@ -471,35 +500,6 @@ export default function pushToSpace({
         ctx.data.fragments = results.filter(Boolean)
       }),
       skip: () => !includeExperienceOrchestration || !(sourceData.fragments || []).length
-    },
-    {
-      title: 'Importing Data Assemblies',
-      task: wrapTask(async (ctx) => {
-        const results = await Promise.all((sourceData.dataAssemblies || []).map(async (entity) => {
-          try {
-            const existing = destinationDataById.dataAssemblies?.get(entity.sys.id)
-            let result
-            if (existing) {
-              const payload: UpdateDataAssemblyProps = { ...entity, sys: { ...entity.sys, version: existing.sys.version } }
-              result = await plainClient.dataAssembly.update(
-                { spaceId, environmentId, dataAssemblyId: entity.sys.id },
-                payload
-              )
-              logEmitter.emit('info', `UPDATE DataAssembly ${entity.sys.id}`)
-            } else {
-              const payload: CreateDataAssemblyProps = omitSys(entity)
-              result = await plainClient.dataAssembly.create({ spaceId, environmentId }, payload)
-              logEmitter.emit('info', `CREATE DataAssembly ${entity.sys.id}`)
-            }
-            return result
-          } catch (err) {
-            logEmitter.emit('error', err)
-            return null
-          }
-        }))
-        ctx.data.dataAssemblies = results.filter(Boolean)
-      }),
-      skip: () => !includeExperienceOrchestration || !(sourceData.dataAssemblies || []).length
     },
     {
       title: 'Importing Experiences',


### PR DESCRIPTION
**NOTE:** this PR is step 1 of 2, only changing the LOAD order of exo entities, nothing else.  The diff is literally just moving the `Importing Data Assemblies` Listr step earlier in the import process.  [Step 2](https://github.com/contentful/contentful-import/pull/1676) will deal with any necessary sorting to ensure that any exo references are loaded before they are needed.

## Summary

- DataAssemblies have no ExO dependencies and must be created first
- ComponentTypes reference DataAssemblies (in their `dataAssemblies` allow-list)
- Fragments and Experiences also reference DataAssemblies
- Previous order caused 422 `InvalidDataAssemblyReference` errors on both ComponentType and Fragment/Experience creates

## Corrected dependency model

| Entity | Depends On |
|---|---|
| DataAssemblies | _(none)_ |
| ComponentTypes | DataAssemblies, other ComponentTypes |
| Templates | ComponentTypes |
| Fragments | ComponentTypes, DataAssemblies |
| Experiences | Templates, Fragments, DataAssemblies |

**Correct import order: `DataAssemblies → ComponentTypes → Templates → Fragments → Experiences`**

## Test plan

- [ ] Existing ExO unit tests pass (`test/unit/tasks/push/push-to-space-exo.test.ts`)
- [ ] End-to-end import of a space with ExO entities succeeds without `InvalidDataAssemblyReference` errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)