### PR TITLE
feat: default includeExperienceOrchestration to true and document ExO import support [AIS-137]

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,9 +215,9 @@ Path to a JSON file with the configuration options. This file will be merged wit
 
 ### Experience Orchestration
 
-#### `includeExperienceOrchestration` [boolean] [default: `true` when run via the CLI — the most common way this tool is used; `false` if you call the module API directly without setting it — see below]
+#### `includeExperienceOrchestration` [boolean] [default: true]
 
-Flag controlling whether Experience Orchestration (ExO) entities — Design Tokens, Components, Experience Templates, Experience Fragments, Data Assemblies, and Experiences — are imported when present in the source content. Requires the `exoM1` entitlement on the destination space's organization. See the "Experience Orchestration (ExO) entities" section below for the CLI-vs-module default split and what happens when the destination isn't entitled.
+Flag controlling whether Experience Orchestration (ExO) entities — Design Tokens, Components, Experience Templates, Experience Fragments, Data Assemblies, and Experiences — are imported when present in the source content. Requires the `exoM1` entitlement on the destination space's organization. Set to `false` to opt out. See the "Experience Orchestration (ExO) entities" section below for what happens when the destination isn't entitled.
 
 ## :rescue_worker_helmet: Troubleshooting
 
@@ -282,10 +282,7 @@ The `designTokens`, `components`, `experienceTemplates`, `dataAssemblies`, `expe
 
 > **Experimental:** ExO entities (`designTokens`, `components`, `experienceTemplates`, `dataAssemblies`, `experienceFragments`, `experiences`) are `@internal` and considered experimental. Their shape and import behavior are subject to change without notice.
 
-ExO import behavior depends on how you run this tool — the default is not the same in both places:
-
-- **CLI** (`bin/contentful-import` — the executable `npm install -g contentful-import` / `npx contentful-import` runs, and the most common way this tool gets used): `--include-experience-orchestration` defaults to `true`. ExO entities import automatically with no flags passed; pass `--include-experience-orchestration=false` to opt out.
-- **Module API** (`require('contentful-import')(options)`): `includeExperienceOrchestration` defaults to `false`. You must explicitly set it to `true` to get ExO entities.
+ExO import is on by default (`includeExperienceOrchestration: true`) — for the CLI and the module API alike. Pass `includeExperienceOrchestration: false` (`--include-experience-orchestration=false` on the CLI) to opt out.
 
 ```javascript
 const contentfulImport = require('contentful-import')
@@ -294,16 +291,18 @@ const options = {
   contentFile: '/path/to/result/of/contentful-export.json',
   spaceId: '<space_id>',
   managementToken: '<content_management_api_key>',
-  includeExperienceOrchestration: true, // required here — the module API defaults to false, unlike the CLI
+  includeExperienceOrchestration: false, // opt out; omit to import ExO entities when present (the default)
   ...
 }
 
 contentfulImport(options)
 ```
 
-Both paths require the `exoM1` entitlement on the destination space's organization. Separately, [contentful-cli](https://github.com/contentful/contentful-cli)'s `space import` command doesn't expose this option at all yet, so ExO import isn't reachable through that CLI regardless of default.
+If your source content has no ExO entities at all — true for anyone not using ExO — this default is a complete no-op. The destination-entitlement check in `lib/tasks/get-destination-data.ts` only runs if the source data actually contains ExO entities (`sourceData.designTokens?.length`, etc.); with nothing to check, no extra API calls happen and nothing extra gets logged. Behavior is identical either way for imports that don't involve ExO content.
 
-If the destination space isn't entitled, ExO import for that space is skipped and the rest of the content (content types, entries, assets, etc.) still imports normally — but the missing-entitlement notice is logged at error level, not warning. That means `contentfulImport()` still rejects with a `ContentfulMultiError` at the end, even though the non-ExO content imported successfully. Don't treat a rejected promise as proof the whole import failed — check `err.errors` (or the `errorLogFile`) for `Experience Orchestration (ExO) is not enabled for this space` before assuming something is actually broken.
+Requires the `exoM1` entitlement on the destination space's organization. [contentful-cli](https://github.com/contentful/contentful-cli)'s `space import` command doesn't expose this option at all yet, so ExO import isn't reachable through that separate CLI regardless of default.
+
+If the destination space isn't entitled and the source data does contain ExO entities, ExO import for that space is skipped and the rest of the content (content types, entries, assets, etc.) still imports normally — but the missing-entitlement notice is logged at error level, not warning. That means `contentfulImport()` still rejects with a `ContentfulMultiError` at the end, even though the non-ExO content imported successfully. Don't treat a rejected promise as proof the whole import failed — check `err.errors` (or the `errorLogFile`) for `Experience Orchestration (ExO) is not enabled for this space` before assuming something is actually broken.
 
 ### Import order
 

--- a/README.md
+++ b/README.md
@@ -215,9 +215,9 @@ Path to a JSON file with the configuration options. This file will be merged wit
 
 ### Experience Orchestration
 
-#### `includeExperienceOrchestration` [boolean] [default: false via the module API; `true` via the bundled CLI — see below]
+#### `includeExperienceOrchestration` [boolean] [default: `true` when run via the CLI — the most common way this tool is used; `false` if you call the module API directly without setting it — see below]
 
-Opt-in flag to import Experience Orchestration (ExO) entities — Design Tokens, Components, Experience Templates, Experience Fragments, Data Assemblies, and Experiences — when present in the source content. Requires the `exoM1` entitlement on the destination space's organization. See the "Experience Orchestration (ExO) entities" section below for the CLI-vs-module default asymmetry and what happens when the destination isn't entitled.
+Flag controlling whether Experience Orchestration (ExO) entities — Design Tokens, Components, Experience Templates, Experience Fragments, Data Assemblies, and Experiences — are imported when present in the source content. Requires the `exoM1` entitlement on the destination space's organization. See the "Experience Orchestration (ExO) entities" section below for the CLI-vs-module default split and what happens when the destination isn't entitled.
 
 ## :rescue_worker_helmet: Troubleshooting
 
@@ -282,7 +282,10 @@ The `designTokens`, `components`, `experienceTemplates`, `dataAssemblies`, `expe
 
 > **Experimental:** ExO entities (`designTokens`, `components`, `experienceTemplates`, `dataAssemblies`, `experienceFragments`, `experiences`) are `@internal` and considered experimental. Their shape and import behavior are subject to change without notice.
 
-ExO import is opt-in via the `includeExperienceOrchestration` option (see "Configuration options" above) and only runs against destination spaces with the `exoM1` entitlement.
+ExO import behavior depends on how you run this tool — the default is not the same in both places:
+
+- **CLI** (`bin/contentful-import` — the executable `npm install -g contentful-import` / `npx contentful-import` runs, and the most common way this tool gets used): `--include-experience-orchestration` defaults to `true`. ExO entities import automatically with no flags passed; pass `--include-experience-orchestration=false` to opt out.
+- **Module API** (`require('contentful-import')(options)`): `includeExperienceOrchestration` defaults to `false`. You must explicitly set it to `true` to get ExO entities.
 
 ```javascript
 const contentfulImport = require('contentful-import')
@@ -291,14 +294,14 @@ const options = {
   contentFile: '/path/to/result/of/contentful-export.json',
   spaceId: '<space_id>',
   managementToken: '<content_management_api_key>',
-  includeExperienceOrchestration: true,
+  includeExperienceOrchestration: true, // required here — the module API defaults to false, unlike the CLI
   ...
 }
 
 contentfulImport(options)
 ```
 
-> **CLI users, note the flipped default:** the module API defaults `includeExperienceOrchestration` to `false` (opt-in), as shown above. The bundled `contentful-import` executable (`bin/contentful-import`, the same binary `npm install -g contentful-import` / `npx contentful-import` runs) defaults `--include-experience-orchestration` to `true` (opt-out) — so running the CLI with no flags imports ExO entities by default, while calling the module with no options does not. Pass `--include-experience-orchestration=false` to the CLI if you don't want ExO content. Separately, [contentful-cli](https://github.com/contentful/contentful-cli)'s `space import` command doesn't expose this option at all yet, so ExO import isn't reachable through that CLI regardless of default.
+Both paths require the `exoM1` entitlement on the destination space's organization. Separately, [contentful-cli](https://github.com/contentful/contentful-cli)'s `space import` command doesn't expose this option at all yet, so ExO import isn't reachable through that CLI regardless of default.
 
 If the destination space isn't entitled, ExO import for that space is skipped and the rest of the content (content types, entries, assets, etc.) still imports normally — but the missing-entitlement notice is logged at error level, not warning. That means `contentfulImport()` still rejects with a `ContentfulMultiError` at the end, even though the non-ExO content imported successfully. Don't treat a rejected promise as proof the whole import failed — check `err.errors` (or the `errorLogFile`) for `Experience Orchestration (ExO) is not enabled for this space` before assuming something is actually broken.
 

--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ The `designTokens`, `components`, `experienceTemplates`, `dataAssemblies`, `expe
 ExO import is on by default (`includeExperienceOrchestration: true`) — for the CLI and the module API alike. Pass `includeExperienceOrchestration: false` (`--include-experience-orchestration=false` on the CLI) to opt out.
 
 ```javascript
-const contentfulImport = require('contentful-import')
+import contentfulImport from 'contentful-import'
 
 const options = {
   contentFile: '/path/to/result/of/contentful-export.json',
@@ -295,7 +295,7 @@ const options = {
   ...
 }
 
-contentfulImport(options)
+await contentfulImport(options)
 ```
 
 If your source content has no ExO entities at all — true for anyone not using ExO — this default is a complete no-op. The destination-entitlement check in `lib/tasks/get-destination-data.ts` only runs if the source data actually contains ExO entities (`sourceData.designTokens?.length`, etc.); with nothing to check, no extra API calls happen and nothing extra gets logged. Behavior is identical either way for imports that don't involve ExO content.

--- a/README.md
+++ b/README.md
@@ -215,9 +215,9 @@ Path to a JSON file with the configuration options. This file will be merged wit
 
 ### Experience Orchestration
 
-#### `includeExperienceOrchestration` [boolean] [default: false]
+#### `includeExperienceOrchestration` [boolean] [default: false via the module API; `true` via the bundled CLI — see below]
 
-Opt-in flag to import Experience Orchestration (ExO) entities — Design Tokens, Components, Experience Templates, Experience Fragments, Data Assemblies, and Experiences — when present in the source content. Requires the `exoM1` entitlement on the destination space's organization. See the "Experience Orchestration (ExO) entities" section below for what happens when the destination isn't entitled.
+Opt-in flag to import Experience Orchestration (ExO) entities — Design Tokens, Components, Experience Templates, Experience Fragments, Data Assemblies, and Experiences — when present in the source content. Requires the `exoM1` entitlement on the destination space's organization. See the "Experience Orchestration (ExO) entities" section below for the CLI-vs-module default asymmetry and what happens when the destination isn't entitled.
 
 ## :rescue_worker_helmet: Troubleshooting
 
@@ -298,7 +298,7 @@ const options = {
 contentfulImport(options)
 ```
 
-> **Module only:** `includeExperienceOrchestration` is not currently exposed by [contentful-cli](https://github.com/contentful/contentful-cli)'s `space import` command. Until that lands, ExO import is only available through the module API shown above, not the CLI.
+> **CLI users, note the flipped default:** the module API defaults `includeExperienceOrchestration` to `false` (opt-in), as shown above. The bundled `contentful-import` executable (`bin/contentful-import`, the same binary `npm install -g contentful-import` / `npx contentful-import` runs) defaults `--include-experience-orchestration` to `true` (opt-out) — so running the CLI with no flags imports ExO entities by default, while calling the module with no options does not. Pass `--include-experience-orchestration=false` to the CLI if you don't want ExO content. Separately, [contentful-cli](https://github.com/contentful/contentful-cli)'s `space import` command doesn't expose this option at all yet, so ExO import isn't reachable through that CLI regardless of default.
 
 If the destination space isn't entitled, ExO import for that space is skipped and the rest of the content (content types, entries, assets, etc.) still imports normally — but the missing-entitlement notice is logged at error level, not warning. That means `contentfulImport()` still rejects with a `ContentfulMultiError` at the end, even though the non-ExO content imported successfully. Don't treat a rejected promise as proof the whole import failed — check `err.errors` (or the `errorLogFile`) for `Experience Orchestration (ExO) is not enabled for this space` before assuming something is actually broken.
 

--- a/README.md
+++ b/README.md
@@ -213,6 +213,12 @@ Display progress in new lines instead of displaying a busy spinner and the statu
 
 Path to a JSON file with the configuration options. This file will be merged with the options passed to the function. The options passed to the function will take precedence over the ones in the config file.
 
+### Experience Orchestration
+
+#### `includeExperienceOrchestration` [boolean] [default: false]
+
+Opt-in flag to import Experience Orchestration (ExO) entities — Design Tokens, Components, Experience Templates, Experience Fragments, Data Assemblies, and Experiences — when present in the source content. Requires the `exoM1` entitlement on the destination space's organization. See the "Experience Orchestration (ExO) entities" section below for what happens when the destination isn't entitled.
+
 ## :rescue_worker_helmet: Troubleshooting
 
 ### Proxy
@@ -258,11 +264,62 @@ The data to import should be structured like this:
   "webhooks": [],
   "roles": [],
   "tags": [],
-  "editorInterfaces": []
+  "editorInterfaces": [],
+  "designTokens": [],
+  "components": [],
+  "experienceTemplates": [],
+  "dataAssemblies": [],
+  "experienceFragments": [],
+  "experiences": []
 }
 ```
 
 Note: `tags` are not available for all users. If you do not have access to this feature, any tags included in your import data will be skipped.
+
+The `designTokens`, `components`, `experienceTemplates`, `dataAssemblies`, `experienceFragments`, and `experiences` keys are Experience Orchestration (ExO) entities — see the "Experience Orchestration (ExO) entities" section below.
+
+## :test_tube: Experience Orchestration (ExO) entities
+
+> **Experimental:** ExO entities (`designTokens`, `components`, `experienceTemplates`, `dataAssemblies`, `experienceFragments`, `experiences`) are `@internal` and considered experimental. Their shape and import behavior are subject to change without notice.
+
+ExO import is opt-in via the `includeExperienceOrchestration` option (see "Configuration options" above) and only runs against destination spaces with the `exoM1` entitlement.
+
+```javascript
+const contentfulImport = require('contentful-import')
+
+const options = {
+  contentFile: '/path/to/result/of/contentful-export.json',
+  spaceId: '<space_id>',
+  managementToken: '<content_management_api_key>',
+  includeExperienceOrchestration: true,
+  ...
+}
+
+contentfulImport(options)
+```
+
+> **Module only:** `includeExperienceOrchestration` is not currently exposed by [contentful-cli](https://github.com/contentful/contentful-cli)'s `space import` command. Until that lands, ExO import is only available through the module API shown above, not the CLI.
+
+If the destination space isn't entitled, ExO import for that space is skipped and the rest of the content (content types, entries, assets, etc.) still imports normally — but the missing-entitlement notice is logged at error level, not warning. That means `contentfulImport()` still rejects with a `ContentfulMultiError` at the end, even though the non-ExO content imported successfully. Don't treat a rejected promise as proof the whole import failed — check `err.errors` (or the `errorLogFile`) for `Experience Orchestration (ExO) is not enabled for this space` before assuming something is actually broken.
+
+### Import order
+
+ExO entities are created and published in dependency order, then unpublished in reverse order once every other import step has finished:
+
+1. Data Assemblies — create, then publish
+2. Design Tokens — create only (no publish/unpublish step; a Design Token is live as soon as it's created or updated)
+3. Components — create, then publish
+4. Experience Templates — create, then publish
+5. Experience Fragments — create, then publish
+6. Experiences — create, then publish
+7. Unpublish pass, in reverse: Experiences → Experience Fragments → Experience Templates → Components → Data Assemblies
+
+An entity that's published in the source is published in the destination on import. An entity that's unpublished (or removed) in the source but still published in the destination is unpublished on re-import — this propagates in both directions, so reverting a published ExO entity back to draft in the source and re-running the import will unpublish it in the destination too.
+
+### URN rewriting / backward compatibility
+
+- Export files taken before the ExO entity rename (`ComponentType` → `Component`, `Fragment` → `ExperienceFragment`, `Template` → `ExperienceTemplate`) are upgraded automatically on import, including the corresponding resource-link `linkType`s and URN path segments. This upgrade is upgrade-only (there's no downgrade path) and idempotent, so it's safe to run against already-upgraded data.
+- Export files that predate ExO entirely (no ExO keys, or empty ExO arrays) import unchanged — no extra configuration is needed to import older export files.
 
 ## :bulb: Importing to a space with existing content
 

--- a/lib/parseOptions.ts
+++ b/lib/parseOptions.ts
@@ -36,7 +36,7 @@ export default async function parseOptions (params) {
     rawProxy: false,
     uploadAssets: false,
     rateLimit: 7,
-    includeExperienceOrchestration: false
+    includeExperienceOrchestration: true
   }
 
   const configFile = params.config

--- a/test/integration/import-exo.test.ts
+++ b/test/integration/import-exo.test.ts
@@ -125,10 +125,6 @@ describe('Importing an ExO export with all 6 entity types', () => {
   })
 })
 
-// Covers: "skipExperienceOrchestration: true skips all ExO tasks even when source file has
-// ExO data" - the ticket names a flag that doesn't exist; the real way to skip ExO tasks is
-// to explicitly pass includeExperienceOrchestration: false (it now defaults to true, so
-// leaving it unset no longer skips ExO tasks).
 describe('Importing with includeExperienceOrchestration: false', () => {
   let spaceId: string
   let plainClient

--- a/test/integration/import-exo.test.ts
+++ b/test/integration/import-exo.test.ts
@@ -126,9 +126,10 @@ describe('Importing an ExO export with all 6 entity types', () => {
 })
 
 // Covers: "skipExperienceOrchestration: true skips all ExO tasks even when source file has
-// ExO data" - the ticket names a flag that doesn't exist; the real (and only) way to skip
-// ExO tasks is to leave includeExperienceOrchestration unset (it defaults to false).
-describe('Importing without includeExperienceOrchestration', () => {
+// ExO data" - the ticket names a flag that doesn't exist; the real way to skip ExO tasks is
+// to explicitly pass includeExperienceOrchestration: false (it now defaults to true, so
+// leaving it unset no longer skips ExO tasks).
+describe('Importing with includeExperienceOrchestration: false', () => {
   let spaceId: string
   let plainClient
 
@@ -151,6 +152,7 @@ describe('Importing without includeExperienceOrchestration', () => {
       environmentId,
       managementToken,
       content: buildExoContent(EXO_FIXTURE_IDS),
+      includeExperienceOrchestration: false,
       useVerboseRenderer: true
     })
 


### PR DESCRIPTION
[AIS-137](https://contentful.atlassian.net/browse/AIS-137)

## Summary
- **Behavior change**: default `includeExperienceOrchestration` to `true` in `lib/parseOptions.ts` (the module API), matching the CLI's existing default (set in `lib/usageParams.ts` under AIS-96 / #1667) so there's one consistent default instead of a confusing CLI-vs-module split
  - Safe for existing callers with no ExO content: the destination `exoM1` entitlement check in `get-destination-data.ts` only runs `if` the source data actually contains ExO entities, so this is a no-op for anyone not using ExO
  - Verified: 219/219 unit tests still pass with this change
- Add `includeExperienceOrchestration` to the Configuration options section, now describing the single unified default
- Add the ExO entity keys to the "Expected input data structure" JSON example
- Document the import/publish/unpublish dependency order, the legacy URN rename upgrade path, and backward compatibility with pre-ExO export files
- Document the `exoM1` entitlement behavior on the destination space, including that a missing entitlement (when the source data *does* contain ExO entities) currently surfaces as a rejected `ContentfulMultiError` even though the rest of the import succeeds
- Add the `@internal`/experimental disclaimer for ExO entities

## Test plan
- [x] Ran `npx jest test/unit` after the default flip — 219/219 tests pass, no regressions
- [ ] Rendered README locally to confirm markdown formatting

Generated with [Claude Code](https://claude.com/claude-code)

[AIS-137]: https://contentful.atlassian.net/browse/AIS-137?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ