### PR TITLE
fix: plainClient.[exoEntityType].create() clobbers id, causing reference chain to break  [AIS-239]

### DIFF
--- a/lib/tasks/push-to-space/push-to-space.ts
+++ b/lib/tasks/push-to-space/push-to-space.ts
@@ -4,15 +4,10 @@ import verboseRenderer from 'listr-verbose-renderer'
 import { logEmitter } from 'contentful-batch-libs/dist/logging'
 import { wrapTask } from 'contentful-batch-libs/dist/listr'
 import {
-  CreateComponentTypeProps,
   UpsertComponentTypeProps,
-  CreateTemplateProps,
   UpsertTemplateProps,
-  CreateFragmentProps,
   UpsertFragmentProps,
-  CreateExperienceProps,
   UpsertExperienceProps,
-  CreateDataAssemblyProps,
   UpdateDataAssemblyProps,
 } from 'contentful-management'
 
@@ -409,8 +404,11 @@ export default function pushToSpace({
               )
               logEmitter.emit('info', `UPDATE DataAssembly ${entity.sys.id}`)
             } else {
-              const payload: CreateDataAssemblyProps = omitSys(entity)
-              result = await plainClient.dataAssembly.create({ spaceId, environmentId }, payload)
+              const payload: UpdateDataAssemblyProps = { ...omitSys(entity), sys: { id: entity.sys.id, type: 'DataAssembly', dataType: entity.sys.dataType, ...(entity.sys.variant ? { variant: entity.sys.variant } : {}), version: 0 } }
+              result = await plainClient.dataAssembly.update(
+                { spaceId, environmentId, dataAssemblyId: entity.sys.id },
+                payload
+              )
               logEmitter.emit('info', `CREATE DataAssembly ${entity.sys.id}`)
             }
             return result
@@ -435,8 +433,8 @@ export default function pushToSpace({
               logEmitter.emit('info', `UPDATE ComponentType ${entity.sys.id}`)
               return result
             } else {
-              const payload: CreateComponentTypeProps = omitSys(entity)
-              const result = await plainClient.componentType.create({ spaceId, environmentId }, payload)
+              const payload: UpsertComponentTypeProps = { ...omitSys(entity), sys: { id: entity.sys.id, type: 'ComponentType' } }
+              const result = await plainClient.componentType.upsert({ spaceId, environmentId, componentTypeId: entity.sys.id }, payload)
               logEmitter.emit('info', `CREATE ComponentType ${entity.sys.id}`)
               return result
             }
@@ -461,8 +459,8 @@ export default function pushToSpace({
               logEmitter.emit('info', `UPDATE Template ${entity.sys.id}`)
               return result
             } else {
-              const payload: CreateTemplateProps = omitSys(entity)
-              const result = await plainClient.template.create({ spaceId, environmentId }, payload)
+              const payload: UpsertTemplateProps = { ...omitSys(entity), sys: { id: entity.sys.id, type: 'Template' } }
+              const result = await plainClient.template.upsert({ spaceId, environmentId, templateId: entity.sys.id }, payload)
               logEmitter.emit('info', `CREATE Template ${entity.sys.id}`)
               return result
             }
@@ -482,13 +480,13 @@ export default function pushToSpace({
           try {
             const existing = destinationDataById.fragments?.get(entity.sys.id)
             if (existing) {
-              const payload: UpsertFragmentProps = { ...entity, sys: { id: entity.sys.id, type: 'Fragment', version: existing.sys.version } }
+              const payload: UpsertFragmentProps = { ...entity, componentType: entity.sys.componentType, sys: { id: entity.sys.id, type: 'Fragment', version: existing.sys.version } }
               const result = await plainClient.fragment.upsert({ spaceId, environmentId, fragmentId: entity.sys.id }, payload)
               logEmitter.emit('info', `UPDATE Fragment ${entity.sys.id}`)
               return result
             } else {
-              const payload: CreateFragmentProps = omitSys(entity)
-              const result = await plainClient.fragment.create({ spaceId, environmentId }, payload)
+              const payload: UpsertFragmentProps = { ...omitSys(entity), componentType: entity.sys.componentType, sys: { id: entity.sys.id, type: 'Fragment' } }
+              const result = await plainClient.fragment.upsert({ spaceId, environmentId, fragmentId: entity.sys.id }, payload)
               logEmitter.emit('info', `CREATE Fragment ${entity.sys.id}`)
               return result
             }
@@ -508,13 +506,13 @@ export default function pushToSpace({
           try {
             const existing = destinationDataById.experiences?.get(entity.sys.id)
             if (existing) {
-              const payload: UpsertExperienceProps = { ...entity, sys: { id: entity.sys.id, type: 'Experience', version: existing.sys.version } }
+              const payload: UpsertExperienceProps = { ...entity, template: entity.sys.template, sys: { id: entity.sys.id, type: 'Experience', version: existing.sys.version } }
               const result = await plainClient.experience.upsert({ spaceId, environmentId, experienceId: entity.sys.id }, payload)
               logEmitter.emit('info', `UPDATE Experience ${entity.sys.id}`)
               return result
             } else {
-              const payload: CreateExperienceProps = omitSys(entity)
-              const result = await plainClient.experience.create({ spaceId, environmentId }, payload)
+              const payload: UpsertExperienceProps = { ...omitSys(entity), template: entity.sys.template, sys: { id: entity.sys.id, type: 'Experience' } }
+              const result = await plainClient.experience.upsert({ spaceId, environmentId, experienceId: entity.sys.id }, payload)
               logEmitter.emit('info', `CREATE Experience ${entity.sys.id}`)
               return result
             }

--- a/test/unit/tasks/push/push-to-space-exo.test.ts
+++ b/test/unit/tasks/push/push-to-space-exo.test.ts
@@ -61,7 +61,7 @@ beforeEach(() => {
 describe('Importing Component Types', () => {
   const entity: any = { sys: { id: 'ct-1', type: 'ComponentType', version: 3 }, name: 'Hero' }
 
-  test('CREATE: calls create without sys when entity does not exist in destination', async () => {
+  test('CREATE: calls upsert with id in sys when entity does not exist in destination', async () => {
     const plainClient = makePlainClientMock()
     await pushToSpace({
       sourceData: { ...baseSourceData, componentTypes: [entity] } as any,
@@ -74,11 +74,13 @@ describe('Importing Component Types', () => {
       requestQueue
     }).run({ data: {} })
 
-    expect(plainClient.componentType.create).toHaveBeenCalledTimes(1)
-    expect(plainClient.componentType.upsert).not.toHaveBeenCalled()
-    const [params, payload] = plainClient.componentType.create.mock.calls[0] as unknown as [any, any]
-    expect(params).toEqual({ spaceId: 'space-1', environmentId: 'master' })
-    expect(payload).not.toHaveProperty('sys')
+    expect(plainClient.componentType.upsert).toHaveBeenCalledTimes(1)
+    expect(plainClient.componentType.create).not.toHaveBeenCalled()
+    const [params, payload] = plainClient.componentType.upsert.mock.calls[0] as unknown as [any, any]
+    expect(params).toEqual({ spaceId: 'space-1', environmentId: 'master', componentTypeId: 'ct-1' })
+    expect(payload.sys.id).toBe('ct-1')
+    expect(payload.sys.type).toBe('ComponentType')
+    expect(payload.sys).not.toHaveProperty('version')
     expect(payload.name).toBe('Hero')
   })
 
@@ -125,7 +127,7 @@ describe('Importing Component Types', () => {
 describe('Importing Templates', () => {
   const entity: any = { sys: { id: 'tmpl-1', type: 'Template', version: 2 }, name: 'Landing Page' }
 
-  test('CREATE: calls create without sys when entity does not exist in destination', async () => {
+  test('CREATE: calls upsert with id in sys when entity does not exist in destination', async () => {
     const plainClient = makePlainClientMock()
     await pushToSpace({
       sourceData: { ...baseSourceData, templates: [entity] } as any,
@@ -138,11 +140,13 @@ describe('Importing Templates', () => {
       requestQueue
     }).run({ data: {} })
 
-    expect(plainClient.template.create).toHaveBeenCalledTimes(1)
-    expect(plainClient.template.upsert).not.toHaveBeenCalled()
-    const [params, payload] = plainClient.template.create.mock.calls[0] as unknown as [any, any]
-    expect(params).toEqual({ spaceId: 'space-1', environmentId: 'master' })
-    expect(payload).not.toHaveProperty('sys')
+    expect(plainClient.template.upsert).toHaveBeenCalledTimes(1)
+    expect(plainClient.template.create).not.toHaveBeenCalled()
+    const [params, payload] = plainClient.template.upsert.mock.calls[0] as unknown as [any, any]
+    expect(params).toEqual({ spaceId: 'space-1', environmentId: 'master', templateId: 'tmpl-1' })
+    expect(payload.sys.id).toBe('tmpl-1')
+    expect(payload.sys.type).toBe('Template')
+    expect(payload.sys).not.toHaveProperty('version')
     expect(payload.name).toBe('Landing Page')
   })
 
@@ -170,9 +174,10 @@ describe('Importing Templates', () => {
 // ─── Fragment ─────────────────────────────────────────────────────────────────
 
 describe('Importing Fragments', () => {
-  const entity: any = { sys: { id: 'frag-1', type: 'Fragment', version: 1 }, name: 'Hero Fragment' }
+  const componentType = { sys: { type: 'ResourceLink', linkType: 'Contentful:ComponentType', urn: 'crn:contentful:::experience:spaces/$self/environments/$self/componentTypes/hero' } }
+  const entity: any = { sys: { id: 'frag-1', type: 'Fragment', version: 1, componentType }, name: 'Hero Fragment' }
 
-  test('CREATE: calls create without sys when entity does not exist in destination', async () => {
+  test('CREATE: calls upsert with id in sys and componentType hoisted from sys', async () => {
     const plainClient = makePlainClientMock()
     await pushToSpace({
       sourceData: { ...baseSourceData, fragments: [entity] } as any,
@@ -185,15 +190,18 @@ describe('Importing Fragments', () => {
       requestQueue
     }).run({ data: {} })
 
-    expect(plainClient.fragment.create).toHaveBeenCalledTimes(1)
-    expect(plainClient.fragment.upsert).not.toHaveBeenCalled()
-    const [params, payload] = plainClient.fragment.create.mock.calls[0] as unknown as [any, any]
-    expect(params).toEqual({ spaceId: 'space-1', environmentId: 'master' })
-    expect(payload).not.toHaveProperty('sys')
+    expect(plainClient.fragment.upsert).toHaveBeenCalledTimes(1)
+    expect(plainClient.fragment.create).not.toHaveBeenCalled()
+    const [params, payload] = plainClient.fragment.upsert.mock.calls[0] as unknown as [any, any]
+    expect(params).toEqual({ spaceId: 'space-1', environmentId: 'master', fragmentId: 'frag-1' })
+    expect(payload.sys.id).toBe('frag-1')
+    expect(payload.sys.type).toBe('Fragment')
+    expect(payload.sys).not.toHaveProperty('version')
+    expect(payload.componentType).toEqual(componentType)
     expect(payload.name).toBe('Hero Fragment')
   })
 
-  test('UPDATE: calls upsert with destination sys.version when entity exists in destination', async () => {
+  test('UPDATE: calls upsert with componentType hoisted and destination sys.version', async () => {
     const plainClient = makePlainClientMock()
     const destinationEntity: any = { sys: { id: 'frag-1', type: 'Fragment', version: 4 } }
     await pushToSpace({
@@ -210,15 +218,16 @@ describe('Importing Fragments', () => {
     const [params, payload] = plainClient.fragment.upsert.mock.calls[0] as unknown as [any, any]
     expect(params).toEqual({ spaceId: 'space-1', environmentId: 'master', fragmentId: 'frag-1' })
     expect(payload.sys.version).toBe(4)
+    expect(payload.componentType).toEqual(componentType)
   })
 })
 
 // ─── DataAssembly ─────────────────────────────────────────────────────────────
 
 describe('Importing Data Assemblies', () => {
-  const entity: any = { sys: { id: 'da-1', type: 'DataAssembly', version: 2 }, name: 'My Assembly' }
+  const entity: any = { sys: { id: 'da-1', type: 'DataAssembly', version: 2, dataType: [{ id: 'headline', name: 'Headline', type: 'Symbol' }] }, name: 'My Assembly' }
 
-  test('CREATE: calls dataAssembly.create (not update) when entity does not exist in destination', async () => {
+  test('CREATE: calls dataAssembly.update with version 0 to preserve id when entity does not exist in destination', async () => {
     const plainClient = makePlainClientMock()
     await pushToSpace({
       sourceData: { ...baseSourceData, dataAssemblies: [entity] } as any,
@@ -231,11 +240,14 @@ describe('Importing Data Assemblies', () => {
       requestQueue
     }).run({ data: {} })
 
-    expect(plainClient.dataAssembly.create).toHaveBeenCalledTimes(1)
-    expect(plainClient.dataAssembly.update).not.toHaveBeenCalled()
-    const [params, payload] = plainClient.dataAssembly.create.mock.calls[0] as unknown as [any, any]
-    expect(params).toEqual({ spaceId: 'space-1', environmentId: 'master' })
-    expect(payload).not.toHaveProperty('sys')
+    expect(plainClient.dataAssembly.update).toHaveBeenCalledTimes(1)
+    expect(plainClient.dataAssembly.create).not.toHaveBeenCalled()
+    const [params, payload] = plainClient.dataAssembly.update.mock.calls[0] as unknown as [any, any]
+    expect(params).toEqual({ spaceId: 'space-1', environmentId: 'master', dataAssemblyId: 'da-1' })
+    expect(payload.sys.id).toBe('da-1')
+    expect(payload.sys.type).toBe('DataAssembly')
+    expect(payload.sys.version).toBe(0)
+    expect(payload.sys.dataType).toEqual(entity.sys.dataType)
     expect(payload.name).toBe('My Assembly')
   })
 
@@ -265,9 +277,10 @@ describe('Importing Data Assemblies', () => {
 // ─── Experience ───────────────────────────────────────────────────────────────
 
 describe('Importing Experiences', () => {
-  const entity: any = { sys: { id: 'exp-1', type: 'Experience', version: 1 }, name: 'My Experience' }
+  const template = { sys: { type: 'ResourceLink', linkType: 'Contentful:Template', urn: 'crn:contentful:::experience:spaces/$self/environments/$self/templates/press-release' } }
+  const entity: any = { sys: { id: 'exp-1', type: 'Experience', version: 1, template }, name: 'My Experience' }
 
-  test('CREATE: calls create without sys when entity does not exist in destination', async () => {
+  test('CREATE: calls upsert with id in sys and template hoisted from sys', async () => {
     const plainClient = makePlainClientMock()
     await pushToSpace({
       sourceData: { ...baseSourceData, experiences: [entity] } as any,
@@ -280,15 +293,18 @@ describe('Importing Experiences', () => {
       requestQueue
     }).run({ data: {} })
 
-    expect(plainClient.experience.create).toHaveBeenCalledTimes(1)
-    expect(plainClient.experience.upsert).not.toHaveBeenCalled()
-    const [params, payload] = plainClient.experience.create.mock.calls[0] as unknown as [any, any]
-    expect(params).toEqual({ spaceId: 'space-1', environmentId: 'master' })
-    expect(payload).not.toHaveProperty('sys')
+    expect(plainClient.experience.upsert).toHaveBeenCalledTimes(1)
+    expect(plainClient.experience.create).not.toHaveBeenCalled()
+    const [params, payload] = plainClient.experience.upsert.mock.calls[0] as unknown as [any, any]
+    expect(params).toEqual({ spaceId: 'space-1', environmentId: 'master', experienceId: 'exp-1' })
+    expect(payload.sys.id).toBe('exp-1')
+    expect(payload.sys.type).toBe('Experience')
+    expect(payload.sys).not.toHaveProperty('version')
+    expect(payload.template).toEqual(template)
     expect(payload.name).toBe('My Experience')
   })
 
-  test('UPDATE: calls upsert with destination sys.version when entity exists in destination', async () => {
+  test('UPDATE: calls upsert with template hoisted and destination sys.version', async () => {
     const plainClient = makePlainClientMock()
     const destinationEntity: any = { sys: { id: 'exp-1', type: 'Experience', version: 6 } }
     await pushToSpace({
@@ -305,6 +321,7 @@ describe('Importing Experiences', () => {
     const [params, payload] = plainClient.experience.upsert.mock.calls[0] as unknown as [any, any]
     expect(params).toEqual({ spaceId: 'space-1', environmentId: 'master', experienceId: 'exp-1' })
     expect(payload.sys.version).toBe(6)
+    expect(payload.template).toEqual(template)
     expect(payload.name).toBe('My Experience')
   })
 })


### PR DESCRIPTION
## Summary
Bug fix to use `upsert()` instead of `create()` when importing exo entities to preserve the id.  using `create()` automatically generates a new ID, which causes any other entities that reference that entity to have broken reference.

## Description

<!-- Describe your changes in detail -->

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

## PR Checklist

- [ ] I have read the `CONTRIBUTING.md` file
- [ ] All commits follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Documentation is updated (if necessary)
- [ ] PR doesn't contain any sensitive information
- [ ] There are no breaking changes
