### PR TITLE
fix: omit component/experienceTemplate from ExO UPDATE payloads [AIS-385]

### DIFF
--- a/lib/tasks/push-to-space/push-to-space.ts
+++ b/lib/tasks/push-to-space/push-to-space.ts
@@ -583,8 +583,9 @@ export default function pushToSpace({
           try {
             const existing = destinationDataById.experienceFragments?.get(entity.sys.id)
             if (existing) {
-              // once an ExperienceFragment is created, its component cannot be changed to a different component
-              const payload: UpsertExperienceFragmentProps = { ...entity, component: entity.sys.component, sys: { id: entity.sys.id, type: 'ExperienceFragment', version: existing.sys.version } }
+              // once an ExperienceFragment is created, its component cannot be changed to a different component -
+              // the API rejects `component` on UPDATE even when the value is unchanged, so omit it entirely
+              const payload: UpsertExperienceFragmentProps = { ...entity, sys: { id: entity.sys.id, type: 'ExperienceFragment', version: existing.sys.version } }
               const result = await plainClient.experienceFragment.upsert({ spaceId, environmentId, experienceFragmentId: entity.sys.id }, payload)
               logEmitter.emit('info', `UPDATE ExperienceFragment ${entity.sys.id}`)
               results.push(result)
@@ -627,8 +628,9 @@ export default function pushToSpace({
           try {
             const existing = destinationDataById.experiences?.get(entity.sys.id)
             if (existing) {
-              // once an Experience is created, its experienceTemplate cannot be changed to a different experienceTemplate
-              const payload: UpsertExperienceProps = { ...entity, experienceTemplate: entity.sys.experienceTemplate, sys: { id: entity.sys.id, type: 'Experience', version: existing.sys.version } }
+              // once an Experience is created, its experienceTemplate cannot be changed to a different experienceTemplate -
+              // the API rejects `experienceTemplate` on UPDATE even when the value is unchanged, so omit it entirely
+              const payload: UpsertExperienceProps = { ...entity, sys: { id: entity.sys.id, type: 'Experience', version: existing.sys.version } }
               const result = await plainClient.experience.upsert({ spaceId, environmentId, experienceId: entity.sys.id }, payload)
               logEmitter.emit('info', `UPDATE Experience ${entity.sys.id}`)
               return result

--- a/test/unit/tasks/push/push-to-space-exo.test.ts
+++ b/test/unit/tasks/push/push-to-space-exo.test.ts
@@ -335,7 +335,7 @@ describe('Importing Experience Fragments', () => {
     expect(payload.name).toBe('Hero Fragment')
   })
 
-  test('UPDATE: calls upsert with destination sys.version and omits component (immutable after creation - the API rejects it on UPDATE even when unchanged)', async () => {
+  test('UPDATE: calls upsert with destination sys.version and omits component (once an ExperienceFragment is created, its component cannot be changed to a different component)', async () => {
     const plainClient = makePlainClientMock()
     const destinationEntity: any = { sys: { id: 'frag-1', type: 'ExperienceFragment', version: 4 } }
     await pushToSpace({
@@ -617,7 +617,7 @@ describe('Importing Experiences', () => {
     expect(payload.name).toBe('My Experience')
   })
 
-  test('UPDATE: calls upsert with destination sys.version and omits experienceTemplate (immutable after creation - the API rejects it on UPDATE even when unchanged)', async () => {
+  test('UPDATE: calls upsert with destination sys.version and omits experienceTemplate (once an Experience is created, its experienceTemplate cannot be changed to a different experienceTemplate)', async () => {
     const plainClient = makePlainClientMock()
     const destinationEntity: any = { sys: { id: 'exp-1', type: 'Experience', version: 6 } }
     await pushToSpace({

--- a/test/unit/tasks/push/push-to-space-exo.test.ts
+++ b/test/unit/tasks/push/push-to-space-exo.test.ts
@@ -335,7 +335,7 @@ describe('Importing Experience Fragments', () => {
     expect(payload.name).toBe('Hero Fragment')
   })
 
-  test('UPDATE: calls upsert with component hoisted and destination sys.version', async () => {
+  test('UPDATE: calls upsert with destination sys.version and omits component (immutable after creation - the API rejects it on UPDATE even when unchanged)', async () => {
     const plainClient = makePlainClientMock()
     const destinationEntity: any = { sys: { id: 'frag-1', type: 'ExperienceFragment', version: 4 } }
     await pushToSpace({
@@ -352,7 +352,7 @@ describe('Importing Experience Fragments', () => {
     const [params, payload] = plainClient.experienceFragment.upsert.mock.calls[0] as unknown as [any, any]
     expect(params).toEqual({ spaceId: 'space-1', environmentId: 'master', experienceFragmentId: 'frag-1' })
     expect(payload.sys.version).toBe(4)
-    expect(payload.component).toEqual(component)
+    expect(payload).not.toHaveProperty('component')
   })
 })
 
@@ -617,7 +617,7 @@ describe('Importing Experiences', () => {
     expect(payload.name).toBe('My Experience')
   })
 
-  test('UPDATE: calls upsert with experienceTemplate hoisted and destination sys.version', async () => {
+  test('UPDATE: calls upsert with destination sys.version and omits experienceTemplate (immutable after creation - the API rejects it on UPDATE even when unchanged)', async () => {
     const plainClient = makePlainClientMock()
     const destinationEntity: any = { sys: { id: 'exp-1', type: 'Experience', version: 6 } }
     await pushToSpace({
@@ -634,7 +634,7 @@ describe('Importing Experiences', () => {
     const [params, payload] = plainClient.experience.upsert.mock.calls[0] as unknown as [any, any]
     expect(params).toEqual({ spaceId: 'space-1', environmentId: 'master', experienceId: 'exp-1' })
     expect(payload.sys.version).toBe(6)
-    expect(payload.experienceTemplate).toEqual(experienceTemplate)
+    expect(payload).not.toHaveProperty('experienceTemplate')
     expect(payload.name).toBe('My Experience')
   })
 })


### PR DESCRIPTION
[AIS-385](https://contentful.atlassian.net/browse/AIS-385)

## Summary
- Every re-import of a space/environment containing any ExperienceFragment or Experience failed outright — same-space or cross-space, changed or unchanged. The API rejects `component`/`experienceTemplate` on UPDATE even when the value is identical (it can't be changed after creation), and `push-to-space.ts` always sent them back on every UPDATE.
- Confirmed via the real import pipeline and independently via a raw API call outside of import — same rejection either way.
- Fix drops `component`/`experienceTemplate` from the UPDATE branch entirely; they're only sent on CREATE now, matching how `sys` is already stripped via `omitSys(entity)` there.

## Test plan
- [x] Updated the two existing UPDATE unit tests to assert the field is omitted (they previously asserted the buggy "hoisted" behavior)
- [x] Full unit suite passes (176/176), lint at baseline (0 new errors), clean `tsc --noEmit`
- [x] Verified end-to-end against a real staging space: re-imported same-space and cross-space with an ExperienceFragment + Experience present — both `UPDATE` calls succeed cleanly where they previously threw a 400

Generated with [Claude Code](https://claude.com/claude-code)

[AIS-385]: https://contentful.atlassian.net/browse/AIS-385?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ