### PR TITLE
feat: import Design Tokens as part of ExO entity group [AIS-120]

### DIFF
--- a/docs/exo-import.md
+++ b/docs/exo-import.md
@@ -52,7 +52,7 @@ ExO entities have a stricter contract: the CMA validates references **at create 
 
 This means the import order must respect the dependency graph above:
 
-1. **DataAssemblies** and **DesignTokens** — no dependencies, can be imported in parallel (relative to each other)
+1. **DataAssemblies** and **DesignTokens** — no dependencies on each other or on any other ExO type; either can be imported before the other with no ordering risk
 2. **ComponentTypes** — depend on DataAssemblies and DesignTokens (must already exist); may depend on other ComponentTypes
 3. **Templates** — depend on ComponentTypes and DesignTokens
 4. **Fragments** — depend on ComponentTypes, DataAssemblies, and DesignTokens; may depend on other Fragments

--- a/docs/exo-import.md
+++ b/docs/exo-import.md
@@ -2,16 +2,16 @@
 
 ## What is ExO?
 
-Experience Orchestration (ExO) is Contentful's system for composing and rendering structured page experiences. It sits above the traditional entry/content-type layer and provides a dedicated set of entity types — DataAssemblies, ComponentTypes, Templates, Fragments, and Experiences — that together describe *how* content is fetched, assembled, and laid out. DataAssemblies define reusable data-fetching contracts (GraphQL resolvers, parameter bindings). ComponentTypes define the visual building blocks that consume that data. Templates describe full page layouts in terms of ComponentTypes. Fragments are reusable, named compositions of ComponentTypes and data bindings. Experiences wire Templates and Fragments together into publishable page definitions.
+Experience Orchestration (ExO) is Contentful's system for composing and rendering structured page experiences. It sits above the traditional entry/content-type layer and provides a dedicated set of entity types — DataAssemblies, DesignTokens, ComponentTypes, Templates, Fragments, and Experiences — that together describe *how* content is fetched, assembled, and laid out. DataAssemblies define reusable data-fetching contracts (GraphQL resolvers, parameter bindings). DesignTokens define reusable design values (colors, spacing, typography, etc.) that other ExO entities can reference via design properties. ComponentTypes define the visual building blocks that consume that data. Templates describe full page layouts in terms of ComponentTypes. Fragments are reusable, named compositions of ComponentTypes and data bindings. Experiences wire Templates and Fragments together into publishable page definitions.
 
 ## Entity Dependency Model
 
 ExO entities form a strict dependency graph. An entity can only reference types that appear earlier in the hierarchy — there are no circular dependencies across types, though intra-type dependencies are possible for ComponentTypes and Fragments.
 
 ```
-DataAssemblies
-      │
-      ▼
+DataAssemblies      DesignTokens
+      │                   │
+      ▼                   ▼
 ComponentTypes ──────────────────┐
       │                          │ (a CT can reference other CTs
       ▼                          │  in its componentTree)
@@ -24,13 +24,16 @@ ComponentTypes ──────────────────┐
         Experiences
 ```
 
-| Entity         | References                                        | Referenced by                        |
-|----------------|---------------------------------------------------|--------------------------------------|
-| DataAssembly   | nothing                                           | ComponentTypes, Fragments, Experiences |
-| ComponentType  | DataAssemblies, other ComponentTypes              | Templates, Fragments, Experiences    |
-| Template       | ComponentTypes                                    | Experiences                          |
-| Fragment       | ComponentTypes, DataAssemblies, other Fragments   | Experiences                          |
-| Experience     | Templates, Fragments, DataAssemblies              | nothing                              |
+DesignTokens feed into ComponentType/Template/Fragment/Experience via design property references (`designProperties.defaultValue`/`fallbackValue`/`allowedResources`), not via the `componentTree`/`slots` mechanism used for CT-to-CT or Fragment-to-Fragment references.
+
+| Entity         | References                                                    | Referenced by                                            |
+|----------------|----------------------------------------------------------------|-----------------------------------------------------------|
+| DesignToken    | nothing                                                         | ComponentTypes, Templates, Fragments, Experiences          |
+| DataAssembly   | nothing                                                         | ComponentTypes, Fragments, Experiences                     |
+| ComponentType  | DataAssemblies, DesignTokens, other ComponentTypes              | Templates, Fragments, Experiences                          |
+| Template       | ComponentTypes, DesignTokens                                    | Experiences                                                |
+| Fragment       | ComponentTypes, DataAssemblies, DesignTokens, other Fragments   | Experiences                                                |
+| Experience     | Templates, Fragments, DataAssemblies, DesignTokens              | nothing                                                    |
 
 ## ID Preservation Is Required
 
@@ -38,7 +41,7 @@ ExO entities reference each other via URN pointers that embed the entity's `sys.
 
 For this reason, all ExO entity creates must use a PUT-with-ID call (upsert semantics), not a bare POST:
 
-- **ComponentTypes, Templates, Fragments, Experiences** — use `plainClient.<type>.upsert(...)` with `sys: { id, type }` and no `version` field (omitting version signals create intent).
+- **ComponentTypes, Templates, Fragments, Experiences, DesignTokens** — use `plainClient.<type>.upsert(...)` with `sys: { id, type }` and no `version` field (omitting version signals create intent).
 - **DataAssemblies** — the SDK has no `upsert`; use `plainClient.dataAssembly.update(...)` with `sys.version: 0`, which maps to `PUT /data_assemblies/{id}` and creates the entity with the specified ID.
 
 ## Why Load Order Matters
@@ -49,14 +52,14 @@ ExO entities have a stricter contract: the CMA validates references **at create 
 
 This means the import order must respect the dependency graph above:
 
-1. **DataAssemblies** — no dependencies, can be imported in parallel
-2. **ComponentTypes** — depend on DataAssemblies (must already exist); may depend on other ComponentTypes
-3. **Templates** — depend on ComponentTypes
-4. **Fragments** — depend on ComponentTypes and DataAssemblies; may depend on other Fragments
-5. **Experiences** — depend on Templates, Fragments, and DataAssemblies
+1. **DataAssemblies** and **DesignTokens** — no dependencies, can be imported in parallel (relative to each other)
+2. **ComponentTypes** — depend on DataAssemblies and DesignTokens (must already exist); may depend on other ComponentTypes
+3. **Templates** — depend on ComponentTypes and DesignTokens
+4. **Fragments** — depend on ComponentTypes, DataAssemblies, and DesignTokens; may depend on other Fragments
+5. **Experiences** — depend on Templates, Fragments, DataAssemblies, and DesignTokens
 
 ## Why Intra-Type Sorting Is Required
 
-DataAssemblies, Templates, and Experiences have no dependencies within their own type and can be imported in parallel. ComponentTypes and Fragments are different: a ComponentType can embed other ComponentTypes in its `componentTree` (e.g. a "Page" CT that slots in a "Hero" CT), and a Fragment can reference other Fragments in its `slots`. If these are imported in arbitrary order — or all at once via `Promise.all` — the CMA can receive a create request for the composite entity before its dependency exists, causing a `404`.
+DataAssemblies, DesignTokens, Templates, and Experiences have no dependencies within their own type and can be imported in parallel. ComponentTypes and Fragments are different: a ComponentType can embed other ComponentTypes in its `componentTree` (e.g. a "Page" CT that slots in a "Hero" CT), and a Fragment can reference other Fragments in its `slots`. If these are imported in arbitrary order — or all at once via `Promise.all` — the CMA can receive a create request for the composite entity before its dependency exists, causing a `404`.
 
 To prevent this, `contentful-import` applies a topological sort (Kahn's algorithm) to both ComponentTypes and Fragments before importing them, and then imports each sorted list sequentially. The sort parses URN references from `componentTree` and `slots` to build a dependency graph, resolves the safe creation order, and falls back to appending any cyclic nodes at the end so the import can still proceed rather than failing outright.

--- a/lib/parseOptions.ts
+++ b/lib/parseOptions.ts
@@ -16,6 +16,7 @@ const SUPPORTED_ENTITY_TYPES = [
   'locales',
   'webhooks',
   'editorInterfaces',
+  'designTokens',
   'componentTypes',
   'templates',
   'dataAssemblies',

--- a/lib/tasks/get-destination-data.ts
+++ b/lib/tasks/get-destination-data.ts
@@ -1,7 +1,7 @@
 import Promise from 'bluebird'
 
 import { logEmitter } from 'contentful-batch-libs/dist/logging'
-import type { AssetProps, ComponentTypeProps, ContentTypeProps, DataAssemblyProps, EntryProps, ExperienceProps, FragmentProps, LocaleProps, TagProps, TemplateProps, WebhookProps } from 'contentful-management'
+import type { AssetProps, ComponentTypeProps, ContentTypeProps, DataAssemblyProps, DesignTokenProps, EntryProps, ExperienceProps, FragmentProps, LocaleProps, TagProps, TemplateProps, WebhookProps } from 'contentful-management'
 import { OriginalSourceData } from '../types'
 import PQueue from 'p-queue'
 
@@ -17,12 +17,12 @@ const OFFSET_QUERY_METHODS = {
 }
 
 const CURSOR_QUERY_METHODS = {
+  designTokens: { name: 'design tokens', namespace: 'designToken' },
   componentTypes: { name: 'component types', namespace: 'componentType' },
   templates: { name: 'templates', namespace: 'template' },
   fragments: { name: 'fragments', namespace: 'fragment' },
   dataAssemblies: { name: 'data assemblies', namespace: 'dataAssembly' },
   experiences: { name: 'experiences', namespace: 'experience' }
-  // TODO: add designTokens once the contentful-management SDK exposes a designToken plain client API
 }
 
 type BatchedIdQueryParams = {
@@ -173,7 +173,7 @@ type AllDestinationData = {
   fragments?: Promise<FragmentProps[]>
   dataAssemblies?: Promise<DataAssemblyProps[]>
   experiences?: Promise<ExperienceProps[]>
-  // TODO: add designTokens once the contentful-management SDK exposes a designToken plain client API
+  designTokens?: Promise<DesignTokenProps[]>
 }
 
 type GetDestinationDataParams = {
@@ -223,7 +223,7 @@ export default async function getDestinationData({
     componentTypes: [],
     fragments: [],
     dataAssemblies: [],
-    // designTokens: [], // TODO: add designTokens once the contentful-management SDK exposes a designToken plain client API
+    designTokens: [],
     webhooks: [],
   }
 
@@ -289,12 +289,12 @@ export default async function getDestinationData({
   }
 
   if (includeExperienceOrchestration && plainClient) {
+    result.designTokens = cursorPaginatedQuery({ plainClient, spaceId, environmentId, type: 'designTokens', requestQueue })
     result.componentTypes = cursorPaginatedQuery({ plainClient, spaceId, environmentId, type: 'componentTypes', requestQueue })
     result.templates = cursorPaginatedQuery({ plainClient, spaceId, environmentId, type: 'templates', requestQueue })
     result.fragments = cursorPaginatedQuery({ plainClient, spaceId, environmentId, type: 'fragments', requestQueue })
     result.dataAssemblies = cursorPaginatedQuery({ plainClient, spaceId, environmentId, type: 'dataAssemblies', requestQueue })
     result.experiences = cursorPaginatedQuery({ plainClient, spaceId, environmentId, type: 'experiences', requestQueue })
-    // TODO: fetch destination designTokens here once the contentful-management SDK exposes a designToken plain client API
   }
 
   return Promise.props(result)

--- a/lib/tasks/push-to-space/push-to-space.ts
+++ b/lib/tasks/push-to-space/push-to-space.ts
@@ -9,6 +9,7 @@ import {
   UpsertFragmentProps,
   UpsertExperienceProps,
   UpdateDataAssemblyProps,
+  UpsertDesignTokenProps,
 } from 'contentful-management'
 
 import * as assets from './assets'
@@ -443,6 +444,32 @@ export default function pushToSpace({
       skip: () => !includeExperienceOrchestration || !(sourceData.dataAssemblies || []).length
     },
     {
+      title: 'Importing Design Tokens',
+      task: wrapTask(async (ctx) => {
+        const results = await Promise.all((sourceData.designTokens || []).map(async (entity) => {
+          try {
+            const existing = destinationDataById.designTokens?.get(entity.sys.id)
+            if (existing) {
+              const payload: UpsertDesignTokenProps = { ...entity, sys: { id: entity.sys.id, type: 'DesignToken', version: existing.sys.version } }
+              const result = await plainClient.designToken.upsert({ spaceId, environmentId, designTokenId: entity.sys.id }, payload)
+              logEmitter.emit('info', `UPDATE DesignToken ${entity.sys.id}`)
+              return result
+            } else {
+              const payload: UpsertDesignTokenProps = { ...omitSys(entity), sys: { id: entity.sys.id, type: 'DesignToken' } }
+              const result = await plainClient.designToken.upsert({ spaceId, environmentId, designTokenId: entity.sys.id }, payload)
+              logEmitter.emit('info', `CREATE DesignToken ${entity.sys.id}`)
+              return result
+            }
+          } catch (err) {
+            logEmitter.emit('error', err)
+            return null
+          }
+        }))
+        ctx.data.designTokens = results.filter(Boolean)
+      }),
+      skip: () => !includeExperienceOrchestration || !(sourceData.designTokens || []).length
+    },
+    {
       title: 'Importing Component Types',
       task: wrapTask(async (ctx) => {
         const sorted = sortComponentTypes(sourceData.componentTypes || [])
@@ -548,7 +575,6 @@ export default function pushToSpace({
       }),
       skip: () => !includeExperienceOrchestration || !(sourceData.experiences || []).length
     }
-    // TODO: add 'Importing Design Tokens' task once the contentful-management SDK exposes a designToken plain client API
   ], listrOptions)
 }
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,7 +1,7 @@
 import type { AssetProps, ContentTypeProps, EditorInterfaceProps, EntryProps, Link, LocaleProps, TagProps, WebhookProps } from 'contentful-management'
-import type { ComponentTypeProps, DataAssemblyProps, ExperienceProps, FragmentProps, TemplateProps } from 'contentful-management'
+import type { ComponentTypeProps, DataAssemblyProps, DesignTokenProps, ExperienceProps, FragmentProps, TemplateProps } from 'contentful-management'
 
-export type { ComponentTypeProps, DataAssemblyProps, ExperienceProps, FragmentProps, TemplateProps }
+export type { ComponentTypeProps, DataAssemblyProps, DesignTokenProps, ExperienceProps, FragmentProps, TemplateProps }
 
 export type Resources = {
   contentTypes?: ContentTypeProps[]
@@ -16,6 +16,7 @@ export type Resources = {
   fragments?: FragmentProps[]
   dataAssemblies?: DataAssemblyProps[]
   experiences?: ExperienceProps[]
+  designTokens?: DesignTokenProps[]
 }
 
 export type ResourcesUnion = (ContentTypeProps | TagProps | LocaleProps | EntryProps | AssetProps | EditorInterfaceProps | WebhookProps)[]
@@ -49,6 +50,7 @@ export type TransformedSourceData = {
   fragments?: FragmentProps[]
   dataAssemblies?: DataAssemblyProps[]
   experiences?: ExperienceProps[]
+  designTokens?: DesignTokenProps[]
 }
 
 export type TransformedSourceDataUnion = (

--- a/lib/usageParams.ts
+++ b/lib/usageParams.ts
@@ -84,7 +84,7 @@ export default yargs
     describe: 'Pass an additional HTTP Header'
   })
   .option('include-experience-orchestration', {
-    describe: 'Import Experience Orchestration entities (componentTypes, templates, fragments, dataAssemblies, experiences). Requires a space with ExO enabled.',
+    describe: 'Import Experience Orchestration entities (designTokens, componentTypes, templates, fragments, dataAssemblies, experiences). Requires a space with ExO enabled.',
     type: 'boolean',
     default: true
   })

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "bluebird": "^3.7.2",
         "cli-table3": "^0.6.5",
         "contentful-batch-libs": "^9.7.0",
-        "contentful-management": "file:../../.local-tarballs/contentful-management-0.0.0-determined-by-semantic-release.tgz",
+        "contentful-management": "^12.12.0",
         "date-fns": "^2.30.0",
         "joi": "^18.2.3",
         "listr": "^0.14.3",
@@ -4982,9 +4982,9 @@
       }
     },
     "node_modules/contentful-management": {
-      "version": "0.0.0-determined-by-semantic-release",
-      "resolved": "file:../../.local-tarballs/contentful-management-0.0.0-determined-by-semantic-release.tgz",
-      "integrity": "sha512-9KLjhvqiaypvxRmc/jCu7LoZuydjjeDZEaiWQ/lkwdKXeFqhOrzMp/8nkJw6C4RDay5N8pBE1zvH1ZG/XPVlQw==",
+      "version": "12.12.0",
+      "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-12.12.0.tgz",
+      "integrity": "sha512-8K4jvWTUfBS+N8VoUKHolFktEi1i2pIBt2uFnPHhAkCeOfARDc4bjEeKizNoPcBL7T7W6YvS2KIJOUPKKHHxVQ==",
       "license": "MIT",
       "dependencies": {
         "@contentful/rich-text-types": "^16.6.1",
@@ -19966,8 +19966,9 @@
       }
     },
     "contentful-management": {
-      "version": "file:../../.local-tarballs/contentful-management-0.0.0-determined-by-semantic-release.tgz",
-      "integrity": "sha512-9KLjhvqiaypvxRmc/jCu7LoZuydjjeDZEaiWQ/lkwdKXeFqhOrzMp/8nkJw6C4RDay5N8pBE1zvH1ZG/XPVlQw==",
+      "version": "12.12.0",
+      "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-12.12.0.tgz",
+      "integrity": "sha512-8K4jvWTUfBS+N8VoUKHolFktEi1i2pIBt2uFnPHhAkCeOfARDc4bjEeKizNoPcBL7T7W6YvS2KIJOUPKKHHxVQ==",
       "requires": {
         "@contentful/rich-text-types": "^16.6.1",
         "axios": "^1.15.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "bluebird": "^3.7.2",
         "cli-table3": "^0.6.5",
         "contentful-batch-libs": "^9.7.0",
-        "contentful-management": "^12.10.0",
+        "contentful-management": "file:../../.local-tarballs/contentful-management-0.0.0-determined-by-semantic-release.tgz",
         "date-fns": "^2.30.0",
         "joi": "^18.2.3",
         "listr": "^0.14.3",
@@ -4982,9 +4982,9 @@
       }
     },
     "node_modules/contentful-management": {
-      "version": "12.10.0",
-      "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-12.10.0.tgz",
-      "integrity": "sha512-pZKIJGCw9RwMrMxNrdTs5qeglkyMRkwvBWOREt5a0MiTJdLWrBPJ7tPXViNFS29Md8BqGiS3IWPCaXaiff2qjw==",
+      "version": "0.0.0-determined-by-semantic-release",
+      "resolved": "file:../../.local-tarballs/contentful-management-0.0.0-determined-by-semantic-release.tgz",
+      "integrity": "sha512-9KLjhvqiaypvxRmc/jCu7LoZuydjjeDZEaiWQ/lkwdKXeFqhOrzMp/8nkJw6C4RDay5N8pBE1zvH1ZG/XPVlQw==",
       "license": "MIT",
       "dependencies": {
         "@contentful/rich-text-types": "^16.6.1",
@@ -16078,6 +16078,24 @@
         "node": ">= 12"
       }
     },
+    "node_modules/tsup/node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
     "node_modules/tunnel": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
@@ -19948,9 +19966,8 @@
       }
     },
     "contentful-management": {
-      "version": "12.10.0",
-      "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-12.10.0.tgz",
-      "integrity": "sha512-pZKIJGCw9RwMrMxNrdTs5qeglkyMRkwvBWOREt5a0MiTJdLWrBPJ7tPXViNFS29Md8BqGiS3IWPCaXaiff2qjw==",
+      "version": "file:../../.local-tarballs/contentful-management-0.0.0-determined-by-semantic-release.tgz",
+      "integrity": "sha512-9KLjhvqiaypvxRmc/jCu7LoZuydjjeDZEaiWQ/lkwdKXeFqhOrzMp/8nkJw6C4RDay5N8pBE1zvH1ZG/XPVlQw==",
       "requires": {
         "@contentful/rich-text-types": "^16.6.1",
         "axios": "^1.15.0",
@@ -27034,6 +27051,14 @@
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
           "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
           "dev": true
+        },
+        "yaml": {
+          "version": "2.9.0",
+          "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+          "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+          "dev": true,
+          "optional": true,
+          "peer": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "bluebird": "^3.7.2",
     "cli-table3": "^0.6.5",
     "contentful-batch-libs": "^9.7.0",
-    "contentful-management": "^12.10.0",
+    "contentful-management": "file:../../.local-tarballs/contentful-management-0.0.0-determined-by-semantic-release.tgz",
     "date-fns": "^2.30.0",
     "joi": "^18.2.3",
     "listr": "^0.14.3",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "bluebird": "^3.7.2",
     "cli-table3": "^0.6.5",
     "contentful-batch-libs": "^9.7.0",
-    "contentful-management": "file:../../.local-tarballs/contentful-management-0.0.0-determined-by-semantic-release.tgz",
+    "contentful-management": "^12.12.0",
     "date-fns": "^2.30.0",
     "joi": "^18.2.3",
     "listr": "^0.14.3",

--- a/test/unit/index.test.ts
+++ b/test/unit/index.test.ts
@@ -165,7 +165,8 @@ test('Runs Contentful Import', () => {
       expect(introTable.push.mock.calls[5][0]).toEqual(['Editor Interfaces', 2])
       expect(introTable.push.mock.calls[6][0]).toEqual(['Locales', 2])
       expect(introTable.push.mock.calls[7][0]).toEqual(['Webhooks', 0])
-      expect(introTable.push.mock.calls).toHaveLength(13)
+      expect(introTable.push.mock.calls[8][0]).toEqual(['Design Tokens', 0])
+      expect(introTable.push.mock.calls).toHaveLength(14)
 
       const resultTable = (TableStub as jest.Mock).mock.instances[1]
       expect(resultTable.push.mock.calls[0][0]).toEqual([{ colSpan: 2, content: 'Imported entities' }])
@@ -176,7 +177,8 @@ test('Runs Contentful Import', () => {
       expect(resultTable.push.mock.calls[5][0]).toEqual(['Editor Interfaces', 2])
       expect(resultTable.push.mock.calls[6][0]).toEqual(['Locales', 2])
       expect(resultTable.push.mock.calls[7][0]).toEqual(['Webhooks', 0])
-      expect(resultTable.push.mock.calls).toHaveLength(13)
+      expect(resultTable.push.mock.calls[8][0]).toEqual(['Design Tokens', 0])
+      expect(resultTable.push.mock.calls).toHaveLength(14)
     })
 })
 
@@ -248,7 +250,8 @@ test('Intro CLI table respects skipContentModel', () => {
       expect(introTable.push.mock.calls[3][0]).toEqual(['Locales', 2])
       expect(introTable.push.mock.calls[4][0]).toEqual(['Tags', 0])
       expect(introTable.push.mock.calls[5][0]).toEqual(['Webhooks', 0])
-      expect(introTable.push.mock.calls).toHaveLength(11)
+      expect(introTable.push.mock.calls[6][0]).toEqual(['Design Tokens', 0])
+      expect(introTable.push.mock.calls).toHaveLength(12)
     })
 })
 

--- a/test/unit/parseOptions.test.ts
+++ b/test/unit/parseOptions.test.ts
@@ -98,6 +98,7 @@ test('parseOptions sets correct default options', async () => {
     componentTypes: [],
     contentTypes: [],
     dataAssemblies: [],
+    designTokens: [],
     editorInterfaces: [],
     entries: [],
     experiences: [],
@@ -191,7 +192,7 @@ test('parseOption cleans up content to only include supported entity types', asy
     }
   })
   const content = options.content
-  expect(Object.keys(content)).toHaveLength(12)
+  expect(Object.keys(content)).toHaveLength(13)
   expect(content.invalid).toBeUndefined()
 })
 

--- a/test/unit/tasks/get-destination-data-exo.test.ts
+++ b/test/unit/tasks/get-destination-data-exo.test.ts
@@ -30,6 +30,7 @@ function makeOffsetResolver(items: any[]) {
 // ─── Fixtures ─────────────────────────────────────────────────────────────────
 
 const exoItems = {
+  designTokens: Array.from({ length: 7 }, (_, i) => makeEntity(`dt-${i}`)),
   componentTypes: Array.from({ length: 5 }, (_, i) => makeEntity(`ct-${i}`)),
   templates: Array.from({ length: 3 }, (_, i) => makeEntity(`tmpl-${i}`)),
   fragments: Array.from({ length: 4 }, (_, i) => makeEntity(`frag-${i}`)),
@@ -39,6 +40,7 @@ const exoItems = {
 
 function makePlainClientMock() {
   return {
+    designToken: { getMany: makeCursorResolver(exoItems.designTokens) },
     componentType: { getMany: makeCursorResolver(exoItems.componentTypes) },
     template: { getMany: makeCursorResolver(exoItems.templates) },
     fragment: { getMany: makeCursorResolver(exoItems.fragments) },
@@ -117,6 +119,7 @@ test('does NOT call plainClient ExO methods when includeExperienceOrchestration 
     requestQueue
   })
 
+  expect(plainClient.designToken.getMany).not.toHaveBeenCalled()
   expect(plainClient.componentType.getMany).not.toHaveBeenCalled()
   expect(plainClient.template.getMany).not.toHaveBeenCalled()
   expect(plainClient.fragment.getMany).not.toHaveBeenCalled()
@@ -147,6 +150,22 @@ test('follows pageNext cursor across multiple pages', async () => {
 })
 
 // ─── Returns destination data for all ExO entities ───────────────────────────
+
+test('returns destination designTokens fetched via cursor pagination', async () => {
+  const plainClient = makePlainClientMock()
+  const result = await getDestinationData({
+    client: mockClient,
+    plainClient,
+    spaceId: 'space-1',
+    environmentId: 'master',
+    sourceData: {},
+    includeExperienceOrchestration: true,
+    requestQueue
+  })
+
+  expect(result.designTokens).toHaveLength(exoItems.designTokens.length)
+  expect(result.designTokens![0].sys.id).toBe('dt-0')
+})
 
 test('returns destination componentTypes fetched via cursor pagination', async () => {
   const plainClient = makePlainClientMock()
@@ -230,6 +249,7 @@ test('returns destination experiences fetched via cursor pagination', async () =
 
 test('returns empty arrays for all ExO entities when none exist in destination', async () => {
   const emptyPlainClient = {
+    designToken: { getMany: jest.fn(() => Promise.resolve({ items: [] })) },
     componentType: { getMany: jest.fn(() => Promise.resolve({ items: [] })) },
     template: { getMany: jest.fn(() => Promise.resolve({ items: [] })) },
     fragment: { getMany: jest.fn(() => Promise.resolve({ items: [] })) },
@@ -247,6 +267,7 @@ test('returns empty arrays for all ExO entities when none exist in destination',
     requestQueue
   })
 
+  expect(result.designTokens).toHaveLength(0)
   expect(result.componentTypes).toHaveLength(0)
   expect(result.templates).toHaveLength(0)
   expect(result.fragments).toHaveLength(0)

--- a/test/unit/tasks/push/push-to-space-exo.test.ts
+++ b/test/unit/tasks/push/push-to-space-exo.test.ts
@@ -27,6 +27,10 @@ function makeClientMock() {
 
 function makePlainClientMock() {
   return {
+    designToken: {
+      create: jest.fn(() => Promise.resolve({ sys: { id: 'dt-1' } })),
+      upsert: jest.fn(() => Promise.resolve({ sys: { id: 'dt-1' } })),
+    },
     componentType: {
       create: jest.fn(() => Promise.resolve({ sys: { id: 'ct-1' } })),
       upsert: jest.fn(() => Promise.resolve({ sys: { id: 'ct-1' } })),
@@ -271,6 +275,73 @@ describe('Importing Data Assemblies', () => {
     expect(params).toEqual({ spaceId: 'space-1', environmentId: 'master', dataAssemblyId: 'da-1' })
     expect(payload.sys.version).toBe(9)
     expect(payload.name).toBe('My Assembly')
+  })
+})
+
+// ─── DesignToken ──────────────────────────────────────────────────────────────
+
+describe('Importing Design Tokens', () => {
+  const entity: any = { sys: { id: 'dt-1', type: 'DesignToken', version: 2 }, name: 'Primary Blue', type: 'DTCG.Color' }
+
+  test('CREATE: calls upsert with id in sys when entity does not exist in destination', async () => {
+    const plainClient = makePlainClientMock()
+    await pushToSpace({
+      sourceData: { ...baseSourceData, designTokens: [entity] } as any,
+      destinationData: { ...baseDestinationData, designTokens: [] },
+      client: makeClientMock(),
+      plainClient,
+      spaceId: 'space-1',
+      environmentId: 'master',
+      includeExperienceOrchestration: true,
+      requestQueue
+    }).run({ data: {} })
+
+    expect(plainClient.designToken.upsert).toHaveBeenCalledTimes(1)
+    expect(plainClient.designToken.create).not.toHaveBeenCalled()
+    const [params, payload] = plainClient.designToken.upsert.mock.calls[0] as unknown as [any, any]
+    expect(params).toEqual({ spaceId: 'space-1', environmentId: 'master', designTokenId: 'dt-1' })
+    expect(payload.sys.id).toBe('dt-1')
+    expect(payload.sys.type).toBe('DesignToken')
+    expect(payload.sys).not.toHaveProperty('version')
+    expect(payload.name).toBe('Primary Blue')
+    expect(payload.type).toBe('DTCG.Color')
+  })
+
+  test('UPDATE: calls upsert with destination sys.version when entity exists in destination', async () => {
+    const plainClient = makePlainClientMock()
+    const destinationEntity: any = { sys: { id: 'dt-1', type: 'DesignToken', version: 7 } }
+    await pushToSpace({
+      sourceData: { ...baseSourceData, designTokens: [entity] } as any,
+      destinationData: { ...baseDestinationData, designTokens: [destinationEntity] },
+      client: makeClientMock(),
+      plainClient,
+      spaceId: 'space-1',
+      environmentId: 'master',
+      includeExperienceOrchestration: true,
+      requestQueue
+    }).run({ data: {} })
+
+    expect(plainClient.designToken.upsert).toHaveBeenCalledTimes(1)
+    const [params, payload] = plainClient.designToken.upsert.mock.calls[0] as unknown as [any, any]
+    expect(params).toEqual({ spaceId: 'space-1', environmentId: 'master', designTokenId: 'dt-1' })
+    expect(payload.sys.version).toBe(7)
+    expect(payload.name).toBe('Primary Blue')
+  })
+
+  test('skips task when includeExperienceOrchestration is false', async () => {
+    const plainClient = makePlainClientMock()
+    await pushToSpace({
+      sourceData: { ...baseSourceData, designTokens: [entity] } as any,
+      destinationData: baseDestinationData,
+      client: makeClientMock(),
+      plainClient,
+      spaceId: 'space-1',
+      environmentId: 'master',
+      includeExperienceOrchestration: false,
+      requestQueue
+    }).run({ data: {} })
+
+    expect(plainClient.designToken.upsert).not.toHaveBeenCalled()
   })
 })
 


### PR DESCRIPTION
[AIS-120](https://contentful.atlassian.net/browse/AIS-120)

## Summary
- Adds DesignToken support to the destination-data prefetch (`get-destination-data.ts`) and `push-to-space` Listr tasks, mirroring the existing pattern for ComponentType/Template/Fragment/DataAssembly/Experience.
- DesignToken has no dependencies but is referenced by ComponentType, Template, Fragment, and Experience (via `designProperties`), all of which validate the reference synchronously at write time against the upstream `assemblies` API. The new "Importing Design Tokens" task is placed before "Importing Component Types" to satisfy this ordering constraint.
- Confirmed via investigation of the upstream `assemblies` API that DesignToken needs neither the `withGraphQLSchemaBackoff` retry wrapper (DataAssembly-specific — DesignToken resolution is a direct entity-store read, not validated against a compiled/cached GraphQL schema) nor an intra-type topological sort (ComponentType/Fragment-specific — DesignTokens don't reference each other).
- Updates `docs/exo-import.md`'s dependency graph, table, and load-order sections to include DesignToken.
- Adds test coverage across `get-destination-data-exo.test.ts` (cursor pagination, skip-when-disabled, empty-destination cases) and `push-to-space-exo.test.ts` (new "Importing Design Tokens" describe block: CREATE/UPDATE/skip, mirroring the Template block). Updates `parseOptions.test.ts` and `index.test.ts` for the new supported entity type.
- Bumps `contentful-management` to `^12.12.0`, which now ships DesignToken support natively — matches the pattern already used for the other 5 ExO entities.

## Test plan
- [x] `tsc` clean on both main and test configs
- [x] `npm run build` succeeds (dual CJS/ESM)
- [x] All 21 suites / 145 unit tests pass
- [x] Verified end-to-end against a live sandbox space (`3fyh0othob6d`): imported the design-token-inclusive export into a fresh environment — all 16 DesignTokens created with preserved IDs, followed by 29 ComponentTypes and 1 Template referencing them with zero `404`/`422` reference-resolution errors. Re-ran the import to confirm the UPDATE path.

Generated with [Claude Code](https://claude.com/claude-code)

[AIS-120]: https://contentful.atlassian.net/browse/AIS-120?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ