### PR TITLE
fix: remove purpose and add taxonomy integration tests [AIS-134]

### DIFF
--- a/docs/exo-import.md
+++ b/docs/exo-import.md
@@ -125,7 +125,7 @@ This is deterministic so re-running the import is idempotent — it won't create
 The source concept is fetched to copy its `prefLabel` (so the folder name carries over). Then for each destination concept:
 
 - If it **doesn't exist**: create it via `createWithId` with `purpose: 'internal'`, the copied `prefLabel`, and `metadata.spaces` pointing to the destination space.
-- If it **already exists**: check for and patch in any missing pieces — the destination space link in `metadata.spaces` and/or `purpose: 'internal'` if absent. This handles previously broken concepts created without `purpose`.
+- If it **already exists**: patch in the destination space link in `metadata.spaces` if missing.
 
 **Step 4 — Link each concept into its parent scheme**
 

--- a/lib/utils/import-exo-folders.ts
+++ b/lib/utils/import-exo-folders.ts
@@ -161,9 +161,7 @@ export async function createOrPatchChildConcepts(
     } else {
       const patches: Array<{ op: string; path: string; value: any }> = []
 
-      // The CMA does not include purpose in every concept GET response. Only
-      // patch it when the API actually returns a different purpose.
-      if (typeof (existing as any).purpose === 'string' && (existing as any).purpose !== 'internal') {
+      if ((existing as any).purpose !== 'internal') {
         patches.push({ op: 'add', path: '/purpose', value: 'internal' })
       }
 

--- a/lib/utils/import-exo-folders.ts
+++ b/lib/utils/import-exo-folders.ts
@@ -161,7 +161,9 @@ export async function createOrPatchChildConcepts(
     } else {
       const patches: Array<{ op: string; path: string; value: any }> = []
 
-      if ((existing as any).purpose !== 'internal') {
+      // The CMA does not include purpose in every concept GET response. Only
+      // patch it when the API actually returns a different purpose.
+      if (typeof (existing as any).purpose === 'string' && (existing as any).purpose !== 'internal') {
         patches.push({ op: 'add', path: '/purpose', value: 'internal' })
       }
 

--- a/lib/utils/import-exo-folders.ts
+++ b/lib/utils/import-exo-folders.ts
@@ -116,8 +116,7 @@ export function deriveChildConceptMap(
  * Step 3: Create or patch each destination child concept.
  * - If the concept doesn't exist: creates it with purpose:'internal', the source
  *   concept's prefLabel, and metadata.spaces scoped to the destination space.
- * - If it already exists: patches in any missing pieces (purpose:'internal' and/or
- *   the destination space link). Handles concepts created by earlier broken runs.
+ * - If it already exists: patches in the destination space link if missing.
  */
 export async function createOrPatchChildConcepts(
   plainClient: any,
@@ -160,12 +159,6 @@ export async function createOrPatchChildConcepts(
       }
     } else {
       const patches: Array<{ op: string; path: string; value: any }> = []
-
-      // The CMA does not include purpose in every concept GET response. Only
-      // patch it when the API actually returns a different purpose.
-      if (typeof (existing as any).purpose === 'string' && (existing as any).purpose !== 'internal') {
-        patches.push({ op: 'add', path: '/purpose', value: 'internal' })
-      }
 
       const spaces: Array<{ sys: { id: string } }> = existing.metadata?.spaces ?? []
       if (!spaces.some((s) => s.sys.id === destinationSpaceId)) {

--- a/test/integration/import-exo-folders.test.ts
+++ b/test/integration/import-exo-folders.test.ts
@@ -1,0 +1,272 @@
+import { createClient } from 'contentful-management'
+
+import runContentfulImport from '../../dist/index'
+import {
+  buildExoFolderContent,
+  buildSameSpaceExoFolderContent,
+  FOLDER_EXO_FIXTURE_IDS,
+  TEST_PREFIX
+} from './utils/exo.utils'
+
+const managementToken = process.env.MANAGEMENT_TOKEN as string
+const orgId = process.env.ORG_ID as string
+const environmentId = 'master'
+
+const DESIGN_TOKEN_SCHEME_ID = 'contentful.folder-group-designToken'
+const COMPONENT_TYPE_SCHEME_ID = 'contentful.folder-group-componentType'
+const TEMPLATE_SCHEME_ID = 'contentful.folder-group-template'
+const FRAGMENT_SCHEME_ID = 'contentful.folder-group-fragment'
+const EXPERIENCE_SCHEME_ID = 'contentful.folder-group-experience'
+const ALL_PARENT_SCHEME_IDS = [
+  DESIGN_TOKEN_SCHEME_ID,
+  COMPONENT_TYPE_SCHEME_ID,
+  TEMPLATE_SCHEME_ID,
+  FRAGMENT_SCHEME_ID,
+  EXPERIENCE_SCHEME_ID
+]
+
+jest.setTimeout(2 * 60 * 1000) // 2min timeout - covers space/concept create+delete + 2 import runs
+
+function isNotFoundError (err: any) {
+  return err?.status === 404 || err?.name === 'NotFound'
+}
+
+async function unlinkConceptFromSchemeIfPresent (plainClient: any, schemeId: string, conceptId: string) {
+  try {
+    const scheme = await plainClient.conceptScheme.get({ organizationId: orgId, conceptSchemeId: schemeId })
+    const index = (scheme.concepts ?? []).findIndex((c: any) => c.sys.id === conceptId)
+    if (index >= 0) {
+      await plainClient.conceptScheme.patch(
+        { organizationId: orgId, conceptSchemeId: schemeId, version: scheme.sys.version },
+        [{ op: 'remove', path: `/concepts/${index}` }]
+      )
+    }
+  } catch (err: any) {
+    if (!isNotFoundError(err)) throw err
+  }
+}
+
+async function linkConceptToSchemeIfAbsent (plainClient: any, schemeId: string, conceptId: string) {
+  const scheme = await plainClient.conceptScheme.get({ organizationId: orgId, conceptSchemeId: schemeId })
+  if (!(scheme.concepts ?? []).some((c: any) => c.sys.id === conceptId)) {
+    await plainClient.conceptScheme.patch(
+      { organizationId: orgId, conceptSchemeId: schemeId, version: scheme.sys.version },
+      [{ op: 'add', path: '/concepts/-', value: { sys: { type: 'Link', linkType: 'TaxonomyConcept', id: conceptId } } }]
+    )
+  }
+}
+
+async function deleteConceptIfPresent (plainClient: any, conceptId: string) {
+  try {
+    const concept = await plainClient.concept.get({ organizationId: orgId, conceptId })
+    await plainClient.concept.delete({ organizationId: orgId, conceptId, version: concept.sys.version })
+  } catch (err: any) {
+    if (!isNotFoundError(err)) throw err
+  }
+}
+
+// ExO folder import (lib/utils/import-exo-folders.ts) is a 5-step process layered on top
+// of Contentful's Taxonomy system: it runs as its own "Create ExO Folders" task before
+// entity upsert (see docs/exo-import.md, "How ExO Folders Are Imported"). Unlike the rest
+// of ExO import, steps 1-4 write to *org-level*, permanent concept/scheme resources shared
+// across every space in CONTENTFUL_ORGANIZATION_ID, not just the throwaway space under
+// test - so every describe block below carefully cleans up exactly what it creates in
+// afterAll, and derives its concept IDs from its own throwaway space ID so concurrent CI
+// runs (e.g. two PRs building at once) can never race on the same org-level resource.
+describe('Importing ExO entities organized into folders (cross-space)', () => {
+  let spaceId: string
+  let plainClient: any
+  let sourceComponentFolderConceptId: string
+  let sourceComponentFolderLabel: string
+  let sourceExperienceFolderConceptId: string
+  let destComponentFolderConceptId: string
+  let destExperienceFolderConceptId: string
+
+  beforeAll(async () => {
+    plainClient = createClient({ accessToken: managementToken })
+
+    const legacyClient = createClient({ accessToken: managementToken }, { type: 'legacy' })
+    const space = await legacyClient.createSpace({ name: 'IMPORT [AUTO] TOOL EXO FOLDER TMP' }, orgId)
+    spaceId = space.sys.id
+
+    // Keep the source IDs short enough for the importer-derived destination IDs
+    // (which append the destination space ID) to remain within the CMA limit.
+    sourceComponentFolderConceptId = `contentful.folder-component-${spaceId}`
+    sourceExperienceFolderConceptId = `contentful.folder-experience-${spaceId}`
+    destComponentFolderConceptId = `${sourceComponentFolderConceptId}-${spaceId}`
+    destExperienceFolderConceptId = `${sourceExperienceFolderConceptId}-${spaceId}`
+    sourceComponentFolderLabel = `${TEST_PREFIX} Component Folder`
+
+    // Pre-create a real "source" concept for the Component folder, mirroring what a
+    // customer's actual source-space folder concept looks like - lets this suite verify
+    // Step 3's prefLabel-copy path against the live API, not just mocks (see
+    // test/unit/utils/import-exo-folders.test.ts for that same branch under mocks). No
+    // source concept is pre-created for the Experience folder, so that arm instead
+    // exercises the fallback-label branch when the source concept can't be found.
+    await plainClient.concept.createWithId(
+      { organizationId: orgId, conceptId: sourceComponentFolderConceptId },
+      { purpose: 'internal', prefLabel: { 'en-US': sourceComponentFolderLabel } }
+    )
+
+    await runContentfulImport({
+      spaceId,
+      environmentId,
+      managementToken,
+      content: buildExoFolderContent(FOLDER_EXO_FIXTURE_IDS, {
+        component: sourceComponentFolderConceptId,
+        experience: sourceExperienceFolderConceptId
+      }),
+      includeExperienceOrchestration: true,
+      useVerboseRenderer: true
+    })
+  })
+
+  afterAll(async () => {
+    // Unlink from the shared, org-level parent schemes first, then delete the concepts
+    // themselves - these are permanent org resources, not scoped to (and so not cleaned
+    // up by) the throwaway space's deletion below.
+    for (const { schemeId, conceptId } of [
+      { schemeId: COMPONENT_TYPE_SCHEME_ID, conceptId: destComponentFolderConceptId },
+      { schemeId: EXPERIENCE_SCHEME_ID, conceptId: destExperienceFolderConceptId }
+    ]) {
+      await unlinkConceptFromSchemeIfPresent(plainClient, schemeId, conceptId)
+    }
+
+    for (const conceptId of [sourceComponentFolderConceptId, destComponentFolderConceptId, destExperienceFolderConceptId]) {
+      await deleteConceptIfPresent(plainClient, conceptId)
+    }
+
+    const legacyClient = createClient({ accessToken: managementToken }, { type: 'legacy' })
+    const space = await legacyClient.getSpace(spaceId)
+    await space.delete()
+  })
+
+  test('creates a destination-scoped concept for the Component folder, copying the source prefLabel', async () => {
+    const concept = await plainClient.concept.get({ organizationId: orgId, conceptId: destComponentFolderConceptId })
+    expect(concept.prefLabel['en-US']).toBe(sourceComponentFolderLabel)
+    expect(concept.metadata.spaces.some((s: any) => s.sys.id === spaceId)).toBe(true)
+  })
+
+  test('creates a destination-scoped concept for the Experience folder, falling back to the derived ID as its label since no source concept exists', async () => {
+    const concept = await plainClient.concept.get({ organizationId: orgId, conceptId: destExperienceFolderConceptId })
+    expect(concept.prefLabel['en-US']).toBe(destExperienceFolderConceptId)
+    expect(concept.metadata.spaces.some((s: any) => s.sys.id === spaceId)).toBe(true)
+  })
+
+  test('links each new concept into its parent folder-group scheme', async () => {
+    const componentScheme = await plainClient.conceptScheme.get({ organizationId: orgId, conceptSchemeId: COMPONENT_TYPE_SCHEME_ID })
+    expect(componentScheme.concepts.some((c: any) => c.sys.id === destComponentFolderConceptId)).toBe(true)
+
+    const experienceScheme = await plainClient.conceptScheme.get({ organizationId: orgId, conceptSchemeId: EXPERIENCE_SCHEME_ID })
+    expect(experienceScheme.concepts.some((c: any) => c.sys.id === destExperienceFolderConceptId)).toBe(true)
+  })
+
+  test('rewrites each entity\'s metadata.concepts to point at the new destination concept, not the source', async () => {
+    const component = await plainClient.component.get({ spaceId, environmentId, componentId: FOLDER_EXO_FIXTURE_IDS.componentId })
+    expect(component.metadata.concepts[0].sys.id).toBe(destComponentFolderConceptId)
+
+    const experience = await plainClient.experience.get({ spaceId, environmentId, experienceId: FOLDER_EXO_FIXTURE_IDS.experienceId })
+    expect(experience.metadata.concepts[0].sys.id).toBe(destExperienceFolderConceptId)
+  })
+
+  test('re-import is idempotent: no duplicate concept version bump or scheme link is created', async () => {
+    const componentConceptBefore = await plainClient.concept.get({ organizationId: orgId, conceptId: destComponentFolderConceptId })
+    const componentSchemeBefore = await plainClient.conceptScheme.get({ organizationId: orgId, conceptSchemeId: COMPONENT_TYPE_SCHEME_ID })
+    const experienceConceptBefore = await plainClient.concept.get({ organizationId: orgId, conceptId: destExperienceFolderConceptId })
+    const experienceSchemeBefore = await plainClient.conceptScheme.get({ organizationId: orgId, conceptSchemeId: EXPERIENCE_SCHEME_ID })
+
+    const result = await runContentfulImport({
+      spaceId,
+      environmentId,
+      managementToken,
+      content: buildExoFolderContent(FOLDER_EXO_FIXTURE_IDS, {
+        component: sourceComponentFolderConceptId,
+        experience: sourceExperienceFolderConceptId
+      }),
+      includeExperienceOrchestration: true,
+      useVerboseRenderer: true
+    })
+    expect(result).toBeDefined()
+
+    const componentConceptAfter = await plainClient.concept.get({ organizationId: orgId, conceptId: destComponentFolderConceptId })
+    const componentSchemeAfter = await plainClient.conceptScheme.get({ organizationId: orgId, conceptSchemeId: COMPONENT_TYPE_SCHEME_ID })
+    const experienceConceptAfter = await plainClient.concept.get({ organizationId: orgId, conceptId: destExperienceFolderConceptId })
+    const experienceSchemeAfter = await plainClient.conceptScheme.get({ organizationId: orgId, conceptSchemeId: EXPERIENCE_SCHEME_ID })
+
+    // Nothing was missing to patch on the concept (purpose + space link already present),
+    // so createOrPatchChildConcepts should be a no-op - no version bump.
+    expect(componentConceptAfter.sys.version).toBe(componentConceptBefore.sys.version)
+    expect(experienceConceptAfter.sys.version).toBe(experienceConceptBefore.sys.version)
+    // Already linked, so linkChildConceptsToParentGroups should skip the patch entirely -
+    // no duplicate entry and no version bump.
+    expect(componentSchemeAfter.concepts.filter((c: any) => c.sys.id === destComponentFolderConceptId).length).toBe(1)
+    expect(componentSchemeAfter.sys.version).toBe(componentSchemeBefore.sys.version)
+    expect(experienceSchemeAfter.concepts.filter((c: any) => c.sys.id === destExperienceFolderConceptId).length).toBe(1)
+    expect(experienceSchemeAfter.sys.version).toBe(experienceSchemeBefore.sys.version)
+  })
+})
+
+// dataAssemblies intentionally excluded - ExO folders aren't supported for that entity
+// type (see PR contentful/contentful-import#1682's description), so there's no
+// ENTITY_TYPE_TO_PARENT_GROUP_ID mapping to exercise there.
+describe('Importing ExO entities organized into folders (same-space)', () => {
+  let spaceId: string
+  let plainClient: any
+  let folderConceptId: string
+
+  beforeAll(async () => {
+    const legacyClient = createClient({ accessToken: managementToken }, { type: 'legacy' })
+    const space = await legacyClient.createSpace({ name: 'IMPORT [AUTO] TOOL EXO FOLDER SAMESPACE TMP' }, orgId)
+    spaceId = space.sys.id
+    plainClient = createClient({ accessToken: managementToken })
+    folderConceptId = `contentful.folder-samespace-${spaceId}`
+
+    await plainClient.concept.createWithId(
+      { organizationId: orgId, conceptId: folderConceptId },
+      {
+        purpose: 'internal',
+        prefLabel: { 'en-US': folderConceptId },
+        metadata: { spaces: [{ sys: { type: 'Link', linkType: 'Space', id: spaceId } }] }
+      }
+    )
+    await linkConceptToSchemeIfAbsent(plainClient, COMPONENT_TYPE_SCHEME_ID, folderConceptId)
+
+    await runContentfulImport({
+      spaceId,
+      environmentId,
+      managementToken,
+      content: buildSameSpaceExoFolderContent(FOLDER_EXO_FIXTURE_IDS, folderConceptId, spaceId),
+      includeExperienceOrchestration: true,
+      useVerboseRenderer: true
+    })
+  })
+
+  afterAll(async () => {
+    const destConceptId = `${folderConceptId}-${spaceId}`
+
+    try {
+      for (const schemeId of ALL_PARENT_SCHEME_IDS) {
+        await unlinkConceptFromSchemeIfPresent(plainClient, schemeId, destConceptId)
+      }
+
+      await deleteConceptIfPresent(plainClient, destConceptId)
+      await unlinkConceptFromSchemeIfPresent(plainClient, COMPONENT_TYPE_SCHEME_ID, folderConceptId)
+      await deleteConceptIfPresent(plainClient, folderConceptId)
+    } finally {
+      const legacyClient = createClient({ accessToken: managementToken }, { type: 'legacy' })
+      const space = await legacyClient.getSpace(spaceId)
+      await space.delete()
+    }
+  })
+
+  test('skips folder import entirely and leaves the source concept ID on the entity untouched', async () => {
+    const component = await plainClient.component.get({ spaceId, environmentId, componentId: FOLDER_EXO_FIXTURE_IDS.componentId })
+    expect(component.metadata.concepts[0].sys.id).toBe(folderConceptId)
+
+    // No destination-scoped concept should have been created for this space, since the
+    // folder import step is skipped entirely when source === destination space.
+    await expect(
+      plainClient.concept.get({ organizationId: orgId, conceptId: `${folderConceptId}-${spaceId}` })
+    ).rejects.toThrow()
+  })
+})

--- a/test/integration/import-exo-folders.test.ts
+++ b/test/integration/import-exo-folders.test.ts
@@ -31,29 +31,58 @@ function isNotFoundError (err: any) {
   return err?.status === 404 || err?.name === 'NotFound'
 }
 
+// Matches the CMA plain client's error shape for a stale sys.version on PATCH/PUT (see
+// handleCreationErrors in lib/tasks/push-to-space/creation.ts for the same check).
+function isVersionMismatchError (err: any) {
+  return err?.error?.sys?.id === 'VersionMismatch'
+}
+
+const VERSION_CONFLICT_MAX_ATTEMPTS = 3
+const VERSION_CONFLICT_RETRY_DELAY_MS = 250
+
+// The 5 parent folder-group schemes are shared, org-wide resources - test-integration
+// runs on every PR against the same org, so two concurrent CI runs can genuinely both
+// read the same scheme, then race to patch it, and lose the optimistic-concurrency check
+// on sys.version. Retrying with a fresh read closes that race instead of failing the test
+// (or, worse in afterAll, aborting cleanup) on ordinary CI-level concurrency.
+async function withVersionConflictRetry<T> (operation: () => Promise<T>): Promise<T> {
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return await operation()
+    } catch (err: any) {
+      if (!isVersionMismatchError(err) || attempt >= VERSION_CONFLICT_MAX_ATTEMPTS) throw err
+      await new Promise((resolve) => setTimeout(resolve, VERSION_CONFLICT_RETRY_DELAY_MS * attempt))
+    }
+  }
+}
+
 async function unlinkConceptFromSchemeIfPresent (plainClient: any, schemeId: string, conceptId: string) {
   try {
-    const scheme = await plainClient.conceptScheme.get({ organizationId: orgId, conceptSchemeId: schemeId })
-    const index = (scheme.concepts ?? []).findIndex((c: any) => c.sys.id === conceptId)
-    if (index >= 0) {
-      await plainClient.conceptScheme.patch(
-        { organizationId: orgId, conceptSchemeId: schemeId, version: scheme.sys.version },
-        [{ op: 'remove', path: `/concepts/${index}` }]
-      )
-    }
+    await withVersionConflictRetry(async () => {
+      const scheme = await plainClient.conceptScheme.get({ organizationId: orgId, conceptSchemeId: schemeId })
+      const index = (scheme.concepts ?? []).findIndex((c: any) => c.sys.id === conceptId)
+      if (index >= 0) {
+        await plainClient.conceptScheme.patch(
+          { organizationId: orgId, conceptSchemeId: schemeId, version: scheme.sys.version },
+          [{ op: 'remove', path: `/concepts/${index}` }]
+        )
+      }
+    })
   } catch (err: any) {
     if (!isNotFoundError(err)) throw err
   }
 }
 
 async function linkConceptToSchemeIfAbsent (plainClient: any, schemeId: string, conceptId: string) {
-  const scheme = await plainClient.conceptScheme.get({ organizationId: orgId, conceptSchemeId: schemeId })
-  if (!(scheme.concepts ?? []).some((c: any) => c.sys.id === conceptId)) {
-    await plainClient.conceptScheme.patch(
-      { organizationId: orgId, conceptSchemeId: schemeId, version: scheme.sys.version },
-      [{ op: 'add', path: '/concepts/-', value: { sys: { type: 'Link', linkType: 'TaxonomyConcept', id: conceptId } } }]
-    )
-  }
+  await withVersionConflictRetry(async () => {
+    const scheme = await plainClient.conceptScheme.get({ organizationId: orgId, conceptSchemeId: schemeId })
+    if (!(scheme.concepts ?? []).some((c: any) => c.sys.id === conceptId)) {
+      await plainClient.conceptScheme.patch(
+        { organizationId: orgId, conceptSchemeId: schemeId, version: scheme.sys.version },
+        [{ op: 'add', path: '/concepts/-', value: { sys: { type: 'Link', linkType: 'TaxonomyConcept', id: conceptId } } }]
+      )
+    }
+  })
 }
 
 async function deleteConceptIfPresent (plainClient: any, conceptId: string) {
@@ -122,23 +151,27 @@ describe('Importing ExO entities organized into folders (cross-space)', () => {
   })
 
   afterAll(async () => {
-    // Unlink from the shared, org-level parent schemes first, then delete the concepts
-    // themselves - these are permanent org resources, not scoped to (and so not cleaned
-    // up by) the throwaway space's deletion below.
-    for (const { schemeId, conceptId } of [
-      { schemeId: COMPONENT_TYPE_SCHEME_ID, conceptId: destComponentFolderConceptId },
-      { schemeId: EXPERIENCE_SCHEME_ID, conceptId: destExperienceFolderConceptId }
-    ]) {
-      await unlinkConceptFromSchemeIfPresent(plainClient, schemeId, conceptId)
-    }
+    try {
+      // Unlink from the shared, org-level parent schemes first, then delete the concepts
+      // themselves - these are permanent org resources, not scoped to (and so not cleaned
+      // up by) the throwaway space's deletion below.
+      for (const { schemeId, conceptId } of [
+        { schemeId: COMPONENT_TYPE_SCHEME_ID, conceptId: destComponentFolderConceptId },
+        { schemeId: EXPERIENCE_SCHEME_ID, conceptId: destExperienceFolderConceptId }
+      ]) {
+        await unlinkConceptFromSchemeIfPresent(plainClient, schemeId, conceptId)
+      }
 
-    for (const conceptId of [sourceComponentFolderConceptId, destComponentFolderConceptId, destExperienceFolderConceptId]) {
-      await deleteConceptIfPresent(plainClient, conceptId)
+      for (const conceptId of [sourceComponentFolderConceptId, destComponentFolderConceptId, destExperienceFolderConceptId]) {
+        await deleteConceptIfPresent(plainClient, conceptId)
+      }
+    } finally {
+      // Always delete the throwaway space, even if org-level concept/scheme cleanup above
+      // failed - the two are independent resources and one failing shouldn't leak the other.
+      const legacyClient = createClient({ accessToken: managementToken }, { type: 'legacy' })
+      const space = await legacyClient.getSpace(spaceId)
+      await space.delete()
     }
-
-    const legacyClient = createClient({ accessToken: managementToken }, { type: 'legacy' })
-    const space = await legacyClient.getSpace(spaceId)
-    await space.delete()
   })
 
   test('creates a destination-scoped concept for the Component folder, copying the source prefLabel', async () => {

--- a/test/integration/utils/exo.utils.ts
+++ b/test/integration/utils/exo.utils.ts
@@ -134,6 +134,108 @@ export function buildExoContent (ids: ExoFixtureIds) {
   }
 }
 
+export function makeFolderConceptLink (conceptId: string) {
+  return { sys: { type: 'Link' as const, linkType: 'TaxonomyConcept' as const, id: conceptId } }
+}
+
+export type FolderExoFixtureIds = {
+  componentId: string
+  experienceTemplateId: string
+  experienceId: string
+}
+
+// Two distinct entity types/parent folder-groups (componentType, experience) in one
+// payload, to catch a mis-mapping in ENTITY_TYPE_TO_PARENT_GROUP_ID without needing all 5.
+export const FOLDER_EXO_FIXTURE_IDS: FolderExoFixtureIds = {
+  componentId: 'exo-folder-component',
+  experienceTemplateId: 'exo-folder-experience-template',
+  experienceId: 'exo-folder-experience'
+}
+
+export type FolderConceptIds = {
+  component: string
+  experience: string
+}
+
+/**
+ * A Component and an Experience (with its required ExperienceTemplate dependency), each
+ * placed in a folder via metadata.concepts - exercises import-exo-folders.ts's 5-step
+ * process (ensure parent groups -> derive dest concept IDs -> create/patch child concepts
+ * -> link into parent groups -> rewrite entity metadata.concepts in-place) across two of
+ * the five parent folder-group schemes in one import run.
+ *
+ * folderConceptIds is caller-supplied (not a fixed literal) because these become real,
+ * permanent, org-scoped TaxonomyConcept IDs shared across every space in the org - the
+ * caller derives them from its own throwaway space ID so concurrent CI runs never race
+ * on the same org-level resource (see import-exo-folders.test.ts).
+ *
+ * No `sys.space` set, so getSourceSpaceId() returns undefined - this is treated as a
+ * cross-space import (undefined !== destinationSpaceId), same as buildExoContent above.
+ */
+export function buildExoFolderContent (ids: FolderExoFixtureIds, folderConceptIds: FolderConceptIds) {
+  return {
+    components: [
+      {
+        sys: { id: ids.componentId, type: 'Component', version: 1 },
+        metadata: { tags: [], concepts: [makeFolderConceptLink(folderConceptIds.component)] },
+        name: `${TEST_PREFIX} Foldered Component`,
+        description: 'Created by an ExO folder import integration test',
+        viewports: [testViewport],
+        contentProperties: [{ id: 'title', name: 'Title', type: 'String', required: false }],
+        designProperties: [{ id: 'color', name: 'Color', type: 'String' }]
+      }
+    ],
+    experienceTemplates: [
+      {
+        sys: { id: ids.experienceTemplateId, type: 'ExperienceTemplate', version: 1 },
+        name: `${TEST_PREFIX} Foldered Experience Template`,
+        description: 'Created by an ExO folder import integration test',
+        viewports: [testViewport],
+        contentProperties: [],
+        designProperties: []
+      }
+    ],
+    experiences: [
+      {
+        sys: {
+          id: ids.experienceId,
+          type: 'Experience',
+          version: 1,
+          experienceTemplate: makeResourceLink('Contentful:ExperienceTemplate', ids.experienceTemplateId)
+        },
+        metadata: { tags: [], concepts: [makeFolderConceptLink(folderConceptIds.experience)] },
+        name: `${TEST_PREFIX} Foldered Experience`,
+        description: 'Created by an ExO folder import integration test',
+        viewports: [testViewport],
+        designProperties: {}
+      }
+    ]
+  }
+}
+
+/**
+ * Same Component/folder pairing as buildExoFolderContent, but with `sys.space.sys.id`
+ * pinned to the destination space - simulates a same-space import, where
+ * importExoFolders() should skip its own logic entirely (source === destination space)
+ * and leave the source concept ID on the entity untouched. Since the skip means no
+ * org-level concept is ever created, folderConceptId can safely be a fixed literal here.
+ */
+export function buildSameSpaceExoFolderContent (ids: FolderExoFixtureIds, folderConceptId: string, spaceId: string) {
+  return {
+    components: [
+      {
+        sys: { id: ids.componentId, type: 'Component', version: 1, space: { sys: { id: spaceId } } },
+        metadata: { tags: [], concepts: [makeFolderConceptLink(folderConceptId)] },
+        name: `${TEST_PREFIX} Foldered Component`,
+        description: 'Created by an ExO folder import integration test',
+        viewports: [testViewport],
+        contentProperties: [{ id: 'title', name: 'Title', type: 'String', required: false }],
+        designProperties: [{ id: 'color', name: 'Color', type: 'String' }]
+      }
+    ]
+  }
+}
+
 /**
  * A re-import payload for just the Component from buildExoContent, with no
  * publishedVersion - i.e. "this entity was unpublished in the source since the last

--- a/test/unit/utils/import-exo-folders.test.ts
+++ b/test/unit/utils/import-exo-folders.test.ts
@@ -220,22 +220,6 @@ describe('createOrPatchChildConcepts', () => {
     )
   })
 
-  it('patches purpose when existing concept is missing it', async () => {
-    const sourceId = 'contentful.folder-a-AA'
-    const destId = `${sourceId}-${DEST_SPACE}`
-    const existing = makeConcept(destId, { purpose: 'extension', spaces: [DEST_SPACE] })
-    const client = makeClient({ existingConcepts: new Map([[destId, existing]]) })
-
-    const childConceptMap = new Map([[sourceId, { destConceptId: destId, parentGroupId: PARENT_FOLDER_GROUP_IDS.designToken }]])
-    await createOrPatchChildConcepts(client, ORG, DEST_SPACE, childConceptMap)
-
-    expect(client.concept.createWithId).not.toHaveBeenCalled()
-    expect(client.concept.patch).toHaveBeenCalledWith(
-      expect.objectContaining({ conceptId: destId }),
-      expect.arrayContaining([{ op: 'add', path: '/purpose', value: 'internal' }])
-    )
-  })
-
   it('patches space link when existing concept is missing destination space', async () => {
     const sourceId = 'contentful.folder-a-AA'
     const destId = `${sourceId}-${DEST_SPACE}`
@@ -248,24 +232,8 @@ describe('createOrPatchChildConcepts', () => {
     expect(client.concept.createWithId).not.toHaveBeenCalled()
     expect(client.concept.patch).toHaveBeenCalledWith(
       expect.objectContaining({ conceptId: destId }),
-      expect.arrayContaining([
-        { op: 'add', path: '/metadata/spaces/-', value: { sys: { type: 'Link', linkType: 'Space', id: DEST_SPACE } } },
-      ])
+      [{ op: 'add', path: '/metadata/spaces/-', value: { sys: { type: 'Link', linkType: 'Space', id: DEST_SPACE } } }]
     )
-  })
-
-  it('patches both purpose and space in a single call when both are missing', async () => {
-    const sourceId = 'contentful.folder-a-AA'
-    const destId = `${sourceId}-${DEST_SPACE}`
-    const existing = makeConcept(destId, { purpose: 'extension', spaces: [] })
-    const client = makeClient({ existingConcepts: new Map([[destId, existing]]) })
-
-    const childConceptMap = new Map([[sourceId, { destConceptId: destId, parentGroupId: PARENT_FOLDER_GROUP_IDS.designToken }]])
-    await createOrPatchChildConcepts(client, ORG, DEST_SPACE, childConceptMap)
-
-    expect(client.concept.patch).toHaveBeenCalledTimes(1)
-    const patches = client.concept.patch.mock.calls[0][1]
-    expect(patches).toHaveLength(2)
   })
 
   it('does not patch when existing concept is already up to date', async () => {


### PR DESCRIPTION
[AIS-134](https://contentful.atlassian.net/browse/AIS-134)

## Summary
- Adds integration test coverage for ExO folder import. Covers: destination-scoped concept creation (prefLabel copied from a real source concept, and the fallback-to-derived-ID path when no source concept exists), linking new concepts into their parent folder-group scheme, in-place rewrite of entity `metadata.concepts`, re-import idempotency, and the same-space skip path.
- Removes dead purpose-patch logic in `lib/utils/import-exo-folders.ts` (per [review](https://github.com/contentful/contentful-import/pull/1696/changes#r3797933013)): the concepts API doesn't reliably return `purpose` in a GET response and doesn't allow updating it after creation, so the existing-concept patch path could never detect or repair it — only the destination space link is patched now. (Initially landed as a narrower guard rather than a full removal; confirmed empirically that *some* fix was load-bearing by reverting it and watching the `re-import is idempotent` test fail live as predicted, then removed the check entirely once review clarified it could never have worked at all.)
- Hardens the new tests' cleanup for concurrent CI: the cross-space `afterAll` now wraps org-scoped cleanup in try/finally so a cleanup failure can't leak the throwaway space, and shared parent-scheme patches retry on `VersionMismatch` since `test-integration` runs on every PR against the same org.
- Rebased onto latest `main` to pick up an unrelated fix ([15a17c1](https://github.com/contentful/contentful-import/commit/15a17c15eaed5347a3f74ba32a1000beeaa13b5d)).

## Test plan
- [x] `npm run test:unit` (248/248 pass)
- [x] `tsc --project tsconfig.test.json --noEmit`
- [x] Ran the integration suite live against the CI org via CI, confirming the fix is load-bearing and the rebase is green
- [ ] Address unrelated pre-existing lint errors reported by the repo-wide test lint command (out of scope for this PR)


[AIS-134]: https://contentful.atlassian.net/browse/AIS-134?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ