### PR TITLE
fix: log and rethrow when EXO topological sort throws [AIS-345]

### DIFF
--- a/lib/tasks/push-to-space/push-to-space.ts
+++ b/lib/tasks/push-to-space/push-to-space.ts
@@ -28,6 +28,20 @@ import sortComponentTypes from '../../utils/sort-component-types'
 import sortFragments from '../../utils/sort-fragments'
 import { filterExoEntitiesToPublish, publishExoEntity } from '../../utils/publish-exo-entities'
 
+// sortComponentTypes/sortFragments run outside the per-entity try/catch below, directly
+// inside wrapTask. An uncaught throw here (e.g. malformed componentTree/slots data) would
+// bubble through wrapTask and abort the run without ever reaching the logEmitter-driven
+// report. This wrapper logs the failure before rethrowing, preserving today's abort-on-failure
+// behavior while ensuring the error is visible in the final report.
+function sortOrReport<T>(sortFn: () => T[]): T[] {
+  try {
+    return sortFn()
+  } catch (err) {
+    logEmitter.emit('error', err)
+    throw err
+  }
+}
+
 async function withGraphQLSchemaBackoff<T>(fn: () => Promise<T>): Promise<T> {
   let lastErr: unknown
   for (let attempt = 0; attempt <= GRAPHQL_SCHEMA_STALE_DELAYS_MS.length; attempt++) {
@@ -492,7 +506,7 @@ export default function pushToSpace({
     {
       title: 'Importing Component Types',
       task: wrapTask(async (ctx) => {
-        const sorted = sortComponentTypes(sourceData.componentTypes || [])
+        const sorted = sortOrReport(() => sortComponentTypes(sourceData.componentTypes || []))
         const results: any[] = []
         for (const entity of sorted) {
           try {
@@ -523,7 +537,7 @@ export default function pushToSpace({
         // Sorted and sequential: a ComponentType's publish validation resolves nested
         // ComponentType/DataAssembly references against their *published* state, so a
         // parent can't publish before the ComponentTypes it embeds are published.
-        const sorted = sortComponentTypes(entitiesToPublish)
+        const sorted = sortOrReport(() => sortComponentTypes(entitiesToPublish))
         const results: ComponentTypeProps[] = []
         for (const entity of sorted) {
           const published = await publishExoEntity<ComponentTypeProps>('ComponentType', entity, () => plainClient.componentType.publish(
@@ -577,7 +591,7 @@ export default function pushToSpace({
     {
       title: 'Importing Fragments',
       task: wrapTask(async (ctx) => {
-        const sorted = sortFragments(sourceData.fragments || [])
+        const sorted = sortOrReport(() => sortFragments(sourceData.fragments || []))
         const results: any[] = []
         for (const entity of sorted) {
           try {
@@ -608,7 +622,7 @@ export default function pushToSpace({
         const entitiesToPublish = filterExoEntitiesToPublish(ctx.data.fragments, sourceData.fragments || [])
         // Sorted and sequential, same reasoning as Publishing Component Types: a Fragment
         // can reference other Fragments in its slots, resolved against published state.
-        const sorted = sortFragments(entitiesToPublish)
+        const sorted = sortOrReport(() => sortFragments(entitiesToPublish))
         const results: FragmentProps[] = []
         for (const entity of sorted) {
           const published = await publishExoEntity<FragmentProps>('Fragment', entity, () => plainClient.fragment.publish(

--- a/lib/tasks/push-to-space/push-to-space.ts
+++ b/lib/tasks/push-to-space/push-to-space.ts
@@ -27,20 +27,7 @@ import { buildDataAssemblySys } from '../../utils/exo-entity-payloads'
 import sortComponentTypes from '../../utils/sort-component-types'
 import sortFragments from '../../utils/sort-fragments'
 import { filterExoEntitiesToPublish, publishExoEntity } from '../../utils/publish-exo-entities'
-
-// sortComponentTypes/sortFragments run outside the per-entity try/catch below, directly
-// inside wrapTask. An uncaught throw here (e.g. malformed componentTree/slots data) would
-// bubble through wrapTask and abort the run without ever reaching the logEmitter-driven
-// report. This wrapper logs the failure before rethrowing, preserving today's abort-on-failure
-// behavior while ensuring the error is visible in the final report.
-function sortOrReport<T>(sortFn: () => T[]): T[] {
-  try {
-    return sortFn()
-  } catch (err) {
-    logEmitter.emit('error', err)
-    throw err
-  }
-}
+import { sortOrReport } from '../../utils/sort-or-report'
 
 async function withGraphQLSchemaBackoff<T>(fn: () => Promise<T>): Promise<T> {
   let lastErr: unknown

--- a/lib/utils/sort-or-report.ts
+++ b/lib/utils/sort-or-report.ts
@@ -1,0 +1,18 @@
+import { logEmitter } from 'contentful-batch-libs/dist/logging'
+
+/**
+ * Runs a topological sort (sortComponentTypes/sortFragments) that executes outside the
+ * per-entity try/catch in push-to-space.ts, directly inside wrapTask. An uncaught throw there
+ * (e.g. malformed componentTree/slots data) would bubble through wrapTask and abort the run
+ * without ever reaching the logEmitter-driven report. This logs the failure before rethrowing,
+ * preserving today's abort-on-failure behavior while ensuring the error is visible in the
+ * final report.
+ */
+export function sortOrReport<T>(sortFn: () => T[]): T[] {
+  try {
+    return sortFn()
+  } catch (err) {
+    logEmitter.emit('error', err)
+    throw err
+  }
+}

--- a/test/unit/tasks/push/push-to-space-exo-sort-errors.test.ts
+++ b/test/unit/tasks/push/push-to-space-exo-sort-errors.test.ts
@@ -1,0 +1,111 @@
+import PQueue from 'p-queue'
+
+import { logEmitter } from 'contentful-batch-libs/dist/logging'
+
+// logEmitter is a plain node:events EventEmitter. Node treats 'error' as a special
+// event name and throws synchronously if it's emitted with no listener attached, so
+// register a no-op listener before any test exercises an error/log-and-continue path.
+logEmitter.on('error', () => {})
+
+jest.mock('../../../../lib/utils/sort-component-types', () => ({
+  __esModule: true,
+  default: jest.fn(() => {
+    throw new Error('malformed componentTree')
+  })
+}))
+jest.mock('../../../../lib/utils/sort-fragments', () => ({
+  __esModule: true,
+  default: jest.fn(() => {
+    throw new Error('malformed slots')
+  })
+}))
+
+// Imported after the mocks above so push-to-space picks up the mocked sort modules.
+import pushToSpace from '../../../../lib/tasks/push-to-space/push-to-space'
+
+const baseSourceData = {
+  locales: [],
+  contentTypes: [],
+  assets: [],
+  editorInterfaces: [],
+  entries: [],
+  tags: [],
+  webhooks: []
+}
+
+const baseDestinationData = {}
+
+function makeClientMock() {
+  return {
+    getSpace: jest.fn(() => Promise.resolve({
+      getEnvironment: jest.fn(() => Promise.resolve({
+        getEditorInterfaceForContentType: jest.fn(() => Promise.resolve({ update: jest.fn() }))
+      }))
+    }))
+  }
+}
+
+function makePlainClientMock() {
+  return {
+    componentType: { upsert: jest.fn(), publish: jest.fn() },
+    fragment: { upsert: jest.fn(), publish: jest.fn() }
+  }
+}
+
+let requestQueue: PQueue
+
+beforeEach(() => {
+  requestQueue = new PQueue({ interval: 1000, intervalCap: 1000 })
+})
+
+describe('Importing Component Types: setup-code failures', () => {
+  const entity: any = { sys: { id: 'ct-1', type: 'ComponentType', version: 1 }, name: 'Hero' }
+
+  test('logs the sort failure via logEmitter and still aborts the run', async () => {
+    const plainClient = makePlainClientMock()
+    const emitSpy = jest.spyOn(logEmitter, 'emit')
+
+    await expect(pushToSpace({
+      sourceData: { ...baseSourceData, componentTypes: [entity] } as any,
+      destinationData: { ...baseDestinationData, componentTypes: [] },
+      client: makeClientMock(),
+      plainClient,
+      spaceId: 'space-1',
+      environmentId: 'master',
+      includeExperienceOrchestration: true,
+      requestQueue
+    }).run({ data: {} })).rejects.toThrow()
+
+    const errorCall = emitSpy.mock.calls.find((args) => args[0] === 'error')
+    expect(errorCall?.[1]).toBeInstanceOf(Error)
+    expect((errorCall?.[1] as Error).message).toBe('malformed componentTree')
+    expect(plainClient.componentType.upsert).not.toHaveBeenCalled()
+    emitSpy.mockRestore()
+  })
+})
+
+describe('Importing Fragments: setup-code failures', () => {
+  const entity: any = { sys: { id: 'frag-1', type: 'Fragment', version: 1 }, name: 'Hero Fragment' }
+
+  test('logs the sort failure via logEmitter and still aborts the run', async () => {
+    const plainClient = makePlainClientMock()
+    const emitSpy = jest.spyOn(logEmitter, 'emit')
+
+    await expect(pushToSpace({
+      sourceData: { ...baseSourceData, fragments: [entity] } as any,
+      destinationData: { ...baseDestinationData, fragments: [] },
+      client: makeClientMock(),
+      plainClient,
+      spaceId: 'space-1',
+      environmentId: 'master',
+      includeExperienceOrchestration: true,
+      requestQueue
+    }).run({ data: {} })).rejects.toThrow()
+
+    const errorCall = emitSpy.mock.calls.find((args) => args[0] === 'error')
+    expect(errorCall?.[1]).toBeInstanceOf(Error)
+    expect((errorCall?.[1] as Error).message).toBe('malformed slots')
+    expect(plainClient.fragment.upsert).not.toHaveBeenCalled()
+    emitSpy.mockRestore()
+  })
+})

--- a/test/unit/utils/sort-or-report.test.ts
+++ b/test/unit/utils/sort-or-report.test.ts
@@ -1,0 +1,19 @@
+import { logEmitter } from 'contentful-batch-libs/dist/logging'
+import { sortOrReport } from '../../../lib/utils/sort-or-report'
+
+test('returns the sort result unchanged when the sort function succeeds', () => {
+  const result = sortOrReport(() => [3, 1, 2])
+  expect(result).toEqual([3, 1, 2])
+})
+
+test('logs the error via logEmitter and rethrows when the sort function throws', () => {
+  const sortError = new Error('malformed data')
+  const emitSpy = jest.spyOn(logEmitter, 'emit').mockImplementation(() => true)
+
+  expect(() => sortOrReport(() => {
+    throw sortError
+  })).toThrow(sortError)
+
+  expect(emitSpy).toHaveBeenCalledWith('error', sortError)
+  emitSpy.mockRestore()
+})


### PR DESCRIPTION
[AIS-345](https://contentful.atlassian.net/browse/AIS-345)

## Summary
- `sortComponentTypes`/`sortFragments` run outside the per-entity try/catch in `push-to-space.ts`, directly inside `wrapTask`. An uncaught throw there (e.g. malformed `componentTree`/`slots` data) bubbles through `wrapTask` and aborts the run without ever reaching the `logEmitter`-driven report.
- Added a `sortOrReport<T>(sortFn)` helper: runs the sort, and on throw, emits via `logEmitter` before rethrowing — preserves today's abort-on-failure behavior (no change to the happy path) while ensuring the failure is visible in the final report.
- Wrapped all 4 call sites: `sortComponentTypes` (Importing + Publishing Component Types), `sortFragments` (Importing + Publishing Fragments).

## Test plan
- [x] New test file `push-to-space-exo-sort-errors.test.ts` mocks the sort utilities to throw, asserts the run still rejects (behavior unchanged) but `logEmitter.emit('error', ...)` fires first with the underlying error
- [x] Full unit suite passes (160/160)
- [x] Lint has no new errors
- [x] Verified real before/after behavior via a driven demo script — before, the error crashed the process with `(no errors captured)` on `logEmitter`, invisible to the JSON error-log file; after, the same abort now captures the full error + stack trace in the report first

Generated with [Claude Code](https://claude.com/claude-code)

[AIS-345]: https://contentful.atlassian.net/browse/AIS-345?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ