### PR TITLE
test: add integration tests for ExO entity import [AIS-134]

### DIFF
--- a/test/integration/import-exo.test.ts
+++ b/test/integration/import-exo.test.ts
@@ -1,0 +1,192 @@
+import { createClient } from 'contentful-management'
+
+import runContentfulImport from '../../dist/index'
+import { buildExoContent, buildUnpublishedComponentContent, EXO_FIXTURE_IDS } from './utils/exo.utils'
+
+const managementToken = process.env.MANAGEMENT_TOKEN as string
+const orgId = process.env.ORG_ID as string
+const environmentId = 'master'
+
+jest.setTimeout(2 * 60 * 1000) // 2min timeout - covers space create/delete + 6 ExO entity types + publish
+
+// Each describe block below creates its own throwaway space (same pattern as
+// import-lib.test.ts) and deletes it in afterAll.
+
+// Covers: "Import of an ExO export file creates all 6 entity types in destination",
+// "URN rewriting: cross-space import produces valid URNs pointing to destination space/env",
+// and "Publish state is preserved" - one import run, multiple assertions, since all three
+// ACs are properties of the same operation rather than independent scenarios.
+describe('Importing an ExO export with all 6 entity types', () => {
+  let spaceId: string
+  let plainClient
+
+  beforeAll(async () => {
+    const legacyClient = createClient({ accessToken: managementToken }, { type: 'legacy' })
+    const space = await legacyClient.createSpace({ name: 'IMPORT [AUTO] TOOL EXO TMP' }, orgId)
+    spaceId = space.sys.id
+    plainClient = createClient({ accessToken: managementToken })
+
+    await runContentfulImport({
+      spaceId,
+      environmentId,
+      managementToken,
+      content: buildExoContent(EXO_FIXTURE_IDS),
+      includeExperienceOrchestration: true,
+      useVerboseRenderer: true
+    })
+  })
+
+  afterAll(async () => {
+    const legacyClient = createClient({ accessToken: managementToken }, { type: 'legacy' })
+    const space = await legacyClient.getSpace(spaceId)
+    await space.delete()
+  })
+
+  test('creates the DesignToken', async () => {
+    const designToken = await plainClient.designToken.get({ spaceId, environmentId, designTokenId: EXO_FIXTURE_IDS.designTokenId })
+    expect(designToken.sys.type).toBe('DesignToken')
+    expect(designToken.type).toBe('DTCG.Color')
+  })
+
+  test('creates and publishes the Component', async () => {
+    const component = await plainClient.component.get({ spaceId, environmentId, componentId: EXO_FIXTURE_IDS.componentId })
+    expect(component.sys.type).toBe('Component')
+    expect(component.sys.publishedVersion).toBeDefined()
+  })
+
+  test('creates the DataAssembly as draft', async () => {
+    const dataAssembly = await plainClient.dataAssembly.get({ spaceId, environmentId, dataAssemblyId: EXO_FIXTURE_IDS.dataAssemblyId })
+    expect(dataAssembly.sys.type).toBe('DataAssembly')
+    expect(dataAssembly.sys.publishedVersion).toBeUndefined()
+  })
+
+  test('creates and publishes the ExperienceTemplate', async () => {
+    const experienceTemplate = await plainClient.experienceTemplate.get({ spaceId, environmentId, experienceTemplateId: EXO_FIXTURE_IDS.experienceTemplateId })
+    expect(experienceTemplate.sys.type).toBe('ExperienceTemplate')
+    expect(experienceTemplate.sys.publishedVersion).toBeDefined()
+  })
+
+  test('creates the ExperienceFragment as draft, with its Component reference intact', async () => {
+    const fragment = await plainClient.experienceFragment.get({ spaceId, environmentId, experienceFragmentId: EXO_FIXTURE_IDS.experienceFragmentId })
+    expect(fragment.sys.type).toBe('ExperienceFragment')
+    expect(fragment.sys.publishedVersion).toBeUndefined()
+
+    // URN stays $self-relative (no rewriting) and still resolves to the sibling Component
+    // that was imported alongside it, in this same destination space/environment.
+    expect(fragment.sys.component.sys.urn).toBe(
+      `crn:contentful:::experience:spaces/$self/environments/$self/components/${EXO_FIXTURE_IDS.componentId}`
+    )
+    const referencedComponent = await plainClient.component.get({ spaceId, environmentId, componentId: EXO_FIXTURE_IDS.componentId })
+    expect(referencedComponent.sys.id).toBe(EXO_FIXTURE_IDS.componentId)
+  })
+
+  test('creates and publishes the Experience, with its ExperienceTemplate reference intact', async () => {
+    const experience = await plainClient.experience.get({ spaceId, environmentId, experienceId: EXO_FIXTURE_IDS.experienceId })
+    expect(experience.sys.type).toBe('Experience')
+    expect(experience.sys.publishedVersion).toBeDefined()
+
+    expect(experience.sys.experienceTemplate.sys.urn).toBe(
+      `crn:contentful:::experience:spaces/$self/environments/$self/experienceTemplates/${EXO_FIXTURE_IDS.experienceTemplateId}`
+    )
+    const referencedTemplate = await plainClient.experienceTemplate.get({ spaceId, environmentId, experienceTemplateId: EXO_FIXTURE_IDS.experienceTemplateId })
+    expect(referencedTemplate.sys.id).toBe(EXO_FIXTURE_IDS.experienceTemplateId)
+  })
+
+  // Both tests below run after the six above and re-import into the same space, exercising
+  // the UPDATE path (not covered elsewhere in this file) - guards against two real bugs
+  // AIS-385 found that only surfaced against the live API, not mocks: sending an immutable
+  // field on UPDATE 400ing, and unpublish never propagating on re-import.
+
+  test('re-imports the same content again without error', async () => {
+    const result = await runContentfulImport({
+      spaceId,
+      environmentId,
+      managementToken,
+      content: buildExoContent(EXO_FIXTURE_IDS),
+      includeExperienceOrchestration: true,
+      useVerboseRenderer: true
+    })
+
+    expect(result).toBeDefined()
+  })
+
+  test('propagates an unpublish from source to destination on re-import', async () => {
+    await runContentfulImport({
+      spaceId,
+      environmentId,
+      managementToken,
+      content: buildUnpublishedComponentContent(EXO_FIXTURE_IDS),
+      includeExperienceOrchestration: true,
+      useVerboseRenderer: true
+    })
+
+    const component = await plainClient.component.get({ spaceId, environmentId, componentId: EXO_FIXTURE_IDS.componentId })
+    expect(component.sys.publishedVersion).toBeUndefined()
+  })
+})
+
+// Covers: "skipExperienceOrchestration: true skips all ExO tasks even when source file has
+// ExO data" - the ticket names a flag that doesn't exist; the real (and only) way to skip
+// ExO tasks is to leave includeExperienceOrchestration unset (it defaults to false).
+describe('Importing without includeExperienceOrchestration', () => {
+  let spaceId: string
+  let plainClient
+
+  beforeAll(async () => {
+    const legacyClient = createClient({ accessToken: managementToken }, { type: 'legacy' })
+    const space = await legacyClient.createSpace({ name: 'IMPORT [AUTO] TOOL EXO SKIP TMP' }, orgId)
+    spaceId = space.sys.id
+    plainClient = createClient({ accessToken: managementToken })
+  })
+
+  afterAll(async () => {
+    const legacyClient = createClient({ accessToken: managementToken }, { type: 'legacy' })
+    const space = await legacyClient.getSpace(spaceId)
+    await space.delete()
+  })
+
+  test('does not create any ExO entities even though the source file has ExO data', async () => {
+    await runContentfulImport({
+      spaceId,
+      environmentId,
+      managementToken,
+      content: buildExoContent(EXO_FIXTURE_IDS),
+      useVerboseRenderer: true
+    })
+
+    await expect(
+      plainClient.component.get({ spaceId, environmentId, componentId: EXO_FIXTURE_IDS.componentId })
+    ).rejects.toThrow('The resource could not be found')
+  })
+})
+
+// Covers: "Import of an old export file (no ExO arrays) completes without errors"
+describe('Importing a legacy export file with no ExO entity arrays', () => {
+  let spaceId: string
+
+  beforeAll(async () => {
+    const legacyClient = createClient({ accessToken: managementToken }, { type: 'legacy' })
+    const space = await legacyClient.createSpace({ name: 'IMPORT [AUTO] TOOL EXO LEGACY TMP' }, orgId)
+    spaceId = space.sys.id
+  })
+
+  afterAll(async () => {
+    const legacyClient = createClient({ accessToken: managementToken }, { type: 'legacy' })
+    const space = await legacyClient.getSpace(spaceId)
+    await space.delete()
+  })
+
+  test('completes without error', async () => {
+    // If this rejects, Jest fails the test - that IS the "completes without errors" assertion.
+    const result = await runContentfulImport({
+      spaceId,
+      environmentId,
+      managementToken,
+      content: {},
+      includeExperienceOrchestration: true,
+      useVerboseRenderer: true
+    })
+
+    expect(result).toBeDefined()
+  })
+})

--- a/test/integration/utils/exo.utils.ts
+++ b/test/integration/utils/exo.utils.ts
@@ -1,0 +1,158 @@
+export const TEST_PREFIX = '[Exo Integration Test]'
+
+// $self-relative CRN format for same-space/environment ExO ResourceLinks -
+// see reference_exo_resource_link_urns memory / exo-rename.ts for the canonical form.
+const EXO_CRN_PREFIX = 'crn:contentful:::experience:spaces/$self/environments/$self'
+
+const entityPaths: Record<string, string> = {
+  'Contentful:Component': 'components',
+  'Contentful:ExperienceTemplate': 'experienceTemplates'
+}
+
+export function makeResourceLink (linkType: keyof typeof entityPaths, id: string) {
+  return {
+    sys: {
+      type: 'ResourceLink' as const,
+      linkType,
+      urn: `${EXO_CRN_PREFIX}/${entityPaths[linkType]}/${id}`
+    }
+  }
+}
+
+export const testViewport = {
+  id: 'desktop',
+  query: '(min-width: 1024px)',
+  displayName: 'Desktop',
+  previewSize: '100%'
+}
+
+export type ExoFixtureIds = {
+  designTokenId: string
+  componentId: string
+  dataAssemblyId: string
+  experienceTemplateId: string
+  experienceFragmentId: string
+  experienceId: string
+}
+
+// Each describe block in import-exo.test.ts creates and deletes its own throwaway space
+// (same pattern as import-lib.test.ts), so there's no cross-run collision risk - literal,
+// stable IDs are fine and easier to read/debug than generated ones.
+export const EXO_FIXTURE_IDS: ExoFixtureIds = {
+  designTokenId: 'exo-design-token',
+  componentId: 'exo-component',
+  dataAssemblyId: 'exo-data-assembly',
+  experienceTemplateId: 'exo-experience-template',
+  experienceFragmentId: 'exo-experience-fragment',
+  experienceId: 'exo-experience'
+}
+
+/**
+ * Builds an export-shaped content payload covering all 6 ExO entity types, in the same
+ * "read" shape contentful-export would produce: cross-entity references (ExperienceFragment
+ * -> Component, Experience -> ExperienceTemplate) live under `sys`, as returned by the CMA,
+ * not at the top level (that's the CREATE-payload shape push-to-space.ts builds from this).
+ *
+ * DesignToken, DataAssembly and ExperienceFragment are left draft; Component,
+ * ExperienceTemplate and Experience are published - covers publish-state preservation
+ * with a single import run instead of a dedicated one per state.
+ */
+export function buildExoContent (ids: ExoFixtureIds) {
+  return {
+    designTokens: [
+      {
+        sys: { id: ids.designTokenId, type: 'DesignToken', version: 1 },
+        name: `${TEST_PREFIX} Design Token`,
+        type: 'DTCG.Color'
+      }
+    ],
+    components: [
+      {
+        sys: { id: ids.componentId, type: 'Component', version: 1, publishedVersion: 1 },
+        name: `${TEST_PREFIX} Component`,
+        description: 'Created by an ExO import integration test',
+        viewports: [testViewport],
+        contentProperties: [{ id: 'title', name: 'Title', type: 'String', required: false }],
+        designProperties: [{ id: 'color', name: 'Color', type: 'String' }]
+      }
+    ],
+    dataAssemblies: [
+      {
+        sys: {
+          id: ids.dataAssemblyId,
+          type: 'DataAssembly',
+          version: 1,
+          dataType: [{ id: 'title', name: 'Title', type: 'String', required: false }]
+        },
+        metadata: { tags: [] },
+        name: `${TEST_PREFIX} Data Assembly`,
+        description: 'Created by an ExO import integration test',
+        parameters: {},
+        resolvers: {},
+        return: {}
+      }
+    ],
+    experienceTemplates: [
+      {
+        sys: { id: ids.experienceTemplateId, type: 'ExperienceTemplate', version: 1, publishedVersion: 1 },
+        name: `${TEST_PREFIX} Experience Template`,
+        description: 'Created by an ExO import integration test',
+        viewports: [testViewport],
+        contentProperties: [],
+        designProperties: []
+      }
+    ],
+    experienceFragments: [
+      {
+        sys: {
+          id: ids.experienceFragmentId,
+          type: 'ExperienceFragment',
+          version: 1,
+          component: makeResourceLink('Contentful:Component', ids.componentId)
+        },
+        name: `${TEST_PREFIX} Experience Fragment`,
+        description: 'Created by an ExO import integration test',
+        viewports: [testViewport],
+        designProperties: {}
+      }
+    ],
+    experiences: [
+      {
+        sys: {
+          id: ids.experienceId,
+          type: 'Experience',
+          version: 1,
+          publishedVersion: 1,
+          experienceTemplate: makeResourceLink('Contentful:ExperienceTemplate', ids.experienceTemplateId)
+        },
+        name: `${TEST_PREFIX} Experience`,
+        description: 'Created by an ExO import integration test',
+        viewports: [testViewport],
+        designProperties: {}
+      }
+    ]
+  }
+}
+
+/**
+ * A re-import payload for just the Component from buildExoContent, with no
+ * publishedVersion - i.e. "this entity was unpublished in the source since the last
+ * export." Only the Component key is set; every other entity type defaults to empty and
+ * is left untouched by the import. Used to verify that an unpublish in the source
+ * propagates to the destination on re-import (see push-to-space.ts's "Unpublishing
+ * Components" task).
+ */
+export function buildUnpublishedComponentContent (ids: ExoFixtureIds) {
+  return {
+    components: [
+      {
+        sys: { id: ids.componentId, type: 'Component', version: 1 },
+        name: `${TEST_PREFIX} Component`,
+        description: 'Created by an ExO import integration test',
+        viewports: [testViewport],
+        contentProperties: [{ id: 'title', name: 'Title', type: 'String', required: false }],
+        designProperties: [{ id: 'color', name: 'Color', type: 'String' }]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
[AIS-134](https://contentful.atlassian.net/browse/AIS-134)

## Summary
- Adds `test/integration/import-exo.test.ts` covering all 5 ACs from AIS-134: creates all 6 ExO entity types, preserves publish state from source, keeps `$self`-relative ResourceLink URNs valid across a cross-space import, confirms `includeExperienceOrchestration` gating (unset → skips ExO tasks even with ExO data present - the ticket named a `skipExperienceOrchestration` flag that doesn't exist in the code), and imports a legacy export with no ExO arrays cleanly.
- Also covers the re-import (update) path, beyond the literal ACs: re-imports the same fixture a second time, then unpublishes one entity in a follow-up import and confirms it propagates to the destination. This is where two real bugs previously surfaced against the live API (immutable `component`/`experienceTemplate` on UPDATE, unpublish never propagating) - both fixed already, but only guarded by mocked unit tests until now.
- Fully self-contained, same pattern as the existing `import-lib.test.ts`: each describe block creates its own throwaway space via `createSpace()` and deletes it in `afterAll` - no new env var, no pre-provisioned space, no GH secret needed.

## Test plan
- [x] `npm run lint` - clean
- [x] `npm run test:unit` - passing, unaffected by this change
- [x] Ran `test/integration/import-exo.test.ts` for real against a live, exoM1-entitled space - all 10 tests pass, entities created/cleaned up correctly, cross-references resolved, skip-flag behavior confirmed, re-import/unpublish-propagation confirmed

Generated with [Claude Code](https://claude.com/claude-code)

[AIS-134]: https://contentful.atlassian.net/browse/AIS-134?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ