### PR TITLE
fix: log and continue on Editor Interface update failure instead of aborting [AIS-345]

### DIFF
--- a/lib/tasks/push-to-space/push-to-space.ts
+++ b/lib/tasks/push-to-space/push-to-space.ts
@@ -21,7 +21,6 @@ import * as assets from './assets'
 import * as creation from './creation'
 import * as publishing from './publishing'
 import type { DestinationData, TransformedSourceData, Resources, TransformedAsset } from '../../types'
-import { ContentfulEntityError } from '../../utils/errors'
 import { GRAPHQL_SCHEMA_STALE_DELAYS_MS, isGraphQLSchemaStaleError } from '../../utils/graphql-schema-backoff'
 import { buildDataAssemblySys } from '../../utils/exo-entity-payloads'
 import sortComponentTypes from '../../utils/sort-component-types'
@@ -259,10 +258,9 @@ export default function pushToSpace({
             const updatedEditorInterface = await requestQueue.add(() => ctEditorInterface.update())
             return updatedEditorInterface
           } catch (err: any) {
-            if (err instanceof ContentfulEntityError) {
-              err.entity = editorInterface
-            }
-            throw err
+            err.entity = editorInterface
+            logEmitter.emit('error', err)
+            return null
           }
         })
 

--- a/test/unit/tasks/push/push-to-space.test.ts
+++ b/test/unit/tasks/push/push-to-space.test.ts
@@ -2,11 +2,17 @@ import PQueue from 'p-queue'
 import { each } from 'lodash/collection'
 
 import pushToSpace from '../../../../lib/tasks/push-to-space/push-to-space'
-
+import { logEmitter } from 'contentful-batch-libs/dist/logging'
 import { createEntities, createEntries, createLocales } from '../../../../lib/tasks/push-to-space/creation'
 import { archiveEntities, publishEntities } from '../../../../lib/tasks/push-to-space/publishing'
 import { getAssetStreamForURL, processAssets } from '../../../../lib/tasks/push-to-space/assets'
 import { EntityTransformed, TransformedAsset, TransformedSourceData } from '../../../../lib/types'
+
+// logEmitter is a plain node:events EventEmitter. Node treats 'error' as a special
+// event name and throws synchronously if it's emitted with no listener attached, so
+// register a no-op listener before any test exercises an error/log-and-continue path.
+logEmitter.on('error', () => {})
+
 // We group together these functions into objects manually instead of
 // using wildcard imports (*). This ensures that during the `afterEach` cleanup,
 // Jest's mock clearing mechanism does not attempt to invoke `mockClear`
@@ -283,5 +289,75 @@ test('Upload each local asset file before pushing to space', () => {
       expect(assets.getAssetStreamForURL).toHaveBeenCalledWith('https://images/contentful-de.jpg', 'assets')
       expect(transformedAssets[0].transformed.fields.file['en-US']).not.toHaveProperty('upload')
       expect(transformedAssets[0].transformed.fields.file['en-US']).toHaveProperty('uploadFrom')
+    })
+})
+
+test('Editor interface update failure is logged and does not abort the run', () => {
+  const failingUpdateMock = jest.fn(() => Promise.reject(new Error('422 validation failed')))
+  const succeedingUpdateMock = jest.fn(() => Promise.resolve())
+
+  const twoContentTypesSourceData = {
+    ...transformedSourceData,
+    contentTypes: [
+      ...transformedSourceData.contentTypes,
+      { original: { sys: { id: 'otherId', type: 'ContentType', publishedVersion: 1 } } }
+    ],
+    editorInterfaces: [
+      {
+        sys: { type: 'EditorInterface', contentType: { sys: { id: 'someId' } } }
+      },
+      {
+        sys: { type: 'EditorInterface', contentType: { sys: { id: 'otherId' } } }
+      }
+    ]
+  } as unknown as TransformedSourceData
+
+  ;(creation.createEntities as jest.Mock).mockImplementationOnce(({ context }) => {
+    if (context.type === 'ContentType') {
+      return Promise.resolve([
+        { sys: { id: 'someId', type: 'ContentType', publishedVersion: 1 } },
+        { sys: { id: 'otherId', type: 'ContentType', publishedVersion: 1 } }
+      ])
+    }
+    return Promise.resolve([])
+  })
+  ;(publishing.publishEntities as jest.Mock).mockImplementationOnce(({ entities }) => {
+    if (entities[0] && entities[0].sys.type === 'ContentType') {
+      return Promise.resolve(entities)
+    }
+    return Promise.resolve([])
+  })
+
+  const clientMockWithMixedResults = {
+    getSpace: jest.fn(() => Promise.resolve({
+      getEnvironment: jest.fn(() => Promise.resolve({
+        getEditorInterfaceForContentType: (contentTypeId: string) => {
+          return Promise.resolve({
+            sys: { type: 'EditorInterface', contentType: { sys: { id: contentTypeId } } },
+            update: contentTypeId === 'someId' ? failingUpdateMock : succeedingUpdateMock
+          })
+        },
+        createUpload: () => Promise.resolve({ sys: { id: 'id' } })
+      }))
+    }))
+  }
+
+  const emitSpy = jest.spyOn(logEmitter, 'emit')
+
+  return expect(pushToSpace({
+    sourceData: twoContentTypesSourceData,
+    destinationData,
+    client: clientMockWithMixedResults,
+    spaceId: 'spaceid',
+    environmentId: 'master',
+    requestQueue
+  }).run({ data: {} })).resolves.not.toThrow()
+    .then(() => {
+      expect(failingUpdateMock).toHaveBeenCalledTimes(1)
+      expect(succeedingUpdateMock).toHaveBeenCalledTimes(1)
+      const errorCall = emitSpy.mock.calls.find((args) => args[0] === 'error')
+      expect(errorCall?.[1]).toBeInstanceOf(Error)
+      expect((errorCall?.[1] as Error).message).toBe('422 validation failed')
+      emitSpy.mockRestore()
     })
 })


### PR DESCRIPTION
[AIS-345](https://contentful.atlassian.net/browse/AIS-345)

## Summary
- The "Importing Editor Interfaces" task rethrew per-item errors, aborting the whole run on a single failure — unlike every other task in `push-to-space.ts`, which logs via `logEmitter` and continues.
- Changed the catch block from `throw err` to `logEmitter.emit('error', err); return null`, matching the pattern already used in `publishing.ts`/`creation.ts`/`assets.ts`. The existing `.filter((editorInterface) => editorInterface)` downstream already discards the `null` return, so no other code changes needed.
- Also drops a dead `err instanceof ContentfulEntityError` guard this fix initially copied forward. That class is never actually constructed anywhere — not in this repo's history, not by any SDK version I checked — and this line was unconditional (`err.entity = editorInterface`) before it was added in a 2023 TypeScript `strict` mode migration (#906). I couldn't find a PR description, review comment, or issue explaining the guard, so my best guess is it was incidental to that migration rather than a deliberate choice. This restores the original unconditional behavior; flagging in case anyone remembers a reason I couldn't find.

## Test plan
- [x] Added "Editor interface update failure is logged and does not abort the run" — two content types, one editor-interface update rejects, asserts the run resolves (not throws), the other content type's editor interface still updates, and the error was emitted with the right message
- [x] Full unit suite passes (159/159)
- [x] Lint at exact baseline, no new warnings/errors
- [x] Verified real before/after behavior via a driven demo script against `origin/exo` — before, the run aborted immediately after the failed editor interface (zero downstream tasks ran); after, all 25 subsequent task-state transitions completed normally

Generated with [Claude Code](https://claude.com/claude-code)

[AIS-345]: https://contentful.atlassian.net/browse/AIS-345?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ