### PR TITLE
fix: attach entity to error before emitting for EXO push tasks [AIS-345]

### DIFF
--- a/lib/tasks/push-to-space/push-to-space.ts
+++ b/lib/tasks/push-to-space/push-to-space.ts
@@ -441,7 +441,8 @@ export default function pushToSpace({
               logEmitter.emit('info', `CREATE DataAssembly ${entity.sys.id}`)
             }
             return result
-          } catch (err) {
+          } catch (err: any) {
+            err.entity = entity
             logEmitter.emit('error', err)
             return null
           }
@@ -480,7 +481,8 @@ export default function pushToSpace({
               logEmitter.emit('info', `CREATE DesignToken ${entity.sys.id}`)
               return result
             }
-          } catch (err) {
+          } catch (err: any) {
+            err.entity = entity
             logEmitter.emit('error', err)
             return null
           }
@@ -508,7 +510,8 @@ export default function pushToSpace({
               logEmitter.emit('info', `CREATE ComponentType ${entity.sys.id}`)
               results.push(result)
             }
-          } catch (err) {
+          } catch (err: any) {
+            err.entity = entity
             logEmitter.emit('error', err)
           }
         }
@@ -552,7 +555,8 @@ export default function pushToSpace({
               logEmitter.emit('info', `CREATE Template ${entity.sys.id}`)
               return result
             }
-          } catch (err) {
+          } catch (err: any) {
+            err.entity = entity
             logEmitter.emit('error', err)
             return null
           }
@@ -594,7 +598,8 @@ export default function pushToSpace({
               logEmitter.emit('info', `CREATE Fragment ${entity.sys.id}`)
               results.push(result)
             }
-          } catch (err) {
+          } catch (err: any) {
+            err.entity = entity
             logEmitter.emit('error', err)
           }
         }
@@ -638,7 +643,8 @@ export default function pushToSpace({
               logEmitter.emit('info', `CREATE Experience ${entity.sys.id}`)
               return result
             }
-          } catch (err) {
+          } catch (err: any) {
+            err.entity = entity
             logEmitter.emit('error', err)
             return null
           }

--- a/lib/utils/publish-exo-entities.ts
+++ b/lib/utils/publish-exo-entities.ts
@@ -24,7 +24,8 @@ export async function publishExoEntity<T>(type: string, entity: { sys: { id: str
     const result = await publish()
     logEmitter.emit('info', `PUBLISH ${type} ${entity.sys.id}`)
     return result
-  } catch (err) {
+  } catch (err: any) {
+    err.entity = entity
     logEmitter.emit('error', err)
     return null
   }

--- a/test/unit/tasks/push/push-to-space-exo.test.ts
+++ b/test/unit/tasks/push/push-to-space-exo.test.ts
@@ -141,6 +141,29 @@ describe('Importing Component Types', () => {
 
     expect(plainClient.componentType.upsert).not.toHaveBeenCalled()
   })
+
+  test('attaches the entity to the error before emitting, and continues on failure', async () => {
+    const plainClient = makePlainClientMock()
+    const upsertError = new Error('422 validation failed')
+    plainClient.componentType.upsert = jest.fn((_params, _payload) => Promise.reject(upsertError))
+    const emitSpy = jest.spyOn(logEmitter, 'emit')
+
+    await expect(pushToSpace({
+      sourceData: { ...baseSourceData, componentTypes: [entity] } as any,
+      destinationData: { ...baseDestinationData, componentTypes: [] },
+      client: makeClientMock(),
+      plainClient,
+      spaceId: 'space-1',
+      environmentId: 'master',
+      includeExperienceOrchestration: true,
+      requestQueue
+    }).run({ data: {} })).resolves.not.toThrow()
+
+    const errorCall = emitSpy.mock.calls.find((args) => args[0] === 'error')
+    expect(errorCall?.[1]).toBe(upsertError)
+    expect((errorCall?.[1] as any).entity).toBe(entity)
+    emitSpy.mockRestore()
+  })
 })
 
 describe('Publishing Component Types', () => {
@@ -202,7 +225,10 @@ describe('Publishing Component Types', () => {
 
   test('logs and continues when publish fails, without throwing', async () => {
     const plainClient = makePlainClientMock()
-    plainClient.componentType.publish = jest.fn(() => Promise.reject(new Error('422 validation failed')))
+    const publishError = new Error('422 validation failed')
+    plainClient.componentType.publish = jest.fn(() => Promise.reject(publishError))
+    const emitSpy = jest.spyOn(logEmitter, 'emit')
+
     await expect(pushToSpace({
       sourceData: { ...baseSourceData, componentTypes: [publishedEntity] } as any,
       destinationData: { ...baseDestinationData, componentTypes: [destinationEntity] },
@@ -213,6 +239,11 @@ describe('Publishing Component Types', () => {
       includeExperienceOrchestration: true,
       requestQueue
     }).run({ data: {} })).resolves.not.toThrow()
+
+    const errorCall = emitSpy.mock.calls.find((args) => args[0] === 'error')
+    expect(errorCall?.[1]).toBe(publishError)
+    expect((errorCall?.[1] as any).entity.sys.id).toBe('ct-1')
+    emitSpy.mockRestore()
   })
 })
 
@@ -263,6 +294,29 @@ describe('Importing Templates', () => {
     expect(payload.sys.version).toBe(5)
     expect(payload.name).toBe('Landing Page')
   })
+
+  test('attaches the entity to the error before emitting, and continues on failure', async () => {
+    const plainClient = makePlainClientMock()
+    const upsertError = new Error('422 validation failed')
+    plainClient.template.upsert = jest.fn((_params, _payload) => Promise.reject(upsertError))
+    const emitSpy = jest.spyOn(logEmitter, 'emit')
+
+    await expect(pushToSpace({
+      sourceData: { ...baseSourceData, templates: [entity] } as any,
+      destinationData: { ...baseDestinationData, templates: [] },
+      client: makeClientMock(),
+      plainClient,
+      spaceId: 'space-1',
+      environmentId: 'master',
+      includeExperienceOrchestration: true,
+      requestQueue
+    }).run({ data: {} })).resolves.not.toThrow()
+
+    const errorCall = emitSpy.mock.calls.find((args) => args[0] === 'error')
+    expect(errorCall?.[1]).toBe(upsertError)
+    expect((errorCall?.[1] as any).entity).toBe(entity)
+    emitSpy.mockRestore()
+  })
 })
 
 describe('Publishing Templates', () => {
@@ -302,6 +356,29 @@ describe('Publishing Templates', () => {
     }).run({ data: {} })
 
     expect(plainClient.template.publish).not.toHaveBeenCalled()
+  })
+
+  test('logs and continues when publish fails, without throwing', async () => {
+    const plainClient = makePlainClientMock()
+    const publishError = new Error('422 validation failed')
+    plainClient.template.publish = jest.fn(() => Promise.reject(publishError))
+    const emitSpy = jest.spyOn(logEmitter, 'emit')
+
+    await expect(pushToSpace({
+      sourceData: { ...baseSourceData, templates: [publishedEntity] } as any,
+      destinationData: { ...baseDestinationData, templates: [destinationEntity] },
+      client: makeClientMock(),
+      plainClient,
+      spaceId: 'space-1',
+      environmentId: 'master',
+      includeExperienceOrchestration: true,
+      requestQueue
+    }).run({ data: {} })).resolves.not.toThrow()
+
+    const errorCall = emitSpy.mock.calls.find((args) => args[0] === 'error')
+    expect(errorCall?.[1]).toBe(publishError)
+    expect((errorCall?.[1] as any).entity.sys.id).toBe('tmpl-1')
+    emitSpy.mockRestore()
   })
 })
 
@@ -354,6 +431,29 @@ describe('Importing Fragments', () => {
     expect(payload.sys.version).toBe(4)
     expect(payload.componentType).toBeUndefined()
   })
+
+  test('attaches the entity to the error before emitting, and continues on failure', async () => {
+    const plainClient = makePlainClientMock()
+    const upsertError = new Error('422 validation failed')
+    plainClient.fragment.upsert = jest.fn((_params, _payload) => Promise.reject(upsertError))
+    const emitSpy = jest.spyOn(logEmitter, 'emit')
+
+    await expect(pushToSpace({
+      sourceData: { ...baseSourceData, fragments: [entity] } as any,
+      destinationData: { ...baseDestinationData, fragments: [] },
+      client: makeClientMock(),
+      plainClient,
+      spaceId: 'space-1',
+      environmentId: 'master',
+      includeExperienceOrchestration: true,
+      requestQueue
+    }).run({ data: {} })).resolves.not.toThrow()
+
+    const errorCall = emitSpy.mock.calls.find((args) => args[0] === 'error')
+    expect(errorCall?.[1]).toBe(upsertError)
+    expect((errorCall?.[1] as any).entity).toBe(entity)
+    emitSpy.mockRestore()
+  })
 })
 
 describe('Publishing Fragments', () => {
@@ -393,6 +493,29 @@ describe('Publishing Fragments', () => {
     }).run({ data: {} })
 
     expect(plainClient.fragment.publish).not.toHaveBeenCalled()
+  })
+
+  test('logs and continues when publish fails, without throwing', async () => {
+    const plainClient = makePlainClientMock()
+    const publishError = new Error('422 validation failed')
+    plainClient.fragment.publish = jest.fn(() => Promise.reject(publishError))
+    const emitSpy = jest.spyOn(logEmitter, 'emit')
+
+    await expect(pushToSpace({
+      sourceData: { ...baseSourceData, fragments: [publishedEntity] } as any,
+      destinationData: { ...baseDestinationData, fragments: [destinationEntity] },
+      client: makeClientMock(),
+      plainClient,
+      spaceId: 'space-1',
+      environmentId: 'master',
+      includeExperienceOrchestration: true,
+      requestQueue
+    }).run({ data: {} })).resolves.not.toThrow()
+
+    const errorCall = emitSpy.mock.calls.find((args) => args[0] === 'error')
+    expect(errorCall?.[1]).toBe(publishError)
+    expect((errorCall?.[1] as any).entity.sys.id).toBe('frag-1')
+    emitSpy.mockRestore()
   })
 })
 
@@ -478,6 +601,29 @@ describe('Importing Data Assemblies', () => {
     const [, payload] = plainClient.dataAssembly.update.mock.calls[0] as unknown as [any, any]
     expect(payload.sys).toEqual({ id: 'da-1', type: 'DataAssembly', dataType: publishedEntity.sys.dataType, version: 9 })
   })
+
+  test('attaches the entity to the error before emitting, and continues on failure', async () => {
+    const plainClient = makePlainClientMock()
+    const updateError = new Error('422 validation failed')
+    plainClient.dataAssembly.update = jest.fn((_params, _payload) => Promise.reject(updateError))
+    const emitSpy = jest.spyOn(logEmitter, 'emit')
+
+    await expect(pushToSpace({
+      sourceData: { ...baseSourceData, dataAssemblies: [entity] } as any,
+      destinationData: { ...baseDestinationData, dataAssemblies: [] },
+      client: makeClientMock(),
+      plainClient,
+      spaceId: 'space-1',
+      environmentId: 'master',
+      includeExperienceOrchestration: true,
+      requestQueue
+    }).run({ data: {} })).resolves.not.toThrow()
+
+    const errorCall = emitSpy.mock.calls.find((args) => args[0] === 'error')
+    expect(errorCall?.[1]).toBe(updateError)
+    expect((errorCall?.[1] as any).entity).toBe(entity)
+    emitSpy.mockRestore()
+  })
 })
 
 describe('Publishing Data Assemblies', () => {
@@ -517,6 +663,29 @@ describe('Publishing Data Assemblies', () => {
     }).run({ data: {} })
 
     expect(plainClient.dataAssembly.publish).not.toHaveBeenCalled()
+  })
+
+  test('logs and continues when publish fails, without throwing', async () => {
+    const plainClient = makePlainClientMock()
+    const publishError = new Error('422 validation failed')
+    plainClient.dataAssembly.publish = jest.fn(() => Promise.reject(publishError))
+    const emitSpy = jest.spyOn(logEmitter, 'emit')
+
+    await expect(pushToSpace({
+      sourceData: { ...baseSourceData, dataAssemblies: [publishedEntity] } as any,
+      destinationData: { ...baseDestinationData, dataAssemblies: [destinationEntity] },
+      client: makeClientMock(),
+      plainClient,
+      spaceId: 'space-1',
+      environmentId: 'master',
+      includeExperienceOrchestration: true,
+      requestQueue
+    }).run({ data: {} })).resolves.not.toThrow()
+
+    const errorCall = emitSpy.mock.calls.find((args) => args[0] === 'error')
+    expect(errorCall?.[1]).toBe(publishError)
+    expect((errorCall?.[1] as any).entity.sys.id).toBe('da-1')
+    emitSpy.mockRestore()
   })
 })
 
@@ -585,6 +754,29 @@ describe('Importing Design Tokens', () => {
 
     expect(plainClient.designToken.upsert).not.toHaveBeenCalled()
   })
+
+  test('attaches the entity to the error before emitting, and continues on failure', async () => {
+    const plainClient = makePlainClientMock()
+    const upsertError = new Error('422 validation failed')
+    plainClient.designToken.upsert = jest.fn((_params, _payload) => Promise.reject(upsertError))
+    const emitSpy = jest.spyOn(logEmitter, 'emit')
+
+    await expect(pushToSpace({
+      sourceData: { ...baseSourceData, designTokens: [entity] } as any,
+      destinationData: { ...baseDestinationData, designTokens: [] },
+      client: makeClientMock(),
+      plainClient,
+      spaceId: 'space-1',
+      environmentId: 'master',
+      includeExperienceOrchestration: true,
+      requestQueue
+    }).run({ data: {} })).resolves.not.toThrow()
+
+    const errorCall = emitSpy.mock.calls.find((args) => args[0] === 'error')
+    expect(errorCall?.[1]).toBe(upsertError)
+    expect((errorCall?.[1] as any).entity).toBe(entity)
+    emitSpy.mockRestore()
+  })
 })
 
 // ─── Experience ───────────────────────────────────────────────────────────────
@@ -636,6 +828,29 @@ describe('Importing Experiences', () => {
     expect(payload.sys.version).toBe(6)
     expect(payload.template).toBeUndefined()
     expect(payload.name).toBe('My Experience')
+  })
+
+  test('attaches the entity to the error before emitting, and continues on failure', async () => {
+    const plainClient = makePlainClientMock()
+    const upsertError = new Error('422 validation failed')
+    plainClient.experience.upsert = jest.fn((_params, _payload) => Promise.reject(upsertError))
+    const emitSpy = jest.spyOn(logEmitter, 'emit')
+
+    await expect(pushToSpace({
+      sourceData: { ...baseSourceData, experiences: [entity] } as any,
+      destinationData: { ...baseDestinationData, experiences: [] },
+      client: makeClientMock(),
+      plainClient,
+      spaceId: 'space-1',
+      environmentId: 'master',
+      includeExperienceOrchestration: true,
+      requestQueue
+    }).run({ data: {} })).resolves.not.toThrow()
+
+    const errorCall = emitSpy.mock.calls.find((args) => args[0] === 'error')
+    expect(errorCall?.[1]).toBe(upsertError)
+    expect((errorCall?.[1] as any).entity).toBe(entity)
+    emitSpy.mockRestore()
   })
 })
 
@@ -693,5 +908,28 @@ describe('Publishing Experiences', () => {
     }).run({ data: {} })
 
     expect(plainClient.experience.publish).not.toHaveBeenCalled()
+  })
+
+  test('logs and continues when publish fails, without throwing', async () => {
+    const plainClient = makePlainClientMock()
+    const publishError = new Error('422 validation failed')
+    plainClient.experience.publish = jest.fn(() => Promise.reject(publishError))
+    const emitSpy = jest.spyOn(logEmitter, 'emit')
+
+    await expect(pushToSpace({
+      sourceData: { ...baseSourceData, experiences: [publishedEntity] } as any,
+      destinationData: { ...baseDestinationData, experiences: [destinationEntity] },
+      client: makeClientMock(),
+      plainClient,
+      spaceId: 'space-1',
+      environmentId: 'master',
+      includeExperienceOrchestration: true,
+      requestQueue
+    }).run({ data: {} })).resolves.not.toThrow()
+
+    const errorCall = emitSpy.mock.calls.find((args) => args[0] === 'error')
+    expect(errorCall?.[1]).toBe(publishError)
+    expect((errorCall?.[1] as any).entity.sys.id).toBe('exp-1')
+    emitSpy.mockRestore()
   })
 })


### PR DESCRIPTION
[AIS-345](https://contentful.atlassian.net/browse/AIS-345)

## Summary
- EXO entity catch blocks (DataAssembly, DesignToken, ComponentType, Template, Fragment, Experience) emitted raw SDK errors without entity context, on both the Importing and Publishing side, unlike `creation.ts`/`publishing.ts` which already set `err.entity`. The final error report couldn't identify which entity failed.
- Sets `err.entity = entity` in all 6 EXO Importing catch blocks in `push-to-space.ts`, and in `publishExoEntity` (used by all 5 Publishing EXO tasks) in `lib/utils/publish-exo-entities.ts`.
- Verified against real error-log fixtures from staging: every EXO `ValidationFailed`/`BadRequest` error (Importing and Publishing) had zero `entity` field before this fix.

## Test plan
- [x] Added "attaches the entity to the error before emitting, and continues on failure" test per EXO entity type for the Importing side (6 tests)
- [x] Added "logs and continues when publish fails" test per EXO entity type for the Publishing side (5 tests)
- [x] Full unit suite passes (168/168)
- [x] Lint has no new errors (only expected `no-explicit-any` warnings from `err: any`, consistent with existing convention)
- [x] Verified real before/after log output via a driven demo script against `origin/exo` — entity now appears in the JSON error-log file where it was previously absent; console output unaffected (formatter doesn't read `err.entity`)

Generated with [Claude Code](https://claude.com/claude-code)

[AIS-345]: https://contentful.atlassian.net/browse/AIS-345?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ