### PR TITLE
fix: correct ExO entity UPDATE payloads for DataAssembly, Fragment, Experience [AIS-341]

### DIFF
--- a/lib/tasks/push-to-space/push-to-space.ts
+++ b/lib/tasks/push-to-space/push-to-space.ts
@@ -419,7 +419,7 @@ export default function pushToSpace({
             const existing = destinationDataById.dataAssemblies?.get(entity.sys.id)
             let result
             if (existing) {
-              const payload: UpdateDataAssemblyProps = { ...entity, sys: { ...entity.sys, version: existing.sys.version } }
+              const payload: UpdateDataAssemblyProps = { ...omitSys(entity), sys: { id: entity.sys.id, type: 'DataAssembly', dataType: entity.sys.dataType, ...(entity.sys.variant ? { variant: entity.sys.variant } : {}), version: existing.sys.version } }
               result = await withGraphQLSchemaBackoff(() => plainClient.dataAssembly.update(
                 { spaceId, environmentId, dataAssemblyId: entity.sys.id },
                 payload
@@ -531,7 +531,8 @@ export default function pushToSpace({
           try {
             const existing = destinationDataById.fragments?.get(entity.sys.id)
             if (existing) {
-              const payload: UpsertFragmentProps = { ...entity, componentType: entity.sys.componentType, sys: { id: entity.sys.id, type: 'Fragment', version: existing.sys.version } }
+              // componentType is immutable after creation; omit it from the update payload
+              const payload: UpsertFragmentProps = { ...entity, sys: { id: entity.sys.id, type: 'Fragment', version: existing.sys.version } }
               const result = await plainClient.fragment.upsert({ spaceId, environmentId, fragmentId: entity.sys.id }, payload)
               logEmitter.emit('info', `UPDATE Fragment ${entity.sys.id}`)
               results.push(result)
@@ -556,7 +557,8 @@ export default function pushToSpace({
           try {
             const existing = destinationDataById.experiences?.get(entity.sys.id)
             if (existing) {
-              const payload: UpsertExperienceProps = { ...entity, template: entity.sys.template, sys: { id: entity.sys.id, type: 'Experience', version: existing.sys.version } }
+              // template is immutable after creation; omit it from the update payload
+              const payload: UpsertExperienceProps = { ...entity, sys: { id: entity.sys.id, type: 'Experience', version: existing.sys.version } }
               const result = await plainClient.experience.upsert({ spaceId, environmentId, experienceId: entity.sys.id }, payload)
               logEmitter.emit('info', `UPDATE Experience ${entity.sys.id}`)
               return result

--- a/lib/tasks/push-to-space/push-to-space.ts
+++ b/lib/tasks/push-to-space/push-to-space.ts
@@ -10,6 +10,7 @@ import {
   UpsertExperienceProps,
   UpdateDataAssemblyProps,
   UpsertDesignTokenProps,
+  DataAssemblyProps,
 } from 'contentful-management'
 
 import * as assets from './assets'
@@ -419,14 +420,14 @@ export default function pushToSpace({
             const existing = destinationDataById.dataAssemblies?.get(entity.sys.id)
             let result
             if (existing) {
-              const payload: UpdateDataAssemblyProps = { ...omitSys(entity), sys: { id: entity.sys.id, type: 'DataAssembly', dataType: entity.sys.dataType, ...(entity.sys.variant ? { variant: entity.sys.variant } : {}), version: existing.sys.version } }
+              const payload: UpdateDataAssemblyProps = { ...omitSys(entity), sys: buildDataAssemblySys(entity, existing.sys.version) }
               result = await withGraphQLSchemaBackoff(() => plainClient.dataAssembly.update(
                 { spaceId, environmentId, dataAssemblyId: entity.sys.id },
                 payload
               ))
               logEmitter.emit('info', `UPDATE DataAssembly ${entity.sys.id}`)
             } else {
-              const payload: UpdateDataAssemblyProps = { ...omitSys(entity), sys: { id: entity.sys.id, type: 'DataAssembly', dataType: entity.sys.dataType, ...(entity.sys.variant ? { variant: entity.sys.variant } : {}), version: 0 } }
+              const payload: UpdateDataAssemblyProps = { ...omitSys(entity), sys: buildDataAssemblySys(entity, 0) }
               result = await withGraphQLSchemaBackoff(() => plainClient.dataAssembly.update(
                 { spaceId, environmentId, dataAssemblyId: entity.sys.id },
                 payload
@@ -584,6 +585,16 @@ function omitSys(entity) {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { sys: _sys, ...rest } = entity
   return rest
+}
+
+function buildDataAssemblySys(entity: DataAssemblyProps, version: number) {
+  return {
+    id: entity.sys.id,
+    type: 'DataAssembly' as const,
+    dataType: entity.sys.dataType,
+    ...(entity.sys.variant ? { variant: entity.sys.variant } : {}),
+    version
+  }
 }
 
 function archiveEntities({ entities, sourceEntities, requestQueue }) {

--- a/lib/tasks/push-to-space/push-to-space.ts
+++ b/lib/tasks/push-to-space/push-to-space.ts
@@ -532,7 +532,7 @@ export default function pushToSpace({
           try {
             const existing = destinationDataById.fragments?.get(entity.sys.id)
             if (existing) {
-              // componentType is immutable after creation; omit it from the update payload
+              // once a Fragment is created, its componentType cannot be changed to a different componentType
               const payload: UpsertFragmentProps = { ...entity, sys: { id: entity.sys.id, type: 'Fragment', version: existing.sys.version } }
               const result = await plainClient.fragment.upsert({ spaceId, environmentId, fragmentId: entity.sys.id }, payload)
               logEmitter.emit('info', `UPDATE Fragment ${entity.sys.id}`)
@@ -558,7 +558,7 @@ export default function pushToSpace({
           try {
             const existing = destinationDataById.experiences?.get(entity.sys.id)
             if (existing) {
-              // template is immutable after creation; omit it from the update payload
+              // once an Experience is created, its template cannot be changed to a different template
               const payload: UpsertExperienceProps = { ...entity, sys: { id: entity.sys.id, type: 'Experience', version: existing.sys.version } }
               const result = await plainClient.experience.upsert({ spaceId, environmentId, experienceId: entity.sys.id }, payload)
               logEmitter.emit('info', `UPDATE Experience ${entity.sys.id}`)

--- a/lib/tasks/push-to-space/push-to-space.ts
+++ b/lib/tasks/push-to-space/push-to-space.ts
@@ -10,7 +10,6 @@ import {
   UpsertExperienceProps,
   UpdateDataAssemblyProps,
   UpsertDesignTokenProps,
-  DataAssemblyProps,
 } from 'contentful-management'
 
 import * as assets from './assets'
@@ -19,6 +18,7 @@ import * as publishing from './publishing'
 import type { DestinationData, TransformedSourceData, Resources, TransformedAsset } from '../../types'
 import { ContentfulEntityError } from '../../utils/errors'
 import { GRAPHQL_SCHEMA_STALE_DELAYS_MS, isGraphQLSchemaStaleError } from '../../utils/graphql-schema-backoff'
+import { buildDataAssemblySys } from '../../utils/exo-entity-payloads'
 import sortComponentTypes from '../../utils/sort-component-types'
 import sortFragments from '../../utils/sort-fragments'
 
@@ -585,16 +585,6 @@ function omitSys(entity) {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { sys: _sys, ...rest } = entity
   return rest
-}
-
-function buildDataAssemblySys(entity: DataAssemblyProps, version: number) {
-  return {
-    id: entity.sys.id,
-    type: 'DataAssembly' as const,
-    dataType: entity.sys.dataType,
-    ...(entity.sys.variant ? { variant: entity.sys.variant } : {}),
-    version
-  }
 }
 
 function archiveEntities({ entities, sourceEntities, requestQueue }) {

--- a/lib/utils/exo-entity-payloads.ts
+++ b/lib/utils/exo-entity-payloads.ts
@@ -1,0 +1,11 @@
+import { DataAssemblyProps } from 'contentful-management'
+
+export function buildDataAssemblySys(entity: DataAssemblyProps, version: number) {
+  return {
+    id: entity.sys.id,
+    type: 'DataAssembly' as const,
+    dataType: entity.sys.dataType,
+    ...(entity.sys.variant ? { variant: entity.sys.variant } : {}),
+    version
+  }
+}

--- a/test/unit/tasks/push/push-to-space-exo.test.ts
+++ b/test/unit/tasks/push/push-to-space-exo.test.ts
@@ -205,7 +205,7 @@ describe('Importing Fragments', () => {
     expect(payload.name).toBe('Hero Fragment')
   })
 
-  test('UPDATE: calls upsert with componentType hoisted and destination sys.version', async () => {
+  test('UPDATE: calls upsert with destination sys.version and omits componentType (immutable after creation)', async () => {
     const plainClient = makePlainClientMock()
     const destinationEntity: any = { sys: { id: 'frag-1', type: 'Fragment', version: 4 } }
     await pushToSpace({
@@ -222,7 +222,7 @@ describe('Importing Fragments', () => {
     const [params, payload] = plainClient.fragment.upsert.mock.calls[0] as unknown as [any, any]
     expect(params).toEqual({ spaceId: 'space-1', environmentId: 'master', fragmentId: 'frag-1' })
     expect(payload.sys.version).toBe(4)
-    expect(payload.componentType).toEqual(componentType)
+    expect(payload.componentType).toBeUndefined()
   })
 })
 
@@ -275,6 +275,38 @@ describe('Importing Data Assemblies', () => {
     expect(params).toEqual({ spaceId: 'space-1', environmentId: 'master', dataAssemblyId: 'da-1' })
     expect(payload.sys.version).toBe(9)
     expect(payload.name).toBe('My Assembly')
+  })
+
+  test('UPDATE: strips server-managed sys fields from a published source entity', async () => {
+    const plainClient = makePlainClientMock()
+    const publishedEntity: any = {
+      sys: {
+        id: 'da-1',
+        type: 'DataAssembly',
+        version: 3,
+        dataType: [{ id: 'headline', name: 'Headline', type: 'Symbol' }],
+        publishedVersion: 2,
+        publishedAt: '2026-01-01T00:00:00.000Z',
+        publishedCounter: 1,
+        createdAt: '2026-01-01T00:00:00.000Z',
+        createdBy: { sys: { type: 'Link', linkType: 'User', id: 'user-1' } }
+      },
+      name: 'My Assembly'
+    }
+    const destinationEntity: any = { sys: { id: 'da-1', type: 'DataAssembly', version: 9 } }
+    await pushToSpace({
+      sourceData: { ...baseSourceData, dataAssemblies: [publishedEntity] } as any,
+      destinationData: { ...baseDestinationData, dataAssemblies: [destinationEntity] },
+      client: makeClientMock(),
+      plainClient,
+      spaceId: 'space-1',
+      environmentId: 'master',
+      includeExperienceOrchestration: true,
+      requestQueue
+    }).run({ data: {} })
+
+    const [, payload] = plainClient.dataAssembly.update.mock.calls[0] as unknown as [any, any]
+    expect(payload.sys).toEqual({ id: 'da-1', type: 'DataAssembly', dataType: publishedEntity.sys.dataType, version: 9 })
   })
 })
 
@@ -375,7 +407,7 @@ describe('Importing Experiences', () => {
     expect(payload.name).toBe('My Experience')
   })
 
-  test('UPDATE: calls upsert with template hoisted and destination sys.version', async () => {
+  test('UPDATE: calls upsert with destination sys.version and omits template (immutable after creation)', async () => {
     const plainClient = makePlainClientMock()
     const destinationEntity: any = { sys: { id: 'exp-1', type: 'Experience', version: 6 } }
     await pushToSpace({
@@ -392,7 +424,7 @@ describe('Importing Experiences', () => {
     const [params, payload] = plainClient.experience.upsert.mock.calls[0] as unknown as [any, any]
     expect(params).toEqual({ spaceId: 'space-1', environmentId: 'master', experienceId: 'exp-1' })
     expect(payload.sys.version).toBe(6)
-    expect(payload.template).toEqual(template)
+    expect(payload.template).toBeUndefined()
     expect(payload.name).toBe('My Experience')
   })
 })


### PR DESCRIPTION
[AIS-341](https://contentful.atlassian.net/browse/AIS-341)

## Summary
Two pre-existing bugs found while doing staging verification for AIS-341 (#1683). Both only reproduce when re-importing into a space that already has these entities — the CREATE path was unaffected, which is why they went unnoticed until now.

- **DataAssembly UPDATE** spread the entire source `sys` object (`{ ...entity.sys, version: existing.sys.version }`), including server-managed fields like `publishedVersion`, `createdAt`, etc. The API rejects that with `422 Invalid input at "sys"` on every update. Fixed to send only the fields the API accepts, matching the shape already used on create.
- **Fragment/Experience UPDATE** included `componentType`/`template` in the payload, but those fields are immutable after creation — the API rejects with `400 componentType/template is immutable after creation` on every update. Fixed by omitting them from the update payload; the link is preserved server-side from creation and doesn't need to be resent.

## Test plan
- [x] Unit tests updated: strengthened DataAssembly UPDATE test with realistic source `sys` (previously too minimal to catch the bug), added assertion that server-managed fields are stripped; Fragment/Experience UPDATE tests now assert `componentType`/`template` are omitted from the payload rather than asserting the old (buggy) behavior
- [x] `tsc --noEmit` clean
- [x] No new lint errors beyond the pre-existing baseline on `exo`
- [x] Verified against real staging: re-imported into a space already containing DataAssembly/Fragment/Experience entities from a prior import — all updates now succeed with zero errors, and confirmed the immutable `componentType`/`template` links remain correctly intact post-update

Generated with [Claude Code](https://claude.com/claude-code)

[AIS-341]: https://contentful.atlassian.net/browse/AIS-341?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ