### PR TITLE
fix: Sort Component & Fragment by references [AIS-239]

### DIFF
--- a/docs/exo-import.md
+++ b/docs/exo-import.md
@@ -1,0 +1,62 @@
+# Experience Orchestration (ExO) Import
+
+## What is ExO?
+
+Experience Orchestration (ExO) is Contentful's system for composing and rendering structured page experiences. It sits above the traditional entry/content-type layer and provides a dedicated set of entity types — DataAssemblies, ComponentTypes, Templates, Fragments, and Experiences — that together describe *how* content is fetched, assembled, and laid out. DataAssemblies define reusable data-fetching contracts (GraphQL resolvers, parameter bindings). ComponentTypes define the visual building blocks that consume that data. Templates describe full page layouts in terms of ComponentTypes. Fragments are reusable, named compositions of ComponentTypes and data bindings. Experiences wire Templates and Fragments together into publishable page definitions.
+
+## Entity Dependency Model
+
+ExO entities form a strict dependency graph. An entity can only reference types that appear earlier in the hierarchy — there are no circular dependencies across types, though intra-type dependencies are possible for ComponentTypes and Fragments.
+
+```
+DataAssemblies
+      │
+      ▼
+ComponentTypes ──────────────────┐
+      │                          │ (a CT can reference other CTs
+      ▼                          │  in its componentTree)
+  Templates                      │
+      │               Fragments ─┤
+      │                   │      │ (a Fragment can reference other
+      │                   │      │  Fragments in its slots)
+      └──────┬────────────┘
+             ▼
+        Experiences
+```
+
+| Entity         | References                                        | Referenced by                        |
+|----------------|---------------------------------------------------|--------------------------------------|
+| DataAssembly   | nothing                                           | ComponentTypes, Fragments, Experiences |
+| ComponentType  | DataAssemblies, other ComponentTypes              | Templates, Fragments, Experiences    |
+| Template       | ComponentTypes                                    | Experiences                          |
+| Fragment       | ComponentTypes, DataAssemblies, other Fragments   | Experiences                          |
+| Experience     | Templates, Fragments, DataAssemblies              | nothing                              |
+
+## ID Preservation Is Required
+
+ExO entities reference each other via URN pointers that embed the entity's `sys.id`, e.g. `crn:contentful:::experience:spaces/$self/environments/$self/componentTypes/section`. If a create operation generates a new random ID instead of preserving the source ID, any entity that references it by URN will fail validation at write time with a `404 Not Found` or `422 InvalidDataAssemblyReference` — even if the dependency was created first.
+
+For this reason, all ExO entity creates must use a PUT-with-ID call (upsert semantics), not a bare POST:
+
+- **ComponentTypes, Templates, Fragments, Experiences** — use `plainClient.<type>.upsert(...)` with `sys: { id, type }` and no `version` field (omitting version signals create intent).
+- **DataAssemblies** — the SDK has no `upsert`; use `plainClient.dataAssembly.update(...)` with `sys.version: 0`, which maps to `PUT /data_assemblies/{id}` and creates the entity with the specified ID.
+
+## Why Load Order Matters
+
+Standard content entries do not have this problem: the CMA treats entry link fields as opaque references at write time, storing the `sys.id` pointer without checking whether the target entry or asset exists. Entries can be created in parallel regardless of their link graph, and broken links simply resolve as null until the targets are created. Ordering only becomes relevant for entries at **publish time**, which `contentful-import` handles via a multi-pass retry queue.
+
+ExO entities have a stricter contract: the CMA validates references **at create time**. If you attempt to create a ComponentType that lists a DataAssembly in its `dataAssemblies` allow-list before that DataAssembly exists, the API returns a `422 InvalidDataAssemblyReference`. Creating a ComponentType whose `componentTree` references another ComponentType that hasn't been created yet returns a `404 Not Found`. The retry-queue approach used for entries wouldn't help here — a failed create is not automatically retried, it's just an error.
+
+This means the import order must respect the dependency graph above:
+
+1. **DataAssemblies** — no dependencies, can be imported in parallel
+2. **ComponentTypes** — depend on DataAssemblies (must already exist); may depend on other ComponentTypes
+3. **Templates** — depend on ComponentTypes
+4. **Fragments** — depend on ComponentTypes and DataAssemblies; may depend on other Fragments
+5. **Experiences** — depend on Templates, Fragments, and DataAssemblies
+
+## Why Intra-Type Sorting Is Required
+
+DataAssemblies, Templates, and Experiences have no dependencies within their own type and can be imported in parallel. ComponentTypes and Fragments are different: a ComponentType can embed other ComponentTypes in its `componentTree` (e.g. a "Page" CT that slots in a "Hero" CT), and a Fragment can reference other Fragments in its `slots`. If these are imported in arbitrary order — or all at once via `Promise.all` — the CMA can receive a create request for the composite entity before its dependency exists, causing a `404`.
+
+To prevent this, `contentful-import` applies a topological sort (Kahn's algorithm) to both ComponentTypes and Fragments before importing them, and then imports each sorted list sequentially. The sort parses URN references from `componentTree` and `slots` to build a dependency graph, resolves the safe creation order, and falls back to appending any cyclic nodes at the end so the import can still proceed rather than failing outright.

--- a/lib/tasks/push-to-space/push-to-space.ts
+++ b/lib/tasks/push-to-space/push-to-space.ts
@@ -16,6 +16,8 @@ import * as creation from './creation'
 import * as publishing from './publishing'
 import type { DestinationData, TransformedSourceData, Resources, TransformedAsset } from '../../types'
 import { ContentfulEntityError } from '../../utils/errors'
+import sortComponentTypes from '../../utils/sort-component-types'
+import sortFragments from '../../utils/sort-fragments'
 
 const DEFAULT_CONTENT_STRUCTURE = {
   entries: [],
@@ -424,26 +426,27 @@ export default function pushToSpace({
     {
       title: 'Importing Component Types',
       task: wrapTask(async (ctx) => {
-        const results = await Promise.all((sourceData.componentTypes || []).map(async (entity) => {
+        const sorted = sortComponentTypes(sourceData.componentTypes || [])
+        const results: any[] = []
+        for (const entity of sorted) {
           try {
             const existing = destinationDataById.componentTypes?.get(entity.sys.id)
             if (existing) {
               const payload: UpsertComponentTypeProps = { ...entity, sys: { id: entity.sys.id, type: 'ComponentType', version: existing.sys.version } }
               const result = await plainClient.componentType.upsert({ spaceId, environmentId, componentTypeId: entity.sys.id }, payload)
               logEmitter.emit('info', `UPDATE ComponentType ${entity.sys.id}`)
-              return result
+              results.push(result)
             } else {
               const payload: UpsertComponentTypeProps = { ...omitSys(entity), sys: { id: entity.sys.id, type: 'ComponentType' } }
               const result = await plainClient.componentType.upsert({ spaceId, environmentId, componentTypeId: entity.sys.id }, payload)
               logEmitter.emit('info', `CREATE ComponentType ${entity.sys.id}`)
-              return result
+              results.push(result)
             }
           } catch (err) {
             logEmitter.emit('error', err)
-            return null
           }
-        }))
-        ctx.data.componentTypes = results.filter(Boolean)
+        }
+        ctx.data.componentTypes = results
       }),
       skip: () => !includeExperienceOrchestration || !(sourceData.componentTypes || []).length
     },
@@ -476,26 +479,27 @@ export default function pushToSpace({
     {
       title: 'Importing Fragments',
       task: wrapTask(async (ctx) => {
-        const results = await Promise.all((sourceData.fragments || []).map(async (entity) => {
+        const sorted = sortFragments(sourceData.fragments || [])
+        const results: any[] = []
+        for (const entity of sorted) {
           try {
             const existing = destinationDataById.fragments?.get(entity.sys.id)
             if (existing) {
               const payload: UpsertFragmentProps = { ...entity, componentType: entity.sys.componentType, sys: { id: entity.sys.id, type: 'Fragment', version: existing.sys.version } }
               const result = await plainClient.fragment.upsert({ spaceId, environmentId, fragmentId: entity.sys.id }, payload)
               logEmitter.emit('info', `UPDATE Fragment ${entity.sys.id}`)
-              return result
+              results.push(result)
             } else {
               const payload: UpsertFragmentProps = { ...omitSys(entity), componentType: entity.sys.componentType, sys: { id: entity.sys.id, type: 'Fragment' } }
               const result = await plainClient.fragment.upsert({ spaceId, environmentId, fragmentId: entity.sys.id }, payload)
               logEmitter.emit('info', `CREATE Fragment ${entity.sys.id}`)
-              return result
+              results.push(result)
             }
           } catch (err) {
             logEmitter.emit('error', err)
-            return null
           }
-        }))
-        ctx.data.fragments = results.filter(Boolean)
+        }
+        ctx.data.fragments = results
       }),
       skip: () => !includeExperienceOrchestration || !(sourceData.fragments || []).length
     },

--- a/lib/utils/sort-component-types.ts
+++ b/lib/utils/sort-component-types.ts
@@ -1,0 +1,67 @@
+type ComponentTypeLike = { sys: { id: string }; componentTree?: any[] }
+
+/**
+ * Topologically sorts component types so that any component type referenced
+ * inside another's componentTree is guaranteed to appear earlier in the list.
+ * This ensures creates succeed in dependency order.
+ *
+ * Uses Kahn's algorithm. Cycles are broken by appending the remaining nodes
+ * at the end so import can still proceed.
+ */
+export default function sortComponentTypes<T extends ComponentTypeLike>(componentTypes: T[]): T[] {
+  const idToIndex = new Map<string, number>()
+  componentTypes.forEach((ct, i) => idToIndex.set(ct.sys.id, i))
+
+  const URN_PATTERN = /componentTypes\/([^"\\]+)/g
+
+  function getDeps(ct: any): string[] {
+    const ids = new Set<string>()
+    const tree = JSON.stringify(ct.componentTree || [])
+    let match: RegExpExecArray | null
+    while ((match = URN_PATTERN.exec(tree)) !== null) {
+      const dep = match[1]
+      if (dep !== ct.sys.id && idToIndex.has(dep)) {
+        ids.add(dep)
+      }
+    }
+    return [...ids]
+  }
+
+  // Build adjacency: dep -> list of nodes that depend on dep
+  const dependents = new Map<string, string[]>()
+  const inDegree = new Map<string, number>()
+
+  componentTypes.forEach((ct) => {
+    inDegree.set(ct.sys.id, 0)
+    dependents.set(ct.sys.id, [])
+  })
+
+  componentTypes.forEach((ct) => {
+    for (const dep of getDeps(ct)) {
+      dependents.get(dep)!.push(ct.sys.id)
+      inDegree.set(ct.sys.id, (inDegree.get(ct.sys.id) ?? 0) + 1)
+    }
+  })
+
+  const queue = componentTypes
+    .filter((ct) => inDegree.get(ct.sys.id) === 0)
+    .map((ct) => ct.sys.id)
+
+  const sorted: T[] = []
+  while (queue.length > 0) {
+    const id = queue.shift()!
+    sorted.push(componentTypes[idToIndex.get(id)!])
+    for (const dependent of dependents.get(id) ?? []) {
+      const deg = (inDegree.get(dependent) ?? 1) - 1
+      inDegree.set(dependent, deg)
+      if (deg === 0) queue.push(dependent)
+    }
+  }
+
+  // Append anything left (cycles) so we don't silently drop them
+  componentTypes.forEach((ct) => {
+    if (!sorted.includes(ct)) sorted.push(ct)
+  })
+
+  return sorted
+}

--- a/lib/utils/sort-fragments.ts
+++ b/lib/utils/sort-fragments.ts
@@ -1,0 +1,64 @@
+type FragmentLike = { sys: { id: string }; componentTree?: any; slots?: any }
+
+/**
+ * Topologically sorts fragments so that any fragment referenced in another
+ * fragment's slots appears earlier in the list.
+ *
+ * Uses Kahn's algorithm. Cycles are broken by appending remaining nodes
+ * at the end so import can still proceed.
+ */
+export default function sortFragments<T extends FragmentLike>(fragments: T[]): T[] {
+  const idToIndex = new Map<string, number>()
+  fragments.forEach((f, i) => idToIndex.set(f.sys.id, i))
+
+  const FRAGMENT_URN_PATTERN = /fragments\/([^"\\]+)/g
+
+  function getDeps(fragment: T): string[] {
+    const ids = new Set<string>()
+    const json = JSON.stringify({ slots: fragment.slots || [], componentTree: fragment.componentTree || [] })
+    let match: RegExpExecArray | null
+    while ((match = FRAGMENT_URN_PATTERN.exec(json)) !== null) {
+      const dep = match[1]
+      if (dep !== fragment.sys.id && idToIndex.has(dep)) {
+        ids.add(dep)
+      }
+    }
+    return [...ids]
+  }
+
+  const dependents = new Map<string, string[]>()
+  const inDegree = new Map<string, number>()
+
+  fragments.forEach((f) => {
+    inDegree.set(f.sys.id, 0)
+    dependents.set(f.sys.id, [])
+  })
+
+  fragments.forEach((f) => {
+    for (const dep of getDeps(f)) {
+      dependents.get(dep)!.push(f.sys.id)
+      inDegree.set(f.sys.id, (inDegree.get(f.sys.id) ?? 0) + 1)
+    }
+  })
+
+  const queue = fragments
+    .filter((f) => inDegree.get(f.sys.id) === 0)
+    .map((f) => f.sys.id)
+
+  const sorted: T[] = []
+  while (queue.length > 0) {
+    const id = queue.shift()!
+    sorted.push(fragments[idToIndex.get(id)!])
+    for (const dependent of dependents.get(id) ?? []) {
+      const deg = (inDegree.get(dependent) ?? 1) - 1
+      inDegree.set(dependent, deg)
+      if (deg === 0) queue.push(dependent)
+    }
+  }
+
+  fragments.forEach((f) => {
+    if (!sorted.includes(f)) sorted.push(f)
+  })
+
+  return sorted
+}

--- a/test/unit/sort-fragments.test.ts
+++ b/test/unit/sort-fragments.test.ts
@@ -1,0 +1,100 @@
+import sortFragments from '../../lib/utils/sort-fragments'
+
+function idx(sorted: { sys: { id: string } }[], id: string) {
+  return sorted.findIndex((f) => f.sys.id === id)
+}
+
+function frag(id: string, slots?: object, componentTree?: object) {
+  return { sys: { id }, ...(slots ? { slots } : {}), ...(componentTree ? { componentTree } : {}) }
+}
+
+// Embed a fragment URN reference into a slots/componentTree structure
+function ref(id: string) {
+  return [{ urn: `urn:contentful:fragments/${id}` }]
+}
+
+test('returns empty array when given empty input', () => {
+  expect(sortFragments([])).toEqual([])
+})
+
+test('returns single fragment unchanged', () => {
+  const result = sortFragments([frag('a')])
+  expect(result).toHaveLength(1)
+  expect(result[0].sys.id).toBe('a')
+})
+
+test('sorts two fragments so dependency via slots comes first', () => {
+  const a = frag('a', ref('b'))
+  const b = frag('b')
+  const result = sortFragments([a, b])
+  expect(idx(result, 'b')).toBeLessThan(idx(result, 'a'))
+  expect(result).toHaveLength(2)
+})
+
+test('sorts two fragments so dependency via componentTree comes first', () => {
+  const a = frag('a', undefined, ref('b'))
+  const b = frag('b')
+  const result = sortFragments([a, b])
+  expect(idx(result, 'b')).toBeLessThan(idx(result, 'a'))
+})
+
+test('sorts a linear chain A→B→C so C comes first', () => {
+  const a = frag('a', ref('b'))
+  const b = frag('b', ref('c'))
+  const c = frag('c')
+  const result = sortFragments([a, b, c])
+  expect(idx(result, 'c')).toBeLessThan(idx(result, 'b'))
+  expect(idx(result, 'b')).toBeLessThan(idx(result, 'a'))
+  expect(result).toHaveLength(3)
+})
+
+test('preserves relative order of independent fragments', () => {
+  const a = frag('a')
+  const b = frag('b')
+  const c = frag('c')
+  const result = sortFragments([a, b, c])
+  expect(idx(result, 'a')).toBeLessThan(idx(result, 'b'))
+  expect(idx(result, 'b')).toBeLessThan(idx(result, 'c'))
+})
+
+test('ignores self-references', () => {
+  const a = frag('a', ref('a'))
+  const result = sortFragments([a])
+  expect(result).toHaveLength(1)
+  expect(result[0].sys.id).toBe('a')
+})
+
+test('ignores references to fragments not in the list', () => {
+  const a = frag('a', ref('unknown'))
+  const b = frag('b')
+  const result = sortFragments([a, b])
+  expect(result).toHaveLength(2)
+})
+
+test('handles a cycle without throwing and includes all fragments', () => {
+  const a = frag('a', ref('b'))
+  const b = frag('b', ref('a'))
+  const result = sortFragments([a, b])
+  expect(result).toHaveLength(2)
+  expect(result.map((f) => f.sys.id)).toEqual(expect.arrayContaining(['a', 'b']))
+})
+
+test('diamond dependency: A and B both depend on C, D depends on A and B', () => {
+  const c = frag('c')
+  const a = frag('a', ref('c'))
+  const b = frag('b', ref('c'))
+  const d = frag('d', [...ref('a'), ...ref('b')])
+  const result = sortFragments([d, b, a, c])
+  expect(idx(result, 'c')).toBeLessThan(idx(result, 'a'))
+  expect(idx(result, 'c')).toBeLessThan(idx(result, 'b'))
+  expect(idx(result, 'a')).toBeLessThan(idx(result, 'd'))
+  expect(idx(result, 'b')).toBeLessThan(idx(result, 'd'))
+  expect(result).toHaveLength(4)
+})
+
+test('fragment with no slots or componentTree fields is treated as having no deps', () => {
+  const a = frag('a')
+  const b = frag('b', ref('a'))
+  const result = sortFragments([b, a])
+  expect(idx(result, 'a')).toBeLessThan(idx(result, 'b'))
+})

--- a/test/unit/utils/sort-component-types.test.ts
+++ b/test/unit/utils/sort-component-types.test.ts
@@ -1,0 +1,61 @@
+import sortComponentTypes from '../../../lib/utils/sort-component-types'
+
+function makeRef(id: string) {
+  return { sys: { type: 'ResourceLink', urn: `crn:..../componentTypes/${id}` } }
+}
+
+function makeCT(id: string, deps: string[] = []) {
+  return {
+    sys: { id },
+    componentTree: deps.map((dep) => ({
+      componentType: makeRef(dep)
+    }))
+  }
+}
+
+test('returns empty array unchanged', () => {
+  expect(sortComponentTypes([])).toEqual([])
+})
+
+test('returns single item unchanged', () => {
+  const cts = [makeCT('a')]
+  expect(sortComponentTypes(cts).map((c) => c.sys.id)).toEqual(['a'])
+})
+
+test('leaf nodes come before nodes that reference them', () => {
+  const cts = [makeCT('composite', ['leaf']), makeCT('leaf')]
+  const sorted = sortComponentTypes(cts).map((c) => c.sys.id)
+  expect(sorted.indexOf('leaf')).toBeLessThan(sorted.indexOf('composite'))
+})
+
+test('handles multi-level dependency chain', () => {
+  const cts = [makeCT('c', ['b']), makeCT('b', ['a']), makeCT('a')]
+  const sorted = sortComponentTypes(cts).map((c) => c.sys.id)
+  expect(sorted.indexOf('a')).toBeLessThan(sorted.indexOf('b'))
+  expect(sorted.indexOf('b')).toBeLessThan(sorted.indexOf('c'))
+})
+
+test('handles multiple independent deps', () => {
+  const cts = [
+    makeCT('top', ['left', 'right']),
+    makeCT('right'),
+    makeCT('left'),
+  ]
+  const sorted = sortComponentTypes(cts).map((c) => c.sys.id)
+  expect(sorted.indexOf('left')).toBeLessThan(sorted.indexOf('top'))
+  expect(sorted.indexOf('right')).toBeLessThan(sorted.indexOf('top'))
+})
+
+test('does not drop nodes involved in a cycle', () => {
+  const cts = [makeCT('a', ['b']), makeCT('b', ['a'])]
+  const sorted = sortComponentTypes(cts).map((c) => c.sys.id)
+  expect(sorted).toHaveLength(2)
+  expect(sorted).toContain('a')
+  expect(sorted).toContain('b')
+})
+
+test('ignores self-references', () => {
+  const cts = [makeCT('a', ['a']), makeCT('b')]
+  const sorted = sortComponentTypes(cts).map((c) => c.sys.id)
+  expect(sorted).toHaveLength(2)
+})


### PR DESCRIPTION
## Context
(Traditional) Contentful entities can obviously reference each other, for example an entry can reference an asset.  Traditional contentful entities like entry/asset use (regular) links to reference other entities, that are NOT validated at create/update time.  The import just **trusts** that when the referenced entity is needed (delivery for example) it will exists.

ExO Contentful entities use `ResourceLink`s that **DO get validated** at create/update time.  Therefore, if entity `A` references, entity `B`, then `B` must be imported before `A`. To accomplish this, this commit adds a "Kahn" topological sorting algorithm to build a reference graph of all the entities to be imported and in what order. 


## Summary
- **Topological sort for Exo entities** — entity types can reference other entities of the same type (`componentTree` for CTs, `slots` for Fragments). Without sorting, a composite CT can be sent before its leaf dependencies exist, causing `404` errors. Kahn's algorithm is applied to both before sequential import.

### Reference dependencies:
| Entity | Depends On |
|---|---|
| DataAssemblies | _(none)_ |
| ComponentTypes | DataAssemblies, other ComponentTypes |
| Templates | ComponentTypes |
| Fragments | ComponentTypes, DataAssemblies |
| Experiences | Templates, Fragments, DataAssemblies |


- **Documentation** — added `docs/exo-import.md` covering the entity dependency model, why load order matters, why intra-type sorting is required, and why ID preservation is required.

## Root cause

The CMA validates ExO entity references **at create time**, not lazily like standard entry links. Creating a `ComponentType` that references a `DataAssembly` URN before that DA exists → `422`. Creating a composite CT that references another CT by ID before that CT exists → `404`. Both errors were caused by the same underlying issue: `POST`-based creates throwing away the original `sys.id`.

## Test plan

- [x] Import the `nextjs-cko-demo` example space (29 ComponentTypes, 1 Template, 9 DataAssemblies) into a fresh environment and verify all entities are created with their original IDs
- [x] Verify no `404 Not Found` or `422 InvalidDataAssemblyReference` errors in the error log for ComponentType or DataAssembly creates
- [x] Verify composite ComponentTypes (e.g. `metricsSection`, `fourRowShowcase`) are created after their leaf dependencies (`metric`, `section`, `title`, etc.)
- [ ] Re-running import on an already-populated space (update path) should still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)