### PR TITLE
BackOff - retry DataAssembly writes on stale GraphQL schema after content type publish [AIS-343]

### DIFF
--- a/lib/tasks/push-to-space/push-to-space.ts
+++ b/lib/tasks/push-to-space/push-to-space.ts
@@ -16,8 +16,27 @@ import * as creation from './creation'
 import * as publishing from './publishing'
 import type { DestinationData, TransformedSourceData, Resources, TransformedAsset } from '../../types'
 import { ContentfulEntityError } from '../../utils/errors'
+import { GRAPHQL_SCHEMA_STALE_DELAYS_MS, isGraphQLSchemaStaleError } from '../../utils/graphql-schema-backoff'
 import sortComponentTypes from '../../utils/sort-component-types'
 import sortFragments from '../../utils/sort-fragments'
+
+async function withGraphQLSchemaBackoff<T>(fn: () => Promise<T>): Promise<T> {
+  let lastErr: unknown
+  for (let attempt = 0; attempt <= GRAPHQL_SCHEMA_STALE_DELAYS_MS.length; attempt++) {
+    try {
+      return await fn()
+    } catch (err) {
+      if (!isGraphQLSchemaStaleError(err) || attempt === GRAPHQL_SCHEMA_STALE_DELAYS_MS.length) {
+        throw err
+      }
+      const delay = GRAPHQL_SCHEMA_STALE_DELAYS_MS[attempt]
+      logEmitter.emit('warning', `DataAssembly GraphQL schema not yet current, retrying in ${delay}ms (attempt ${attempt + 1}/${GRAPHQL_SCHEMA_STALE_DELAYS_MS.length})`)
+      await new Promise((resolve) => setTimeout(resolve, delay))
+      lastErr = err
+    }
+  }
+  throw lastErr
+}
 
 const DEFAULT_CONTENT_STRUCTURE = {
   entries: [],
@@ -400,17 +419,17 @@ export default function pushToSpace({
             let result
             if (existing) {
               const payload: UpdateDataAssemblyProps = { ...entity, sys: { ...entity.sys, version: existing.sys.version } }
-              result = await plainClient.dataAssembly.update(
+              result = await withGraphQLSchemaBackoff(() => plainClient.dataAssembly.update(
                 { spaceId, environmentId, dataAssemblyId: entity.sys.id },
                 payload
-              )
+              ))
               logEmitter.emit('info', `UPDATE DataAssembly ${entity.sys.id}`)
             } else {
               const payload: UpdateDataAssemblyProps = { ...omitSys(entity), sys: { id: entity.sys.id, type: 'DataAssembly', dataType: entity.sys.dataType, ...(entity.sys.variant ? { variant: entity.sys.variant } : {}), version: 0 } }
-              result = await plainClient.dataAssembly.update(
+              result = await withGraphQLSchemaBackoff(() => plainClient.dataAssembly.update(
                 { spaceId, environmentId, dataAssemblyId: entity.sys.id },
                 payload
-              )
+              ))
               logEmitter.emit('info', `CREATE DataAssembly ${entity.sys.id}`)
             }
             return result

--- a/lib/utils/graphql-schema-backoff.ts
+++ b/lib/utils/graphql-schema-backoff.ts
@@ -1,0 +1,32 @@
+export const GRAPHQL_SCHEMA_STALE_DELAYS_MS = [500, 1500, 6000]
+
+type ContentfulValidationError = {
+  details?: {
+    errors?: Array<{ message?: string }>
+  }
+}
+
+export function isGraphQLSchemaStaleError(err: unknown): boolean {
+  if (!(err instanceof Error)) {
+    return false
+  }
+
+  let parsed: ContentfulValidationError
+  try {
+    parsed = JSON.parse(err.message) as ContentfulValidationError
+  } catch {
+    return false
+  }
+
+  const errors = parsed?.details?.errors
+  if (!Array.isArray(errors)) {
+    return false
+  }
+
+  const matched = errors.some(
+    (e) =>
+      typeof e.message === 'string' &&
+      (e.message.includes('GraphQL validation error') || e.message.includes('Unknown content type') || e.message.includes('Pointer path does not exist for'))
+  )
+  return matched
+}

--- a/test/unit/graphql-schema-backoff.test.ts
+++ b/test/unit/graphql-schema-backoff.test.ts
@@ -1,0 +1,83 @@
+import { isGraphQLSchemaStaleError } from '../../lib/utils/graphql-schema-backoff'
+
+function makeContentfulError(details: object, name = 'ValidationFailed'): Error {
+  const err = new Error(
+    JSON.stringify({
+      status: 422,
+      statusText: '',
+      message: 'Validation error',
+      details,
+    })
+  )
+  err.name = name
+  return err
+}
+
+const GRAPHQL_VALIDATION_ERROR = {
+  errors: [{ message: 'GraphQL validation error: Cannot query field "foo" on type "Query".' }],
+}
+
+const UNKNOWN_CONTENT_TYPE_ERROR = {
+  errors: [{ message: 'Unknown content type "myContentType".' }],
+}
+
+const MIXED_ERRORS = {
+  errors: [
+    { message: 'Pointer path does not exist for ...' },
+    { message: 'GraphQL validation error: Cannot query field "bar" on type "Query".' },
+    { message: 'Unknown content type "anotherType".' },
+  ],
+}
+
+const UNRELATED_ERRORS = {
+  errors: [{ message: 'Some other validation error unrelated to GraphQL schema.' }],
+}
+
+describe('isGraphQLSchemaStaleError', () => {
+  describe('returns true', () => {
+    test('for a GraphQL validation error', () => {
+      expect(isGraphQLSchemaStaleError(makeContentfulError(GRAPHQL_VALIDATION_ERROR))).toBe(true)
+    })
+
+    test('for an Unknown content type error', () => {
+      expect(isGraphQLSchemaStaleError(makeContentfulError(UNKNOWN_CONTENT_TYPE_ERROR))).toBe(true)
+    })
+
+    test('when stale schema message is mixed with other errors', () => {
+      expect(isGraphQLSchemaStaleError(makeContentfulError(MIXED_ERRORS))).toBe(true)
+    })
+  })
+
+  describe('returns false', () => {
+    test('for an unrelated validation error', () => {
+      expect(isGraphQLSchemaStaleError(makeContentfulError(UNRELATED_ERRORS))).toBe(false)
+    })
+
+    test('when details.errors is missing', () => {
+      expect(isGraphQLSchemaStaleError(makeContentfulError({}))).toBe(false)
+    })
+
+    test('when details.errors is not an array', () => {
+      expect(isGraphQLSchemaStaleError(makeContentfulError({ errors: 'not an array' }))).toBe(false)
+    })
+
+    test('when err is not an Error instance', () => {
+      expect(isGraphQLSchemaStaleError({ message: 'GraphQL validation error' })).toBe(false)
+    })
+
+    test('when err is null', () => {
+      expect(isGraphQLSchemaStaleError(null)).toBe(false)
+    })
+
+    test('when err.message is not JSON', () => {
+      const err = new Error('plain string message, not JSON')
+      expect(isGraphQLSchemaStaleError(err)).toBe(false)
+    })
+
+    test('when the error name is different but message matches', () => {
+      // Confirm we match on message content, not error name
+      const err = makeContentfulError(GRAPHQL_VALIDATION_ERROR, 'SomeOtherError')
+      expect(isGraphQLSchemaStaleError(err)).toBe(true)
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Adds exponential backoff retry logic to DataAssembly creates and updates, specifically targeting 422 errors caused by a stale SchemaRegistry response after content types are published in the same import run.

## Background

The `assemblies-management-api` fetches a fresh GraphQL schema from the SchemaRegistry on every DataAssembly write and validates the resolver query and parameter `allowedTypes` against it. When content types are published for the first time in a space (as part of the same `contentful-import` run), the SchemaRegistry has a propagation delay before those types appear in the SDL. This causes valid DataAssembly writes to fail with:

- `GraphQL validation error: Cannot query field "X" on type "Query"`
- `Unknown content type "X"`
- `Pointer path does not exist for '$resolvers/main/X/...'`

There is no bypass or skip flag in the server-side validation layer. This is a confirmed server-side propagation delay (investigated via the `assemblies-management-api` source and confirmed in [#exo-prod-dev-extended-team](https://contentful.slack.com/archives/C0B7THAABCK/p1784233810878919)).

## What changed

Added two helpers in `push-to-space.ts`:

- **`isGraphQLSchemaStaleError`** — detects the specific 422 error signatures caused by a stale schema. All other errors (real validation failures, network errors, etc.) are not retried.
- **`withGraphQLSchemaBackoff`** — retries up to 3 times with delays of 500ms, 1500ms, and 6000ms (~8s total worst case). Logs a warning on each retry. Only wraps DataAssembly writes — all other ExO entity types do not perform GraphQL schema validation.

## Test plan

- [ ] Import into a **fresh environment** (no pre-existing content types) — DataAssembly writes should retry and eventually succeed once the schema propagates
- [ ] Import into a **pre-populated environment** — no retries should trigger, import runs at full speed
- [ ] A genuine validation error (e.g. malformed resolver query) should still fail immediately without retrying

🤖 Generated with [Claude Code](https://claude.com/claude-code)