### PR TITLE
fix: propagate source unpublish to destination on ExO re-import [AIS-385]

### DIFF
--- a/lib/tasks/push-to-space/push-to-space.ts
+++ b/lib/tasks/push-to-space/push-to-space.ts
@@ -26,7 +26,7 @@ import { GRAPHQL_SCHEMA_STALE_DELAYS_MS, isGraphQLSchemaStaleError } from '../..
 import { buildDataAssemblySys } from '../../utils/exo-entity-payloads'
 import sortComponents from '../../utils/sort-components'
 import sortExperienceFragments from '../../utils/sort-experience-fragments'
-import { filterExoEntitiesToPublish, publishExoEntity } from '../../utils/publish-exo-entities'
+import { filterExoEntitiesToPublish, filterExoEntitiesToUnpublish, publishExoEntity, unpublishExoEntity } from '../../utils/publish-exo-entities'
 
 async function withGraphQLSchemaBackoff<T>(fn: () => Promise<T>): Promise<T> {
   let lastErr: unknown
@@ -661,6 +661,76 @@ export default function pushToSpace({
         ctx.data.publishedExperiences = results.filter((entity): entity is ExperienceProps => entity !== null)
       }),
       skip: () => !includeExperienceOrchestration || skipContentPublishing || !(sourceData.experiences || []).length
+    },
+    // Unpublishing runs after all Importing/Publishing tasks, in reverse dependency order
+    // (Experience first, DataAssembly last) - the API rejects unpublishing an entity that a
+    // still-published parent references, so parents must unpublish before the children they embed.
+    {
+      title: 'Unpublishing Experiences',
+      task: wrapTask(async (ctx: { data: { experiences: ExperienceProps[] } }) => {
+        const entitiesToUnpublish = filterExoEntitiesToUnpublish(ctx.data.experiences, sourceData.experiences || [])
+        await Promise.all(entitiesToUnpublish.map((entity) =>
+          unpublishExoEntity<ExperienceProps>('Experience', entity, () => plainClient.experience.unpublish(
+            { spaceId, environmentId, experienceId: entity.sys.id, version: entity.sys.version }
+          ))
+        ))
+      }),
+      skip: () => !includeExperienceOrchestration || skipContentPublishing || !(sourceData.experiences || []).length
+    },
+    {
+      title: 'Unpublishing Experience Fragments',
+      task: wrapTask(async (ctx) => {
+        const entitiesToUnpublish = filterExoEntitiesToUnpublish(ctx.data.experienceFragments, sourceData.experienceFragments || [])
+        // Sorted and sequential, reverse of Publishing Experience Fragments: the API rejects
+        // unpublishing a fragment that a still-published parent references, so ancestors must
+        // unpublish first.
+        const sorted = sortExperienceFragments(entitiesToUnpublish).reverse()
+        for (const entity of sorted) {
+          await unpublishExoEntity<ExperienceFragmentProps>('ExperienceFragment', entity, () => plainClient.experienceFragment.unpublish(
+            { spaceId, environmentId, experienceFragmentId: entity.sys.id, version: entity.sys.version }
+          ))
+        }
+      }),
+      skip: () => !includeExperienceOrchestration || skipContentPublishing || !(sourceData.experienceFragments || []).length
+    },
+    {
+      title: 'Unpublishing Experience Templates',
+      task: wrapTask(async (ctx: { data: { experienceTemplates: ExperienceTemplateProps[] } }) => {
+        const entitiesToUnpublish = filterExoEntitiesToUnpublish(ctx.data.experienceTemplates, sourceData.experienceTemplates || [])
+        await Promise.all(entitiesToUnpublish.map((entity) =>
+          unpublishExoEntity<ExperienceTemplateProps>('ExperienceTemplate', entity, () => plainClient.experienceTemplate.unpublish(
+            { spaceId, environmentId, experienceTemplateId: entity.sys.id, version: entity.sys.version }
+          ))
+        ))
+      }),
+      skip: () => !includeExperienceOrchestration || skipContentPublishing || !(sourceData.experienceTemplates || []).length
+    },
+    {
+      title: 'Unpublishing Components',
+      task: wrapTask(async (ctx) => {
+        const entitiesToUnpublish = filterExoEntitiesToUnpublish(ctx.data.components, sourceData.components || [])
+        // Sorted and sequential, reverse of Publishing Components: the API rejects unpublishing
+        // a Component that a still-published parent references, so ancestors must unpublish first.
+        const sorted = sortComponents(entitiesToUnpublish).reverse()
+        for (const entity of sorted) {
+          await unpublishExoEntity<ComponentProps>('Component', entity, () => plainClient.component.unpublish(
+            { spaceId, environmentId, componentId: entity.sys.id, version: entity.sys.version }
+          ))
+        }
+      }),
+      skip: () => !includeExperienceOrchestration || skipContentPublishing || !(sourceData.components || []).length
+    },
+    {
+      title: 'Unpublishing Data Assemblies',
+      task: wrapTask(async (ctx: { data: { dataAssemblies: DataAssemblyProps[] } }) => {
+        const entitiesToUnpublish = filterExoEntitiesToUnpublish(ctx.data.dataAssemblies, sourceData.dataAssemblies || [])
+        await Promise.all(entitiesToUnpublish.map((entity) =>
+          unpublishExoEntity<DataAssemblyProps>('DataAssembly', entity, () => plainClient.dataAssembly.unpublish(
+            { spaceId, environmentId, dataAssemblyId: entity.sys.id, version: entity.sys.version }
+          ))
+        ))
+      }),
+      skip: () => !includeExperienceOrchestration || skipContentPublishing || !(sourceData.dataAssemblies || []).length
     }
   ], listrOptions)
 }

--- a/lib/utils/publish-exo-entities.ts
+++ b/lib/utils/publish-exo-entities.ts
@@ -19,10 +19,35 @@ export function filterExoEntitiesToPublish<T extends { sys: { id: string; versio
   return entities.filter((entity) => entityIdsToPublish.has(entity.sys.id))
 }
 
+/**
+ * Inverse of filterExoEntitiesToPublish. Finds entities that are currently published at the
+ * destination but draft (or absent) in source, so a source-side unpublish propagates on re-import.
+ */
+export function filterExoEntitiesToUnpublish<T extends { sys: { id: string; version: number; publishedVersion?: number } }>(
+  entities: T[],
+  sourceEntities: PublishableExoEntity[]
+): T[] {
+  const entityIdsPublishedInSource = new Set(
+    sourceEntities.filter((entity) => entity.sys.publishedVersion).map((entity) => entity.sys.id)
+  )
+  return entities.filter((entity) => entity.sys.publishedVersion && !entityIdsPublishedInSource.has(entity.sys.id))
+}
+
 export async function publishExoEntity<T>(type: string, entity: { sys: { id: string } }, publish: () => Promise<T>): Promise<T | null> {
   try {
     const result = await publish()
     logEmitter.emit('info', `PUBLISH ${type} ${entity.sys.id}`)
+    return result
+  } catch (err) {
+    logEmitter.emit('error', err)
+    return null
+  }
+}
+
+export async function unpublishExoEntity<T>(type: string, entity: { sys: { id: string } }, unpublish: () => Promise<T>): Promise<T | null> {
+  try {
+    const result = await unpublish()
+    logEmitter.emit('info', `UNPUBLISH ${type} ${entity.sys.id}`)
     return result
   } catch (err) {
     logEmitter.emit('error', err)

--- a/test/unit/tasks/push/push-to-space-exo.test.ts
+++ b/test/unit/tasks/push/push-to-space-exo.test.ts
@@ -46,27 +46,32 @@ function makePlainClientMock() {
     component: {
       create: jest.fn(() => Promise.resolve({ sys: { id: 'ct-1' } })),
       upsert: echoVersion('ct-1'),
-      publish: jest.fn(() => Promise.resolve({ sys: { id: 'ct-1' } }))
+      publish: jest.fn(() => Promise.resolve({ sys: { id: 'ct-1' } })),
+      unpublish: jest.fn(() => Promise.resolve({ sys: { id: 'ct-1' } }))
     },
     experienceTemplate: {
       create: jest.fn(() => Promise.resolve({ sys: { id: 'tmpl-1' } })),
       upsert: echoVersion('tmpl-1'),
-      publish: jest.fn(() => Promise.resolve({ sys: { id: 'tmpl-1' } }))
+      publish: jest.fn(() => Promise.resolve({ sys: { id: 'tmpl-1' } })),
+      unpublish: jest.fn(() => Promise.resolve({ sys: { id: 'tmpl-1' } }))
     },
     experienceFragment: {
       create: jest.fn(() => Promise.resolve({ sys: { id: 'frag-1' } })),
       upsert: echoVersion('frag-1'),
-      publish: jest.fn(() => Promise.resolve({ sys: { id: 'frag-1' } }))
+      publish: jest.fn(() => Promise.resolve({ sys: { id: 'frag-1' } })),
+      unpublish: jest.fn(() => Promise.resolve({ sys: { id: 'frag-1' } }))
     },
     dataAssembly: {
       update: echoVersion('da-1'),
       create: jest.fn(() => Promise.resolve({ sys: { id: 'da-1' } })),
-      publish: jest.fn(() => Promise.resolve({ sys: { id: 'da-1' } }))
+      publish: jest.fn(() => Promise.resolve({ sys: { id: 'da-1' } })),
+      unpublish: jest.fn(() => Promise.resolve({ sys: { id: 'da-1' } }))
     },
     experience: {
       create: jest.fn(() => Promise.resolve({ sys: { id: 'exp-1' } })),
       upsert: echoVersion('exp-1'),
-      publish: jest.fn(() => Promise.resolve({ sys: { id: 'exp-1' } }))
+      publish: jest.fn(() => Promise.resolve({ sys: { id: 'exp-1' } })),
+      unpublish: jest.fn(() => Promise.resolve({ sys: { id: 'exp-1' } }))
     }
   }
 }
@@ -693,5 +698,192 @@ describe('Publishing Experiences', () => {
     }).run({ data: {} })
 
     expect(plainClient.experience.publish).not.toHaveBeenCalled()
+  })
+})
+
+// ─── Unpublishing ───────────────────────────────────────────────────────────────────────
+// Covers the fix for the bug where a source-side unpublish never propagated on re-import:
+// no unpublish task existed at all for any ExO entity type before this change.
+
+describe('Unpublishing Components', () => {
+  const draftInSource: any = { sys: { id: 'ct-1', type: 'Component', version: 3 }, name: 'Hero' }
+  const publishedInSource: any = { sys: { id: 'ct-1', type: 'Component', version: 3, publishedVersion: 3 }, name: 'Hero' }
+
+  function makePlainClientWithPublishedDestination() {
+    const plainClient = makePlainClientMock()
+    plainClient.component.upsert = jest.fn((_params: any, _payload: any) => Promise.resolve({ sys: { id: 'ct-1', version: 7, publishedVersion: 7 } }))
+    return plainClient
+  }
+
+  test('unpublishes an entity that is published at the destination but draft in the source', async () => {
+    const plainClient = makePlainClientWithPublishedDestination()
+    const destinationEntity: any = { sys: { id: 'ct-1', type: 'Component', version: 7, publishedVersion: 7 } }
+    await pushToSpace({
+      sourceData: { ...baseSourceData, components: [draftInSource] } as any,
+      destinationData: { ...baseDestinationData, components: [destinationEntity] },
+      client: makeClientMock(),
+      plainClient,
+      spaceId: 'space-1',
+      environmentId: 'master',
+      includeExperienceOrchestration: true,
+      requestQueue
+    }).run({ data: {} })
+
+    expect(plainClient.component.unpublish).toHaveBeenCalledTimes(1)
+    expect(plainClient.component.unpublish).toHaveBeenCalledWith(
+      { spaceId: 'space-1', environmentId: 'master', componentId: 'ct-1', version: 7 }
+    )
+  })
+
+  test('does not unpublish an entity that is published in both source and destination', async () => {
+    const plainClient = makePlainClientWithPublishedDestination()
+    const destinationEntity: any = { sys: { id: 'ct-1', type: 'Component', version: 7, publishedVersion: 7 } }
+    await pushToSpace({
+      sourceData: { ...baseSourceData, components: [publishedInSource] } as any,
+      destinationData: { ...baseDestinationData, components: [destinationEntity] },
+      client: makeClientMock(),
+      plainClient,
+      spaceId: 'space-1',
+      environmentId: 'master',
+      includeExperienceOrchestration: true,
+      requestQueue
+    }).run({ data: {} })
+
+    expect(plainClient.component.unpublish).not.toHaveBeenCalled()
+  })
+
+  test('does not unpublish an entity that was never published at the destination', async () => {
+    const plainClient = makePlainClientMock()
+    const destinationEntity: any = { sys: { id: 'ct-1', type: 'Component', version: 3 } }
+    await pushToSpace({
+      sourceData: { ...baseSourceData, components: [draftInSource] } as any,
+      destinationData: { ...baseDestinationData, components: [destinationEntity] },
+      client: makeClientMock(),
+      plainClient,
+      spaceId: 'space-1',
+      environmentId: 'master',
+      includeExperienceOrchestration: true,
+      requestQueue
+    }).run({ data: {} })
+
+    expect(plainClient.component.unpublish).not.toHaveBeenCalled()
+  })
+
+  test('skips unpublishing when skipContentPublishing is set', async () => {
+    const plainClient = makePlainClientWithPublishedDestination()
+    const destinationEntity: any = { sys: { id: 'ct-1', type: 'Component', version: 7, publishedVersion: 7 } }
+    await pushToSpace({
+      sourceData: { ...baseSourceData, components: [draftInSource] } as any,
+      destinationData: { ...baseDestinationData, components: [destinationEntity] },
+      client: makeClientMock(),
+      plainClient,
+      spaceId: 'space-1',
+      environmentId: 'master',
+      includeExperienceOrchestration: true,
+      skipContentPublishing: true,
+      requestQueue
+    }).run({ data: {} })
+
+    expect(plainClient.component.unpublish).not.toHaveBeenCalled()
+  })
+})
+
+describe('Unpublishing Data Assemblies', () => {
+  test('unpublishes an entity that is published at the destination but draft in the source', async () => {
+    const plainClient = makePlainClientMock()
+    plainClient.dataAssembly.update = jest.fn((_params: any, _payload: any) => Promise.resolve({ sys: { id: 'da-1', version: 5, publishedVersion: 5 } }))
+    const draftInSource: any = { sys: { id: 'da-1', type: 'DataAssembly', version: 5, dataType: [] }, name: 'Assembly', metadata: { tags: [] }, parameters: {}, resolvers: {}, return: { $literal: null } }
+    const destinationEntity: any = { sys: { id: 'da-1', type: 'DataAssembly', version: 5, publishedVersion: 5, dataType: [] } }
+    await pushToSpace({
+      sourceData: { ...baseSourceData, dataAssemblies: [draftInSource] } as any,
+      destinationData: { ...baseDestinationData, dataAssemblies: [destinationEntity] },
+      client: makeClientMock(),
+      plainClient,
+      spaceId: 'space-1',
+      environmentId: 'master',
+      includeExperienceOrchestration: true,
+      requestQueue
+    }).run({ data: {} })
+
+    expect(plainClient.dataAssembly.unpublish).toHaveBeenCalledTimes(1)
+    expect(plainClient.dataAssembly.unpublish).toHaveBeenCalledWith(
+      { spaceId: 'space-1', environmentId: 'master', dataAssemblyId: 'da-1', version: 5 }
+    )
+  })
+})
+
+describe('Unpublishing Experience Templates', () => {
+  test('unpublishes an entity that is published at the destination but draft in the source', async () => {
+    const plainClient = makePlainClientMock()
+    plainClient.experienceTemplate.upsert = jest.fn((_params: any, _payload: any) => Promise.resolve({ sys: { id: 'tmpl-1', version: 4, publishedVersion: 4 } }))
+    const draftInSource: any = { sys: { id: 'tmpl-1', type: 'ExperienceTemplate', version: 4 }, name: 'Press Release' }
+    const destinationEntity: any = { sys: { id: 'tmpl-1', type: 'ExperienceTemplate', version: 4, publishedVersion: 4 } }
+    await pushToSpace({
+      sourceData: { ...baseSourceData, experienceTemplates: [draftInSource] } as any,
+      destinationData: { ...baseDestinationData, experienceTemplates: [destinationEntity] },
+      client: makeClientMock(),
+      plainClient,
+      spaceId: 'space-1',
+      environmentId: 'master',
+      includeExperienceOrchestration: true,
+      requestQueue
+    }).run({ data: {} })
+
+    expect(plainClient.experienceTemplate.unpublish).toHaveBeenCalledTimes(1)
+    expect(plainClient.experienceTemplate.unpublish).toHaveBeenCalledWith(
+      { spaceId: 'space-1', environmentId: 'master', experienceTemplateId: 'tmpl-1', version: 4 }
+    )
+  })
+})
+
+describe('Unpublishing Experience Fragments', () => {
+  const component = { sys: { type: 'ResourceLink', linkType: 'Contentful:Component', urn: 'crn:contentful:::experience:spaces/$self/environments/$self/components/hero' } }
+
+  test('unpublishes an entity that is published at the destination but draft in the source', async () => {
+    const plainClient = makePlainClientMock()
+    plainClient.experienceFragment.upsert = jest.fn((_params: any, _payload: any) => Promise.resolve({ sys: { id: 'frag-1', version: 4, publishedVersion: 4 } }))
+    const draftInSource: any = { sys: { id: 'frag-1', type: 'ExperienceFragment', version: 4, component }, name: 'Hero Fragment' }
+    const destinationEntity: any = { sys: { id: 'frag-1', type: 'ExperienceFragment', version: 4, publishedVersion: 4 } }
+    await pushToSpace({
+      sourceData: { ...baseSourceData, experienceFragments: [draftInSource] } as any,
+      destinationData: { ...baseDestinationData, experienceFragments: [destinationEntity] },
+      client: makeClientMock(),
+      plainClient,
+      spaceId: 'space-1',
+      environmentId: 'master',
+      includeExperienceOrchestration: true,
+      requestQueue
+    }).run({ data: {} })
+
+    expect(plainClient.experienceFragment.unpublish).toHaveBeenCalledTimes(1)
+    expect(plainClient.experienceFragment.unpublish).toHaveBeenCalledWith(
+      { spaceId: 'space-1', environmentId: 'master', experienceFragmentId: 'frag-1', version: 4 }
+    )
+  })
+})
+
+describe('Unpublishing Experiences', () => {
+  const experienceTemplate = { sys: { type: 'ResourceLink', linkType: 'Contentful:ExperienceTemplate', urn: 'crn:contentful:::experience:spaces/$self/environments/$self/experienceTemplates/press-release' } }
+
+  test('unpublishes an entity that is published at the destination but draft in the source', async () => {
+    const plainClient = makePlainClientMock()
+    plainClient.experience.upsert = jest.fn((_params: any, _payload: any) => Promise.resolve({ sys: { id: 'exp-1', version: 8, publishedVersion: 8 } }))
+    const draftInSource: any = { sys: { id: 'exp-1', type: 'Experience', version: 8, experienceTemplate }, name: 'My Experience' }
+    const destinationEntity: any = { sys: { id: 'exp-1', type: 'Experience', version: 8, publishedVersion: 8 } }
+    await pushToSpace({
+      sourceData: { ...baseSourceData, experiences: [draftInSource] } as any,
+      destinationData: { ...baseDestinationData, experiences: [destinationEntity] },
+      client: makeClientMock(),
+      plainClient,
+      spaceId: 'space-1',
+      environmentId: 'master',
+      includeExperienceOrchestration: true,
+      requestQueue
+    }).run({ data: {} })
+
+    expect(plainClient.experience.unpublish).toHaveBeenCalledTimes(1)
+    expect(plainClient.experience.unpublish).toHaveBeenCalledWith(
+      { spaceId: 'space-1', environmentId: 'master', experienceId: 'exp-1', version: 8 }
+    )
   })
 })


### PR DESCRIPTION
[AIS-385](https://contentful.atlassian.net/browse/AIS-385)

**Stacked on #1690** — base branch will need retargeting to `exo` once that merges.

## Summary
- Publish state only flowed one direction on re-import: draft→published in the source was picked up correctly, but published→unpublished never was, for any of the 5 ExO entity types. There was no unpublish task anywhere in the import pipeline — `filterExoEntitiesToPublish` only ever added entities to publish, with no inverse.
- Confirmed the unpublish endpoints already exist for all 5 types (checked against the `assemblies` repo's API contracts) — this is a client-side gap, not a missing backend capability.
- Adds `filterExoEntitiesToUnpublish` (the inverse filter) and an "Unpublishing X" task per entity type, run after all Importing/Publishing tasks in reverse dependency order (Experience first, DataAssembly last) — the API rejects unpublishing an entity that a still-published parent references, so parents must unpublish before the children they embed.
- **This brings ExO entities to parity with existing behavior, not new territory:** Entries/Assets already propagate a de-published state on re-import via `archiveEntities` (gated on `sys.archivedVersion` in the source), unconditionally, with no flag — this PR does the same thing for ExO entities via their nearest equivalent (unpublish, since ExO entities have no archive/unarchive endpoint at all). If you unpublish something in your source and re-import, the destination will now unpublish it too, same as archiving already works for entries and assets today.

## Test plan
- [x] Added 8 new unit tests covering unpublish-propagates, does-not-unpublish-when-still-published-in-source, does-not-unpublish-when-never-published-at-destination, and skip-when-skipContentPublishing, across all 5 entity types
- [x] Full unit suite passes (184/184), lint at baseline (0 new errors, 2 new warnings matching this file's pre-existing `space-before-function-paren` convention gap), clean `tsc --noEmit`
- [x] Verified end-to-end against a real staging space, same-space and cross-space, both directions (publish and unpublish): unpublished a Component/DataAssembly in source, re-imported, confirmed the destination's `publishedVersion` correctly went to `DRAFT` in both topologies

Generated with [Claude Code](https://claude.com/claude-code)


[AIS-385]: https://contentful.atlassian.net/browse/AIS-385?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ