### PR TITLE
feat: Experience Orchestration Import [AIS-96]

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,12 @@ Display progress in new lines instead of displaying a busy spinner and the statu
 
 Path to a JSON file with the configuration options. This file will be merged with the options passed to the function. The options passed to the function will take precedence over the ones in the config file.
 
+### Experience Orchestration
+
+#### `includeExperienceOrchestration` [boolean] [default: true]
+
+Flag controlling whether Experience Orchestration (ExO) entities — Design Tokens, Components, Experience Templates, Experience Fragments, Data Assemblies, and Experiences — are imported when present in the source content. Requires the `exoM1` entitlement on the destination space's organization. Set to `false` to opt out. See the "Experience Orchestration (ExO) entities" section below for what happens when the destination isn't entitled.
+
 ## :rescue_worker_helmet: Troubleshooting
 
 ### Proxy
@@ -258,11 +264,64 @@ The data to import should be structured like this:
   "webhooks": [],
   "roles": [],
   "tags": [],
-  "editorInterfaces": []
+  "editorInterfaces": [],
+  "designTokens": [],
+  "components": [],
+  "experienceTemplates": [],
+  "dataAssemblies": [],
+  "experienceFragments": [],
+  "experiences": []
 }
 ```
 
 Note: `tags` are not available for all users. If you do not have access to this feature, any tags included in your import data will be skipped.
+
+The `designTokens`, `components`, `experienceTemplates`, `dataAssemblies`, `experienceFragments`, and `experiences` keys are Experience Orchestration (ExO) entities — see the "Experience Orchestration (ExO) entities" section below.
+
+## :test_tube: Experience Orchestration (ExO) entities
+
+> **Experimental:** ExO entities (`designTokens`, `components`, `experienceTemplates`, `dataAssemblies`, `experienceFragments`, `experiences`) are `@internal` and considered experimental. Their shape and import behavior are subject to change without notice.
+
+ExO import is on by default (`includeExperienceOrchestration: true`) — for the CLI and the module API alike. Pass `includeExperienceOrchestration: false` (`--include-experience-orchestration=false` on the CLI) to opt out.
+
+```javascript
+import contentfulImport from 'contentful-import'
+
+const options = {
+  contentFile: '/path/to/result/of/contentful-export.json',
+  spaceId: '<space_id>',
+  managementToken: '<content_management_api_key>',
+  includeExperienceOrchestration: false, // opt out; omit to import ExO entities when present (the default)
+  ...
+}
+
+await contentfulImport(options)
+```
+
+If your source content has no ExO entities at all — true for anyone not using ExO — this default is a complete no-op. The destination-entitlement check in `lib/tasks/get-destination-data.ts` only runs if the source data actually contains ExO entities (`sourceData.designTokens?.length`, etc.); with nothing to check, no extra API calls happen and nothing extra gets logged. Behavior is identical either way for imports that don't involve ExO content.
+
+Requires the `exoM1` entitlement on the destination space's organization. [contentful-cli](https://github.com/contentful/contentful-cli)'s `space import` command doesn't expose this option at all yet, so ExO import isn't reachable through that separate CLI regardless of default.
+
+If the destination space isn't entitled and the source data does contain ExO entities, ExO import for that space is skipped and the rest of the content (content types, entries, assets, etc.) still imports normally — but the missing-entitlement notice is logged at error level, not warning. That means `contentfulImport()` still rejects with a `ContentfulMultiError` at the end, even though the non-ExO content imported successfully. Don't treat a rejected promise as proof the whole import failed — check `err.errors` (or the `errorLogFile`) for `Experience Orchestration (ExO) is not enabled for this space` before assuming something is actually broken.
+
+### Import order
+
+ExO entities are created and published in dependency order, then unpublished in reverse order once every other import step has finished:
+
+1. Data Assemblies — create, then publish
+2. Design Tokens — create only (no publish/unpublish step; a Design Token is live as soon as it's created or updated)
+3. Components — create, then publish
+4. Experience Templates — create, then publish
+5. Experience Fragments — create, then publish
+6. Experiences — create, then publish
+7. Unpublish pass, in reverse: Experiences → Experience Fragments → Experience Templates → Components → Data Assemblies
+
+An entity that's published in the source is published in the destination on import. An entity that's unpublished (or removed) in the source but still published in the destination is unpublished on re-import — this propagates in both directions, so reverting a published ExO entity back to draft in the source and re-running the import will unpublish it in the destination too.
+
+### URN rewriting / backward compatibility
+
+- Export files taken before the ExO entity rename (`ComponentType` → `Component`, `Fragment` → `ExperienceFragment`, `Template` → `ExperienceTemplate`) are upgraded automatically on import, including the corresponding resource-link `linkType`s and URN path segments. This upgrade is upgrade-only (there's no downgrade path) and idempotent, so it's safe to run against already-upgraded data.
+- Export files that predate ExO entirely (no ExO keys, or empty ExO arrays) import unchanged — no extra configuration is needed to import older export files.
 
 ## :bulb: Importing to a space with existing content
 

--- a/docs/exo-import.md
+++ b/docs/exo-import.md
@@ -1,0 +1,144 @@
+# Experience Orchestration (ExO) Import
+
+## What is ExO?
+
+Experience Orchestration (ExO) is Contentful's system for composing and rendering structured page experiences. It sits above the traditional entry/content-type layer and provides a dedicated set of entity types — DataAssemblies, DesignTokens, ComponentTypes, Templates, Fragments, and Experiences — that together describe *how* content is fetched, assembled, and laid out. DataAssemblies define reusable data-fetching contracts (GraphQL resolvers, parameter bindings). DesignTokens define reusable design values (colors, spacing, typography, etc.) that other ExO entities can reference via design properties. ComponentTypes define the visual building blocks that consume that data. Templates describe full page layouts in terms of ComponentTypes. Fragments are reusable, named compositions of ComponentTypes and data bindings. Experiences wire Templates and Fragments together into publishable page definitions.
+
+## Entity Dependency Model
+
+ExO entities form a strict dependency graph. An entity can only reference types that appear earlier in the hierarchy — there are no circular dependencies across types, though intra-type dependencies are possible for ComponentTypes and Fragments.
+
+```
+DataAssemblies      DesignTokens
+      │                   │
+      ▼                   ▼
+ComponentTypes ──────────────────┐
+      │                          │ (a CT can reference other CTs
+      ▼                          │  in its componentTree)
+  Templates                      │
+      │               Fragments ─┤
+      │                   │      │ (a Fragment can reference other
+      │                   │      │  Fragments in its slots)
+      └──────┬────────────┘
+             ▼
+        Experiences
+```
+
+DesignTokens feed into ComponentType/Template/Fragment/Experience via design property references (`designProperties.defaultValue`/`fallbackValue`/`allowedResources`), not via the `componentTree`/`slots` mechanism used for CT-to-CT or Fragment-to-Fragment references.
+
+| Entity         | References                                                      | Referenced by                                              |
+|----------------|-----------------------------------------------------------------|------------------------------------------------------------|
+| DesignToken    | nothing                                                         | ComponentTypes, Templates, Fragments, Experiences          |
+| DataAssembly   | nothing                                                         | ComponentTypes, Fragments, Experiences                     |
+| ComponentType  | DataAssemblies, DesignTokens, other ComponentTypes              | Templates, Fragments, Experiences                          |
+| Template       | ComponentTypes, DesignTokens                                    | Experiences                                                |
+| Fragment       | ComponentTypes, DataAssemblies, DesignTokens, other Fragments   | Experiences                                                |
+| Experience     | Templates, Fragments, DataAssemblies, DesignTokens              | nothing                                                    |
+
+## ID Preservation Is Required
+
+ExO entities reference each other via URN pointers that embed the entity's `sys.id`, e.g. `crn:contentful:::experience:spaces/$self/environments/$self/componentTypes/section`. If a create operation generates a new random ID instead of preserving the source ID, any entity that references it by URN will fail validation at write time with a `404 Not Found` or `422 InvalidDataAssemblyReference` — even if the dependency was created first.
+
+For this reason, all ExO entity creates must use a PUT-with-ID call (upsert semantics), not a bare POST:
+
+- **ComponentTypes, Templates, Fragments, Experiences, DesignTokens** — use `plainClient.<type>.upsert(...)` with `sys: { id, type }` and no `version` field (omitting version signals create intent).
+- **DataAssemblies** — the SDK has no `upsert`; use `plainClient.dataAssembly.update(...)` with `sys.version: 0`, which maps to `PUT /data_assemblies/{id}` and creates the entity with the specified ID.
+
+## Why Load Order Matters
+
+Standard content entries do not have this problem: the CMA treats entry link fields as opaque references at write time, storing the `sys.id` pointer without checking whether the target entry or asset exists. Entries can be created in parallel regardless of their link graph, and broken links simply resolve as null until the targets are created. Ordering only becomes relevant for entries at **publish time**, which `contentful-import` handles via a multi-pass retry queue.
+
+ExO entities have a stricter contract: the CMA validates references **at create time**. If you attempt to create a ComponentType that lists a DataAssembly in its `dataAssemblies` allow-list before that DataAssembly exists, the API returns a `422 InvalidDataAssemblyReference`. Creating a ComponentType whose `componentTree` references another ComponentType that hasn't been created yet returns a `404 Not Found`. The retry-queue approach used for entries wouldn't help here — a failed create is not automatically retried, it's just an error.
+
+This means the import order must respect the dependency graph above:
+
+1. **DataAssemblies** and **DesignTokens** — no dependencies on each other or on any other ExO type; either can be imported before the other with no ordering risk
+2. **ComponentTypes** — depend on DataAssemblies and DesignTokens (must already exist); may depend on other ComponentTypes
+3. **Templates** — depend on ComponentTypes and DesignTokens
+4. **Fragments** — depend on ComponentTypes, DataAssemblies, and DesignTokens; may depend on other Fragments
+5. **Experiences** — depend on Templates, Fragments, DataAssemblies, and DesignTokens
+
+## How ExO Folders Work
+Reference ExO Entity Folders RFC: https://contentful.atlassian.net/wiki/x/3BOCgAE
+
+ExO folders are built entirely on Contentful's Taxonomy system and have two layers.
+
+**Layer 1 — Parent ConceptSchemes** (one per ExO entity type, org-scoped)
+
+Five well-known, fixed-ID concept schemes act as the registry for each entity type's folders:
+
+| Scheme ID                               | Entity type     |
+|-----------------------------------------|-----------------|
+| `contentful.folder-group-componentType` | ComponentTypes  |
+| `contentful.folder-group-template`      | Templates       |
+| `contentful.folder-group-experience`    | Experiences     |
+| `contentful.folder-group-fragment`      | Fragments       |
+| `contentful.folder-group-designToken`   | DesignTokens    |
+
+These schemes are org-scoped (shared across all spaces in the org). Their `concepts[]` field is the registry of all child folder concepts for that entity type. They must be queried and created with `purpose: 'internal'`.
+
+**Layer 2 — Child Folder Concepts** (user-created, one per folder)
+
+Each user-created folder is a `TaxonomyConcept` with an ID following the pattern `contentful.folder-{slug}-{randomSuffix}` (e.g. `contentful.folder-prototype-2pS5TwVK`). Key properties:
+
+- **`purpose: 'internal'`** — required. This is what makes ExO recognize the concept as a folder. Without it the concept exists in the taxonomy but is invisible to ExO's folder queries.
+- **`prefLabel`** — the human-readable folder name shown in the UI.
+- **`conceptSchemes[]`** — links back up to the parent scheme (e.g. `contentful.folder-group-experience`).
+- **`metadata.spaces[]`** — space links that scope the folder to specific spaces. A concept is org-level but only appears in spaces listed here. A single folder concept can span multiple spaces by adding additional space links to this array.
+
+The parent scheme also links down to every child: its `concepts[]` array contains a link to each child concept. This bidirectional relationship is what the ExO UI traverses to render the folder tree.
+
+An ExO entity is placed in a folder by adding a link to the child concept in its `metadata.concepts[]`:
+
+```json
+{
+  "metadata": {
+    "concepts": [
+      { "sys": { "id": "contentful.folder-prototype-2pS5TwVK", "type": "Link", "linkType": "TaxonomyConcept" } }
+    ]
+  }
+}
+```
+
+## How ExO Folders Are Imported
+
+Cross-space imports require folder concepts to be recreated in the destination org because a folder concept is scoped to specific spaces via `metadata.spaces`. You cannot simply reuse the source concept ID in the destination space — the source concept may not be scoped to the destination space, and keeping them separate allows source and destination folders to diverge independently after import.
+
+**Step 1 — Ensure parent ConceptSchemes exist**
+
+All five `contentful.folder-group-*` schemes are checked in the destination org. Any that are missing are created with `purpose: 'internal'`. Same-org imports will find them already present.
+
+**Step 2 — Derive destination concept IDs**
+
+For each unique `contentful.folder-*` concept referenced across all source entities, a deterministic destination concept ID is derived:
+
+```
+{sourceConceptId}-{destinationSpaceId}
+```
+
+e.g. `contentful.folder-prototype-2pS5TwVK-dwqjhi6vdvp4`
+
+This is deterministic so re-running the import is idempotent — it won't create duplicate concepts.
+
+**Step 3 — Create or patch each destination concept**
+
+The source concept is fetched to copy its `prefLabel` (so the folder name carries over). Then for each destination concept:
+
+- If it **doesn't exist**: create it via `createWithId` with `purpose: 'internal'`, the copied `prefLabel`, and `metadata.spaces` pointing to the destination space.
+- If it **already exists**: check for and patch in any missing pieces — the destination space link in `metadata.spaces` and/or `purpose: 'internal'` if absent. This handles previously broken concepts created without `purpose`.
+
+**Step 4 — Link each concept into its parent scheme**
+
+The destination concept is added to the `concepts[]` array of the appropriate `contentful.folder-group-*` scheme if not already present.
+
+**Step 5 — Rewrite entity metadata in-place**
+
+Before the ExO entities are upserted, every source entity's `metadata.concepts[]` is scanned. Any link pointing to a source folder concept ID is replaced with the corresponding destination concept ID. This mutation happens in-memory; the rewritten IDs are then persisted to the API as part of the normal entity upsert payloads in the subsequent import steps.
+
+**Same-space imports are skipped entirely** — if source and destination space IDs match, the existing folder concepts are already valid and no taxonomy work is needed.
+
+## Why Intra-Type Sorting Is Required
+
+DataAssemblies, DesignTokens, Templates, and Experiences have no dependencies within their own type and can be imported in parallel. ComponentTypes and Fragments are different: a ComponentType can embed other ComponentTypes in its `componentTree` (e.g. a "Page" CT that slots in a "Hero" CT), and a Fragment can reference other Fragments in its `slots`. If these are imported in arbitrary order — or all at once via `Promise.all` — the CMA can receive a create request for the composite entity before its dependency exists, causing a `404`.
+
+To prevent this, `contentful-import` applies a topological sort (Kahn's algorithm) to both ComponentTypes and Fragments before importing them, and then imports each sorted list sequentially. The sort parses URN references from `componentTree` and `slots` to build a dependency graph, resolves the safe creation order, and falls back to appending any cyclic nodes at the end so the import can still proceed rather than failing outright.

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -10,7 +10,7 @@ import PQueue from 'p-queue'
 import { displayErrorLog, setupLogging, writeErrorLogFile } from 'contentful-batch-libs/dist/logging'
 import { wrapTask } from 'contentful-batch-libs/dist/listr'
 
-import initClient from './tasks/init-client'
+import initClient, { initPlainClient } from './tasks/init-client'
 import getDestinationData from './tasks/get-destination-data'
 import pushToSpace from './tasks/push-to-space/push-to-space'
 import transformSpace from './transform/transform-space'
@@ -59,6 +59,7 @@ type RunContentfulImportParams = {
   headers?: object,
   errorLogFile?: string,
   useVerboseRenderer?: boolean,
+  includeExperienceOrchestration?: boolean,
   // TODO These properties are not documented in the Readme
   timeout?: number,
   retryLimit?: number,
@@ -112,6 +113,7 @@ async function runContentfulImport (params: RunContentfulImportParams) {
       title: 'Initialize client',
       task: wrapTask(async (ctx) => {
         ctx.client = initClient({ ...options, content: undefined })
+        ctx.plainClient = initPlainClient({ ...options, content: undefined })
       })
     },
     {
@@ -119,11 +121,13 @@ async function runContentfulImport (params: RunContentfulImportParams) {
       task: wrapTask(async (ctx) => {
         const destinationData = await getDestinationData({
           client: ctx.client,
+          plainClient: ctx.plainClient,
           spaceId: options.spaceId,
           environmentId: options.environmentId,
           sourceData: options.content,
           skipLocales: options.skipLocales,
           skipContentModel: options.skipContentModel,
+          includeExperienceOrchestration: options.includeExperienceOrchestration,
           requestQueue
         })
 
@@ -146,7 +150,9 @@ async function runContentfulImport (params: RunContentfulImportParams) {
           sourceData: ctx.sourceData,
           destinationData: ctx.destinationData,
           client: ctx.client,
+          plainClient: ctx.plainClient,
           spaceId: options.spaceId,
+          includeExperienceOrchestration: options.includeExperienceOrchestration,
           environmentId: options.environmentId,
           contentModelOnly: options.contentModelOnly,
           skipLocales: options.skipLocales,

--- a/lib/parseOptions.ts
+++ b/lib/parseOptions.ts
@@ -15,7 +15,13 @@ const SUPPORTED_ENTITY_TYPES = [
   'assets',
   'locales',
   'webhooks',
-  'editorInterfaces'
+  'editorInterfaces',
+  'designTokens',
+  'components',
+  'experienceTemplates',
+  'dataAssemblies',
+  'experienceFragments',
+  'experiences'
 ]
 
 export default async function parseOptions (params) {
@@ -29,7 +35,8 @@ export default async function parseOptions (params) {
     environmentId: 'master',
     rawProxy: false,
     uploadAssets: false,
-    rateLimit: 7
+    rateLimit: 7,
+    includeExperienceOrchestration: true
   }
 
   const configFile = params.config

--- a/lib/tasks/get-destination-data.ts
+++ b/lib/tasks/get-destination-data.ts
@@ -1,14 +1,15 @@
 import Promise from 'bluebird'
 
 import { logEmitter } from 'contentful-batch-libs/dist/logging'
-import type { AssetProps, ContentTypeProps, EntryProps, LocaleProps, TagProps, WebhookProps } from 'contentful-management'
+import type { AssetProps, ComponentProps, ContentTypeProps, DataAssemblyProps, DesignTokenProps, EntryProps, ExperienceProps, ExperienceFragmentProps, LocaleProps, TagProps, ExperienceTemplateProps, WebhookProps } from 'contentful-management'
 import { OriginalSourceData } from '../types'
+import { isExoEntitlementError, spaceHasExoM1Entitlement } from '../utils/publish-exo-entities'
 import PQueue from 'p-queue'
 
 const BATCH_CHAR_LIMIT = 1990
 const BATCH_SIZE_LIMIT = 100
 
-const METHODS = {
+const OFFSET_QUERY_METHODS = {
   contentTypes: { name: 'content types', method: 'getContentTypes' },
   locales: { name: 'locales', method: 'getLocales' },
   entries: { name: 'entries', method: 'getEntries' },
@@ -16,18 +17,35 @@ const METHODS = {
   tags: { name: 'tags', method: 'getTags' }
 }
 
+const CURSOR_QUERY_METHODS = {
+  designTokens: { name: 'design tokens', namespace: 'designToken' },
+  components: { name: 'components', namespace: 'component' },
+  experienceTemplates: { name: 'experience templates', namespace: 'experienceTemplate' },
+  experienceFragments: { name: 'experience fragments', namespace: 'experienceFragment' },
+  dataAssemblies: { name: 'data assemblies', namespace: 'dataAssembly' },
+  experiences: { name: 'experiences', namespace: 'experience' }
+}
+
 type BatchedIdQueryParams = {
   requestQueue: PQueue
   environment: any
-  type: keyof typeof METHODS
+  type: keyof typeof OFFSET_QUERY_METHODS
   ids: string[]
 }
 
 type BatchedPageQueryParams = Omit<BatchedIdQueryParams, 'ids'>
 
-async function batchedIdQuery ({ environment, type, ids, requestQueue }: BatchedIdQueryParams) {
-  const method = METHODS[type].method
-  const entityTypeName = METHODS[type].name
+type CursorPaginatedQueryParams = {
+  requestQueue: PQueue
+  plainClient: any
+  spaceId: string
+  environmentId: string
+  type: keyof typeof CURSOR_QUERY_METHODS
+}
+
+async function batchedIdQuery({ environment, type, ids, requestQueue }: BatchedIdQueryParams) {
+  const method = OFFSET_QUERY_METHODS[type].method
+  const entityTypeName = OFFSET_QUERY_METHODS[type].name
   const batches = getIdBatches(ids)
 
   let totalFetched = 0
@@ -51,9 +69,9 @@ async function batchedIdQuery ({ environment, type, ids, requestQueue }: Batched
   return responses.flat()
 }
 
-async function batchedPageQuery ({ environment, type, requestQueue }: BatchedPageQueryParams) {
-  const method = METHODS[type].method
-  const entityTypeName = METHODS[type].name
+async function batchedPageQuery({ environment, type, requestQueue }: BatchedPageQueryParams) {
+  const method = OFFSET_QUERY_METHODS[type].method
+  const entityTypeName = OFFSET_QUERY_METHODS[type].name
 
   let totalFetched = 0
   const { items, total } = await requestQueue.add(async () => {
@@ -86,7 +104,7 @@ async function batchedPageQuery ({ environment, type, requestQueue }: BatchedPag
   return items.concat(remainingResponses.flat())
 }
 
-function getIdBatches (ids) {
+function getIdBatches(ids) {
   const batches: string[] = []
   let currentBatch = ''
   let currentSize = 0
@@ -119,24 +137,74 @@ function getPagedBatches(totalFetched: number, total: number) {
   return batches
 }
 
+async function cursorPaginatedQuery ({ plainClient, spaceId, environmentId, type, requestQueue }: CursorPaginatedQueryParams) {
+  const { name: entityTypeName, namespace } = CURSOR_QUERY_METHODS[type]
+
+  let totalFetched = 0
+  let pageNext: string | undefined = undefined
+  const allItems: any[] = []
+
+  do {
+    const items: any[] = await requestQueue.add(async () => {
+      const response = await plainClient[namespace].getMany({
+        spaceId,
+        environmentId,
+        query: { limit: BATCH_SIZE_LIMIT, ...(pageNext && { pageNext }) }
+      })
+      totalFetched += response.items.length
+      logEmitter.emit('info', `Fetched ${totalFetched} ${entityTypeName}`)
+      pageNext = response.pages?.next
+      return response.items
+    })
+    allItems.push(...items)
+  } while (pageNext)
+
+  return allItems
+}
+
+// A destination space without the ExO entitlement 403s on every ExO endpoint. That's a normal,
+// expected outcome (most spaces don't have ExO enabled) rather than a fatal error, so it's
+// handled the same way the `tags` fetch above handles spaces without Tags access: warn and
+// fall back to an empty array instead of failing the whole destination-data fetch.
+async function cursorPaginatedQueryOrWarn (params: CursorPaginatedQueryParams): Promise<any[]> {
+  try {
+    return await cursorPaginatedQuery(params)
+  } catch (err) {
+    const { name: entityTypeName } = CURSOR_QUERY_METHODS[params.type]
+    if (isExoEntitlementError(err)) {
+      logEmitter.emit('error', new Error(`Skipping ${entityTypeName} import: Experience Orchestration (ExO) is not enabled for this space`))
+    } else {
+      logEmitter.emit('error', err instanceof Error ? err : new Error(String(err)))
+    }
+    return []
+  }
+}
+
 type AllDestinationData = {
   contentTypes: Promise<ContentTypeProps[]>
   tags: Promise<TagProps[]>
   locales: Promise<LocaleProps[]>
   entries: Promise<EntryProps[]>
   assets: Promise<AssetProps[]>
-  // TODO Why are webhooks optional?
   webhooks?: Promise<WebhookProps[]>
+  components?: Promise<ComponentProps[]>
+  experienceTemplates?: Promise<ExperienceTemplateProps[]>
+  experienceFragments?: Promise<ExperienceFragmentProps[]>
+  dataAssemblies?: Promise<DataAssemblyProps[]>
+  experiences?: Promise<ExperienceProps[]>
+  designTokens?: Promise<DesignTokenProps[]>
 }
 
 type GetDestinationDataParams = {
   client: any
+  plainClient?: any
   spaceId: string
   environmentId: string
   sourceData: OriginalSourceData
   contentModelOnly?: boolean
   skipLocales?: boolean
   skipContentModel?: boolean
+  includeExperienceOrchestration?: boolean
   requestQueue: PQueue
 }
 
@@ -149,14 +217,16 @@ type GetDestinationDataParams = {
  *
  */
 
-export default async function getDestinationData ({
+export default async function getDestinationData({
   client,
+  plainClient,
   spaceId,
   environmentId,
   sourceData,
   contentModelOnly,
   skipLocales,
   skipContentModel,
+  includeExperienceOrchestration,
   requestQueue
 }: GetDestinationDataParams) {
   const space = await client.getSpace(spaceId)
@@ -166,7 +236,14 @@ export default async function getDestinationData ({
     tags: [],
     locales: [],
     entries: [],
-    assets: []
+    assets: [],
+    experiences: [],
+    experienceTemplates: [],
+    components: [],
+    experienceFragments: [],
+    dataAssemblies: [],
+    designTokens: [],
+    webhooks: [],
   }
 
   // Make sure all required properties are available and at least an empty array
@@ -213,7 +290,7 @@ export default async function getDestinationData ({
 
   const entryIds = sourceData.entries?.map((e) => e.sys.id)
   const assetIds = sourceData.assets?.map((e) => e.sys.id)
-  if (entryIds) {
+  if (entryIds && entryIds.length) {
     result.entries = batchedIdQuery({
       environment,
       type: 'entries',
@@ -221,7 +298,7 @@ export default async function getDestinationData ({
       requestQueue
     })
   }
-  if (assetIds) {
+  if (assetIds && assetIds.length) {
     result.assets = batchedIdQuery({
       environment,
       type: 'assets',
@@ -230,7 +307,45 @@ export default async function getDestinationData ({
     })
   }
 
-  result.webhooks = []
+  if (includeExperienceOrchestration && plainClient) {
+    // dataAssemblies is excluded here — confirmed live it isn't actually gated by exoM1,
+    // unlike the other 5, so it always uses its own fetch-and-catch below instead.
+    const sourceHasDesignTokens = Boolean(sourceData.designTokens?.length)
+    const sourceHasComponents = Boolean(sourceData.components?.length)
+    const sourceHasExperienceTemplates = Boolean(sourceData.experienceTemplates?.length)
+    const sourceHasExperienceFragments = Boolean(sourceData.experienceFragments?.length)
+    const sourceHasExperiences = Boolean(sourceData.experiences?.length)
+
+    let entitled: boolean | null = true
+    if (sourceHasDesignTokens || sourceHasComponents || sourceHasExperienceTemplates || sourceHasExperienceFragments || sourceHasExperiences) {
+      entitled = await spaceHasExoM1Entitlement(plainClient, spaceId)
+    }
+
+    if (entitled === false) {
+      logEmitter.emit('error', new Error('Skipping Experience Orchestration import: Experience Orchestration (ExO) is not enabled for this space'))
+    } else {
+      // null (inconclusive check) falls through here too, same as true.
+      if (sourceHasDesignTokens) {
+        result.designTokens = cursorPaginatedQueryOrWarn({ plainClient, spaceId, environmentId, type: 'designTokens', requestQueue })
+      }
+      if (sourceHasComponents) {
+        result.components = cursorPaginatedQueryOrWarn({ plainClient, spaceId, environmentId, type: 'components', requestQueue })
+      }
+      if (sourceHasExperienceTemplates) {
+        result.experienceTemplates = cursorPaginatedQueryOrWarn({ plainClient, spaceId, environmentId, type: 'experienceTemplates', requestQueue })
+      }
+      if (sourceHasExperienceFragments) {
+        result.experienceFragments = cursorPaginatedQueryOrWarn({ plainClient, spaceId, environmentId, type: 'experienceFragments', requestQueue })
+      }
+      if (sourceHasExperiences) {
+        result.experiences = cursorPaginatedQueryOrWarn({ plainClient, spaceId, environmentId, type: 'experiences', requestQueue })
+      }
+    }
+
+    if (sourceData.dataAssemblies?.length) {
+      result.dataAssemblies = cursorPaginatedQueryOrWarn({ plainClient, spaceId, environmentId, type: 'dataAssemblies', requestQueue })
+    }
+  }
 
   return Promise.props(result)
 }

--- a/lib/tasks/init-client.ts
+++ b/lib/tasks/init-client.ts
@@ -17,3 +17,11 @@ export default function initClient (opts) {
   }
   return createClient(config, { type: 'legacy' })
 }
+
+export function initPlainClient (opts) {
+  return createClient({
+    accessToken: opts.managementToken,
+    host: opts.host,
+    logHandler
+  })
+}

--- a/lib/tasks/push-to-space/push-to-space.ts
+++ b/lib/tasks/push-to-space/push-to-space.ts
@@ -3,12 +3,49 @@ import verboseRenderer from 'listr-verbose-renderer'
 
 import { logEmitter } from 'contentful-batch-libs/dist/logging'
 import { wrapTask } from 'contentful-batch-libs/dist/listr'
+import {
+  ComponentProps,
+  DataAssemblyProps,
+  ExperienceProps,
+  ExperienceFragmentProps,
+  ExperienceTemplateProps,
+  UpsertComponentProps,
+  UpsertExperienceTemplateProps,
+  UpsertExperienceFragmentProps,
+  UpsertExperienceProps,
+  UpdateDataAssemblyProps,
+  UpsertDesignTokenProps,
+} from 'contentful-management'
 
 import * as assets from './assets'
 import * as creation from './creation'
 import * as publishing from './publishing'
 import type { DestinationData, TransformedSourceData, Resources, TransformedAsset } from '../../types'
-import { ContentfulEntityError } from '../../utils/errors'
+import { GRAPHQL_SCHEMA_STALE_DELAYS_MS, isGraphQLSchemaStaleError } from '../../utils/graphql-schema-backoff'
+import { buildDataAssemblySys } from '../../utils/exo-entity-payloads'
+import sortComponents from '../../utils/sort-components'
+import sortExperienceFragments from '../../utils/sort-experience-fragments'
+import { filterExoEntitiesToPublish, filterExoEntitiesToUnpublish, publishExoEntity, unpublishExoEntity } from '../../utils/publish-exo-entities'
+import { sortOrReport } from '../../utils/sort-or-report'
+import { importExoFolders } from '../../utils/import-exo-folders'
+
+async function withGraphQLSchemaBackoff<T>(fn: () => Promise<T>): Promise<T> {
+  let lastErr: unknown
+  for (let attempt = 0; attempt <= GRAPHQL_SCHEMA_STALE_DELAYS_MS.length; attempt++) {
+    try {
+      return await fn()
+    } catch (err) {
+      if (!isGraphQLSchemaStaleError(err) || attempt === GRAPHQL_SCHEMA_STALE_DELAYS_MS.length) {
+        throw err
+      }
+      const delay = GRAPHQL_SCHEMA_STALE_DELAYS_MS[attempt]
+      logEmitter.emit('warning', `DataAssembly GraphQL schema not yet current, retrying in ${delay}ms (attempt ${attempt + 1}/${GRAPHQL_SCHEMA_STALE_DELAYS_MS.length})`)
+      await new Promise((resolve) => setTimeout(resolve, delay))
+      lastErr = err
+    }
+  }
+  throw lastErr
+}
 
 const DEFAULT_CONTENT_STRUCTURE = {
   entries: [],
@@ -27,9 +64,11 @@ type DestinationDataById = {
 type PushToSpaceParams = {
   destinationData: DestinationData,
   sourceData: TransformedSourceData,
-  client: any,
+  client?: any,
+  plainClient?: any,
   spaceId: string,
   environmentId: string,
+  includeExperienceOrchestration?: boolean,
   contentModelOnly?: boolean,
   skipContentModel?: boolean,
   skipContentUpdates?: boolean,
@@ -67,16 +106,18 @@ type PushToSpaceParams = {
  */
 
 export type PushToSpaceContext = {
-    type: string,
-    target: any,
+  type: string,
+  target: any,
 }
 
-export default function pushToSpace ({
+export default function pushToSpace({
   sourceData,
   destinationData = {},
   client,
+  plainClient,
   spaceId,
   environmentId,
+  includeExperienceOrchestration,
   contentModelOnly,
   skipContentModel,
   skipContentUpdates,
@@ -219,10 +260,9 @@ export default function pushToSpace ({
             const updatedEditorInterface = await requestQueue.add(() => ctEditorInterface.update())
             return updatedEditorInterface
           } catch (err: any) {
-            if (err instanceof ContentfulEntityError) {
-              err.entity = editorInterface
-            }
-            throw err
+            err.entity = editorInterface
+            logEmitter.emit('error', err)
+            return null
           }
         })
 
@@ -282,7 +322,7 @@ export default function pushToSpace ({
           return
         }
         const assetsToProcess = await creation.createEntities({
-          context: { target: ctx.environment, type: 'Asset'},
+          context: { target: ctx.environment, type: 'Asset' },
           entities: sourceData.assets,
           destinationEntitiesById: destinationDataById.assets,
           skipUpdates: skipAssetUpdates,
@@ -377,11 +417,355 @@ export default function pushToSpace ({
       }),
       skip: () =>
         contentModelOnly || (environmentId !== 'master' && 'Webhooks can only be imported in master environment')
+    },
+    {
+      title: 'Create ExO Folders',
+      task: wrapTask(async (ctx) => {
+        await importExoFolders({
+          plainClient,
+          organizationId: ctx.space.sys.organization.sys.id,
+          destinationSpaceId: spaceId,
+          sourceEntities: {
+            designTokens: sourceData.designTokens,
+            components: sourceData.components,
+            experienceTemplates: sourceData.experienceTemplates,
+            experienceFragments: sourceData.experienceFragments,
+            experiences: sourceData.experiences,
+          },
+        })
+      }),
+      skip: () => !includeExperienceOrchestration
+    },
+    {
+      title: 'Importing Data Assemblies',
+      task: wrapTask(async (ctx) => {
+        const results = await Promise.all((sourceData.dataAssemblies || []).map(async (entity) => {
+          try {
+            const existing = destinationDataById.dataAssemblies?.get(entity.sys.id)
+            let result
+            if (existing) {
+              const payload: UpdateDataAssemblyProps = { ...omitSys(entity), sys: buildDataAssemblySys(entity, existing.sys.version) }
+              result = await withGraphQLSchemaBackoff(() => plainClient.dataAssembly.update(
+                { spaceId, environmentId, dataAssemblyId: entity.sys.id },
+                payload
+              ))
+              logEmitter.emit('info', `UPDATE DataAssembly ${entity.sys.id}`)
+            } else {
+              const payload: UpdateDataAssemblyProps = { ...omitSys(entity), sys: buildDataAssemblySys(entity, 0) }
+              result = await withGraphQLSchemaBackoff(() => plainClient.dataAssembly.update(
+                { spaceId, environmentId, dataAssemblyId: entity.sys.id },
+                payload
+              ))
+              logEmitter.emit('info', `CREATE DataAssembly ${entity.sys.id}`)
+            }
+            return result
+          } catch (err: any) {
+            err.entity = entity
+            logEmitter.emit('error', err)
+            return null
+          }
+        }))
+        ctx.data.dataAssemblies = results.filter(Boolean)
+      }),
+      skip: () => !includeExperienceOrchestration || !(sourceData.dataAssemblies || []).length
+    },
+    {
+      title: 'Publishing Data Assemblies',
+      task: wrapTask(async (ctx: { data: { dataAssemblies: DataAssemblyProps[], publishedDataAssemblies: DataAssemblyProps[] } }) => {
+        const entitiesToPublish = filterExoEntitiesToPublish(ctx.data.dataAssemblies, sourceData.dataAssemblies || [])
+        const results = await Promise.all(entitiesToPublish.map((entity) =>
+          publishExoEntity<DataAssemblyProps>('DataAssembly', entity, () => plainClient.dataAssembly.publish(
+            { spaceId, environmentId, dataAssemblyId: entity.sys.id, version: entity.sys.version }
+          ))
+        ))
+        ctx.data.publishedDataAssemblies = results.filter((entity): entity is DataAssemblyProps => entity !== null)
+      }),
+      skip: () => !includeExperienceOrchestration || skipContentPublishing || !(sourceData.dataAssemblies || []).length
+    },
+    {
+      title: 'Importing Design Tokens',
+      task: wrapTask(async (ctx) => {
+        const results = await Promise.all((sourceData.designTokens || []).map(async (entity) => {
+          try {
+            const existing = destinationDataById.designTokens?.get(entity.sys.id)
+            if (existing) {
+              const payload: UpsertDesignTokenProps = { ...entity, sys: { id: entity.sys.id, type: 'DesignToken', version: existing.sys.version } }
+              const result = await plainClient.designToken.upsert({ spaceId, environmentId, designTokenId: entity.sys.id }, payload)
+              logEmitter.emit('info', `UPDATE DesignToken ${entity.sys.id}`)
+              return result
+            } else {
+              const payload: UpsertDesignTokenProps = { ...omitSys(entity), sys: { id: entity.sys.id, type: 'DesignToken' } }
+              const result = await plainClient.designToken.upsert({ spaceId, environmentId, designTokenId: entity.sys.id }, payload)
+              logEmitter.emit('info', `CREATE DesignToken ${entity.sys.id}`)
+              return result
+            }
+          } catch (err: any) {
+            err.entity = entity
+            logEmitter.emit('error', err)
+            return null
+          }
+        }))
+        ctx.data.designTokens = results.filter(Boolean)
+      }),
+      skip: () => !includeExperienceOrchestration || !(sourceData.designTokens || []).length
+    },
+    {
+      title: 'Importing Components',
+      task: wrapTask(async (ctx) => {
+        const sorted = sortOrReport(() => sortComponents(sourceData.components || []))
+        const results: any[] = []
+        for (const entity of sorted) {
+          try {
+            const existing = destinationDataById.components?.get(entity.sys.id)
+            if (existing) {
+              const payload: UpsertComponentProps = { ...entity, sys: { id: entity.sys.id, type: 'Component', version: existing.sys.version } }
+              const result = await plainClient.component.upsert({ spaceId, environmentId, componentId: entity.sys.id }, payload)
+              logEmitter.emit('info', `UPDATE Component ${entity.sys.id}`)
+              results.push(result)
+            } else {
+              const payload: UpsertComponentProps = { ...omitSys(entity), sys: { id: entity.sys.id, type: 'Component' } }
+              const result = await plainClient.component.upsert({ spaceId, environmentId, componentId: entity.sys.id }, payload)
+              logEmitter.emit('info', `CREATE Component ${entity.sys.id}`)
+              results.push(result)
+            }
+          } catch (err: any) {
+            err.entity = entity
+            logEmitter.emit('error', err)
+          }
+        }
+        ctx.data.components = results
+      }),
+      skip: () => !includeExperienceOrchestration || !(sourceData.components || []).length
+    },
+    {
+      title: 'Publishing Components',
+      task: wrapTask(async (ctx) => {
+        const entitiesToPublish = filterExoEntitiesToPublish(ctx.data.components, sourceData.components || [])
+        // Sorted and sequential: a Component's publish validation resolves nested
+        // Component/DataAssembly references against their *published* state, so a
+        // parent can't publish before the Components it embeds are published.
+        const sorted = sortOrReport(() => sortComponents(entitiesToPublish))
+        const results: ComponentProps[] = []
+        for (const entity of sorted) {
+          const published = await publishExoEntity<ComponentProps>('Component', entity, () => plainClient.component.publish(
+            { spaceId, environmentId, componentId: entity.sys.id, version: entity.sys.version }
+          ))
+          if (published) results.push(published)
+        }
+        ctx.data.publishedComponents = results
+      }),
+      skip: () => !includeExperienceOrchestration || skipContentPublishing || !(sourceData.components || []).length
+    },
+    {
+      title: 'Importing Experience Templates',
+      task: wrapTask(async (ctx) => {
+        const results = await Promise.all((sourceData.experienceTemplates || []).map(async (entity) => {
+          try {
+            const existing = destinationDataById.experienceTemplates?.get(entity.sys.id)
+            if (existing) {
+              const payload: UpsertExperienceTemplateProps = { ...entity, sys: { id: entity.sys.id, type: 'ExperienceTemplate', version: existing.sys.version } }
+              const result = await plainClient.experienceTemplate.upsert({ spaceId, environmentId, experienceTemplateId: entity.sys.id }, payload)
+              logEmitter.emit('info', `UPDATE ExperienceTemplate ${entity.sys.id}`)
+              return result
+            } else {
+              const payload: UpsertExperienceTemplateProps = { ...omitSys(entity), sys: { id: entity.sys.id, type: 'ExperienceTemplate' } }
+              const result = await plainClient.experienceTemplate.upsert({ spaceId, environmentId, experienceTemplateId: entity.sys.id }, payload)
+              logEmitter.emit('info', `CREATE ExperienceTemplate ${entity.sys.id}`)
+              return result
+            }
+          } catch (err: any) {
+            err.entity = entity
+            logEmitter.emit('error', err)
+            return null
+          }
+        }))
+        ctx.data.experienceTemplates = results.filter(Boolean)
+      }),
+      skip: () => !includeExperienceOrchestration || !(sourceData.experienceTemplates || []).length
+    },
+    {
+      title: 'Publishing Experience Templates',
+      task: wrapTask(async (ctx: { data: { experienceTemplates: ExperienceTemplateProps[], publishedExperienceTemplates: ExperienceTemplateProps[] } }) => {
+        const entitiesToPublish = filterExoEntitiesToPublish(ctx.data.experienceTemplates, sourceData.experienceTemplates || [])
+        const results = await Promise.all(entitiesToPublish.map((entity) =>
+          publishExoEntity<ExperienceTemplateProps>('ExperienceTemplate', entity, () => plainClient.experienceTemplate.publish(
+            { spaceId, environmentId, experienceTemplateId: entity.sys.id, version: entity.sys.version }
+          ))
+        ))
+        ctx.data.publishedExperienceTemplates = results.filter((entity): entity is ExperienceTemplateProps => entity !== null)
+      }),
+      skip: () => !includeExperienceOrchestration || skipContentPublishing || !(sourceData.experienceTemplates || []).length
+    },
+    {
+      title: 'Importing Experience Fragments',
+      task: wrapTask(async (ctx) => {
+        const sorted = sortOrReport(() => sortExperienceFragments(sourceData.experienceFragments || []))
+        const results: any[] = []
+        for (const entity of sorted) {
+          try {
+            const existing = destinationDataById.experienceFragments?.get(entity.sys.id)
+            if (existing) {
+              // once an ExperienceFragment is created, its component cannot be changed to a different component -
+              // the API rejects `component` on UPDATE even when the value is unchanged, so omit it entirely
+              const payload: UpsertExperienceFragmentProps = { ...entity, sys: { id: entity.sys.id, type: 'ExperienceFragment', version: existing.sys.version } }
+              const result = await plainClient.experienceFragment.upsert({ spaceId, environmentId, experienceFragmentId: entity.sys.id }, payload)
+              logEmitter.emit('info', `UPDATE ExperienceFragment ${entity.sys.id}`)
+              results.push(result)
+            } else {
+              const payload: UpsertExperienceFragmentProps = { ...omitSys(entity), component: entity.sys.component, sys: { id: entity.sys.id, type: 'ExperienceFragment' } }
+              const result = await plainClient.experienceFragment.upsert({ spaceId, environmentId, experienceFragmentId: entity.sys.id }, payload)
+              logEmitter.emit('info', `CREATE ExperienceFragment ${entity.sys.id}`)
+              results.push(result)
+            }
+          } catch (err: any) {
+            err.entity = entity
+            logEmitter.emit('error', err)
+          }
+        }
+        ctx.data.experienceFragments = results
+      }),
+      skip: () => !includeExperienceOrchestration || !(sourceData.experienceFragments || []).length
+    },
+    {
+      title: 'Publishing Experience Fragments',
+      task: wrapTask(async (ctx) => {
+        const entitiesToPublish = filterExoEntitiesToPublish(ctx.data.experienceFragments, sourceData.experienceFragments || [])
+        // Sorted and sequential, same reasoning as Publishing Components: an ExperienceFragment
+        // can reference other ExperienceFragments in its slots, resolved against published state.
+        const sorted = sortOrReport(() => sortExperienceFragments(entitiesToPublish))
+        const results: ExperienceFragmentProps[] = []
+        for (const entity of sorted) {
+          const published = await publishExoEntity<ExperienceFragmentProps>('ExperienceFragment', entity, () => plainClient.experienceFragment.publish(
+            { spaceId, environmentId, experienceFragmentId: entity.sys.id, version: entity.sys.version }
+          ))
+          if (published) results.push(published)
+        }
+        ctx.data.publishedExperienceFragments = results
+      }),
+      skip: () => !includeExperienceOrchestration || skipContentPublishing || !(sourceData.experienceFragments || []).length
+    },
+    {
+      title: 'Importing Experiences',
+      task: wrapTask(async (ctx) => {
+        const results = await Promise.all((sourceData.experiences || []).map(async (entity) => {
+          try {
+            const existing = destinationDataById.experiences?.get(entity.sys.id)
+            if (existing) {
+              // once an Experience is created, its experienceTemplate cannot be changed to a different experienceTemplate -
+              // the API rejects `experienceTemplate` on UPDATE even when the value is unchanged, so omit it entirely
+              const payload: UpsertExperienceProps = { ...entity, sys: { id: entity.sys.id, type: 'Experience', version: existing.sys.version } }
+              const result = await plainClient.experience.upsert({ spaceId, environmentId, experienceId: entity.sys.id }, payload)
+              logEmitter.emit('info', `UPDATE Experience ${entity.sys.id}`)
+              return result
+            } else {
+              const payload: UpsertExperienceProps = { ...omitSys(entity), experienceTemplate: entity.sys.experienceTemplate, sys: { id: entity.sys.id, type: 'Experience' } }
+              const result = await plainClient.experience.upsert({ spaceId, environmentId, experienceId: entity.sys.id }, payload)
+              logEmitter.emit('info', `CREATE Experience ${entity.sys.id}`)
+              return result
+            }
+          } catch (err: any) {
+            err.entity = entity
+            logEmitter.emit('error', err)
+            return null
+          }
+        }))
+        ctx.data.experiences = results.filter(Boolean)
+      }),
+      skip: () => !includeExperienceOrchestration || !(sourceData.experiences || []).length
+    },
+    {
+      title: 'Publishing Experiences',
+      task: wrapTask(async (ctx: { data: { experiences: ExperienceProps[], publishedExperiences: ExperienceProps[] } }) => {
+        const entitiesToPublish = filterExoEntitiesToPublish(ctx.data.experiences, sourceData.experiences || [])
+        const results = await Promise.all(entitiesToPublish.map((entity) =>
+          publishExoEntity<ExperienceProps>('Experience', entity, () => plainClient.experience.publish(
+            { spaceId, environmentId, experienceId: entity.sys.id, version: entity.sys.version }
+          ))
+        ))
+        ctx.data.publishedExperiences = results.filter((entity): entity is ExperienceProps => entity !== null)
+      }),
+      skip: () => !includeExperienceOrchestration || skipContentPublishing || !(sourceData.experiences || []).length
+    },
+    // Unpublishing runs after all Importing/Publishing tasks, in reverse dependency order
+    // (Experience first, DataAssembly last) - the API rejects unpublishing an entity that a
+    // still-published parent references, so parents must unpublish before the children they embed.
+    {
+      title: 'Unpublishing Experiences',
+      task: wrapTask(async (ctx: { data: { experiences: ExperienceProps[] } }) => {
+        const entitiesToUnpublish = filterExoEntitiesToUnpublish(ctx.data.experiences, sourceData.experiences || [])
+        await Promise.all(entitiesToUnpublish.map((entity) =>
+          unpublishExoEntity<ExperienceProps>('Experience', entity, () => plainClient.experience.unpublish(
+            { spaceId, environmentId, experienceId: entity.sys.id, version: entity.sys.version }
+          ))
+        ))
+      }),
+      skip: () => !includeExperienceOrchestration || skipContentPublishing || !(sourceData.experiences || []).length
+    },
+    {
+      title: 'Unpublishing Experience Fragments',
+      task: wrapTask(async (ctx) => {
+        const entitiesToUnpublish = filterExoEntitiesToUnpublish(ctx.data.experienceFragments, sourceData.experienceFragments || [])
+        // Sorted and sequential, reverse of Publishing Experience Fragments: the API rejects
+        // unpublishing a fragment that a still-published parent references, so ancestors must
+        // unpublish first.
+        const sorted = sortExperienceFragments(entitiesToUnpublish).reverse()
+        for (const entity of sorted) {
+          await unpublishExoEntity<ExperienceFragmentProps>('ExperienceFragment', entity, () => plainClient.experienceFragment.unpublish(
+            { spaceId, environmentId, experienceFragmentId: entity.sys.id, version: entity.sys.version }
+          ))
+        }
+      }),
+      skip: () => !includeExperienceOrchestration || skipContentPublishing || !(sourceData.experienceFragments || []).length
+    },
+    {
+      title: 'Unpublishing Experience Templates',
+      task: wrapTask(async (ctx: { data: { experienceTemplates: ExperienceTemplateProps[] } }) => {
+        const entitiesToUnpublish = filterExoEntitiesToUnpublish(ctx.data.experienceTemplates, sourceData.experienceTemplates || [])
+        await Promise.all(entitiesToUnpublish.map((entity) =>
+          unpublishExoEntity<ExperienceTemplateProps>('ExperienceTemplate', entity, () => plainClient.experienceTemplate.unpublish(
+            { spaceId, environmentId, experienceTemplateId: entity.sys.id, version: entity.sys.version }
+          ))
+        ))
+      }),
+      skip: () => !includeExperienceOrchestration || skipContentPublishing || !(sourceData.experienceTemplates || []).length
+    },
+    {
+      title: 'Unpublishing Components',
+      task: wrapTask(async (ctx) => {
+        const entitiesToUnpublish = filterExoEntitiesToUnpublish(ctx.data.components, sourceData.components || [])
+        // Sorted and sequential, reverse of Publishing Components: the API rejects unpublishing
+        // a Component that a still-published parent references, so ancestors must unpublish first.
+        const sorted = sortComponents(entitiesToUnpublish).reverse()
+        for (const entity of sorted) {
+          await unpublishExoEntity<ComponentProps>('Component', entity, () => plainClient.component.unpublish(
+            { spaceId, environmentId, componentId: entity.sys.id, version: entity.sys.version }
+          ))
+        }
+      }),
+      skip: () => !includeExperienceOrchestration || skipContentPublishing || !(sourceData.components || []).length
+    },
+    {
+      title: 'Unpublishing Data Assemblies',
+      task: wrapTask(async (ctx: { data: { dataAssemblies: DataAssemblyProps[] } }) => {
+        const entitiesToUnpublish = filterExoEntitiesToUnpublish(ctx.data.dataAssemblies, sourceData.dataAssemblies || [])
+        await Promise.all(entitiesToUnpublish.map((entity) =>
+          unpublishExoEntity<DataAssemblyProps>('DataAssembly', entity, () => plainClient.dataAssembly.unpublish(
+            { spaceId, environmentId, dataAssemblyId: entity.sys.id, version: entity.sys.version }
+          ))
+        ))
+      }),
+      skip: () => !includeExperienceOrchestration || skipContentPublishing || !(sourceData.dataAssemblies || []).length
     }
   ], listrOptions)
 }
 
-function archiveEntities ({ entities, sourceEntities, requestQueue }) {
+function omitSys(entity) {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { sys: _sys, ...rest } = entity
+  return rest
+}
+
+function archiveEntities({ entities, sourceEntities, requestQueue }) {
   const entityIdsToArchive = sourceEntities
     .filter(({ original }) => original.sys.archivedVersion)
     .map(({ original }) => original.sys.id)
@@ -392,7 +776,7 @@ function archiveEntities ({ entities, sourceEntities, requestQueue }) {
   return publishing.archiveEntities({ entities: entitiesToArchive, requestQueue })
 }
 
-function publishEntities ({ entities, sourceEntities, requestQueue }) {
+function publishEntities({ entities, sourceEntities, requestQueue }) {
   // Find all entities in source content which are published
   const entityIdsToPublish = sourceEntities
     .filter(({ original }) => original.sys.publishedVersion)

--- a/lib/transform/exo-rename.ts
+++ b/lib/transform/exo-rename.ts
@@ -1,0 +1,227 @@
+/**
+ * Upgrades legacy-shaped Experience Orchestration (ExO) entities to the renamed
+ * form the current API expects, so exports taken before the rename can still be
+ * imported without hand-editing the JSON.
+ *
+ * The rename (see contentful-management >= 12.13.0):
+ *   ComponentType      -> Component
+ *   Fragment           -> ExperienceFragment
+ *   Template           -> ExperienceTemplate
+ * along with the corresponding resource-link `linkType`s, URN path segments,
+ * component-tree / slot node shapes, slot-definition `allowedResources`, and
+ * content-property `TypeRef`s.
+ *
+ * This is intentionally UPGRADE-ONLY: import always writes the new form, so
+ * there is no downgrade path. Every function is idempotent — data already in the
+ * new form passes through unchanged — so it is safe to run on mixed input.
+ */
+
+type AnyResourceLink = {
+  sys: {
+    type: 'ResourceLink'
+    linkType: string
+    urn: string
+  }
+}
+
+/** Rewrites the `/{from}/` path segment of a resource-link URN to `/{to}/`. */
+function rewriteUrn (urn: string, from: string, to: string): string {
+  return typeof urn === 'string' ? urn.replace(new RegExp(`/${from}/`, 'g'), `/${to}/`) : urn
+}
+
+function upgradeLink (link: any, toLinkType: string, fromSegment: string, toSegment: string): AnyResourceLink {
+  return {
+    ...link,
+    sys: {
+      ...link.sys,
+      type: 'ResourceLink',
+      linkType: toLinkType,
+      urn: rewriteUrn(link.sys?.urn, fromSegment, toSegment)
+    }
+  }
+}
+
+const upgradeComponentLink = (link: any) =>
+  upgradeLink(link, 'Contentful:Component', 'componentTypes', 'components')
+
+const upgradeTemplateLink = (link: any) =>
+  upgradeLink(link, 'Contentful:ExperienceTemplate', 'templates', 'experienceTemplates')
+
+/**
+ * Upgrades a single component-tree / slot node. Handles both container nodes
+ * (Component, InlineExperienceFragment) with nested slots and leaf reference
+ * nodes (ExperienceFragment, Slot). Nodes already in the new form are returned
+ * unchanged.
+ */
+function upgradeNode (node: any): any {
+  if (!node || typeof node !== 'object') return node
+
+  switch (node.nodeType) {
+    case 'Slot':
+      return node
+
+    // Fragment reference node -> ExperienceFragment reference node
+    case 'Fragment': {
+      const { fragment, ...rest } = node
+      return {
+        ...rest,
+        nodeType: 'ExperienceFragment',
+        experienceFragment: upgradeLink(fragment, 'Contentful:ExperienceFragment', 'fragments', 'experienceFragments')
+      }
+    }
+    case 'ExperienceFragment':
+      return node
+
+    // Component node: legacy carries `componentType`, new carries `component`
+    case 'Component': {
+      const { componentType, ...rest } = node
+      const component = node.component ?? (componentType ? upgradeComponentLink(componentType) : undefined)
+      return {
+        ...rest,
+        nodeType: 'Component',
+        ...(component ? { component } : {}),
+        ...(node.slots !== undefined ? { slots: upgradeNodeMap(node.slots) } : {})
+      }
+    }
+
+    // Inline fragment node: legacy carries `componentType`, new carries `component`
+    case 'InlineFragment': {
+      const { componentType, ...rest } = node
+      const component = node.component ?? (componentType ? upgradeComponentLink(componentType) : undefined)
+      return {
+        ...rest,
+        nodeType: 'InlineExperienceFragment',
+        ...(component ? { component } : {}),
+        ...(node.slots !== undefined ? { slots: upgradeNodeMap(node.slots) } : {})
+      }
+    }
+    case 'InlineExperienceFragment':
+      return {
+        ...node,
+        ...(node.slots !== undefined ? { slots: upgradeNodeMap(node.slots) } : {})
+      }
+
+    default:
+      return node
+  }
+}
+
+/** Upgrades a `Record<slotId, node[]>` map, as used by node `slots` and entity `slots`. */
+function upgradeNodeMap (slots: any): any {
+  if (!slots || typeof slots !== 'object') return slots
+  return Object.fromEntries(
+    Object.entries(slots).map(([key, nodes]) => [key, Array.isArray(nodes) ? nodes.map(upgradeNode) : nodes])
+  )
+}
+
+/** Upgrades a component tree (array of nodes), as used by Component / ExperienceTemplate. */
+function upgradeComponentTree (tree: any): any {
+  return Array.isArray(tree) ? tree.map(upgradeNode) : tree
+}
+
+/** Upgrades slot *definitions* (`allowedResources`), as used by Component / ExperienceTemplate. */
+function upgradeSlotDefinitions (defs: any): any {
+  if (!Array.isArray(defs)) return defs
+  return defs.map((slot) => ({
+    ...slot,
+    ...(slot.allowedResources
+      ? {
+          allowedResources: slot.allowedResources.map((resource: any) => ({
+            ...resource,
+            type: 'Contentful:Component',
+            ...(Array.isArray(resource.allowedTypes)
+              ? { allowedTypes: resource.allowedTypes.map((urn: string) => rewriteUrn(urn, 'componentTypes', 'components')) }
+              : {})
+          }))
+        }
+      : {})
+  }))
+}
+
+/** Recursively upgrades a single content-property definition's `TypeRef` links. */
+function upgradeContentProperty (prop: any): any {
+  if (!prop || typeof prop !== 'object') return prop
+  if (prop.type === 'Array' && prop.items) {
+    return { ...prop, items: upgradeContentProperty(prop.items) }
+  }
+  if (prop.type === 'TypeRef' && prop.ref?.sys?.linkType === 'Contentful:ComponentType') {
+    return { ...prop, ref: upgradeComponentLink(prop.ref) }
+  }
+  return prop
+}
+
+function upgradeContentPropertyTypeRefs (props: any): any {
+  return Array.isArray(props) ? props.map(upgradeContentProperty) : props
+}
+
+// ─── Per-entity upgraders ─────────────────────────────────────────────────────
+
+function upgradeComponent (entity: any): any {
+  return {
+    ...entity,
+    sys: { ...entity.sys, type: 'Component' },
+    ...(entity.componentTree !== undefined ? { componentTree: upgradeComponentTree(entity.componentTree) } : {}),
+    ...(entity.slots !== undefined ? { slots: upgradeSlotDefinitions(entity.slots) } : {}),
+    ...(entity.contentProperties !== undefined ? { contentProperties: upgradeContentPropertyTypeRefs(entity.contentProperties) } : {})
+  }
+}
+
+function upgradeExperienceTemplate (entity: any): any {
+  return {
+    ...entity,
+    sys: { ...entity.sys, type: 'ExperienceTemplate' },
+    ...(entity.componentTree !== undefined ? { componentTree: upgradeComponentTree(entity.componentTree) } : {}),
+    ...(entity.slots !== undefined ? { slots: upgradeSlotDefinitions(entity.slots) } : {}),
+    ...(entity.contentProperties !== undefined ? { contentProperties: upgradeContentPropertyTypeRefs(entity.contentProperties) } : {})
+  }
+}
+
+function upgradeExperienceFragment (entity: any): any {
+  const { componentType, ...restSys } = entity.sys ?? {}
+  // A legacy marker carries sys.componentType; a new one carries sys.component.
+  // Prefer an already-present new link (mixed state) over dereferencing the old.
+  const component = entity.sys?.component ?? (componentType ? upgradeComponentLink(componentType) : undefined)
+  return {
+    ...entity,
+    sys: { ...restSys, type: 'ExperienceFragment', ...(component ? { component } : {}) },
+    ...(entity.slots !== undefined ? { slots: upgradeNodeMap(entity.slots) } : {})
+  }
+}
+
+function upgradeExperience (entity: any): any {
+  const { template, ...restSys } = entity.sys ?? {}
+  // Legacy carries sys.template; new carries sys.experienceTemplate.
+  const experienceTemplate = entity.sys?.experienceTemplate ?? (template ? upgradeTemplateLink(template) : undefined)
+  return {
+    ...entity,
+    sys: { ...restSys, type: 'Experience', ...(experienceTemplate ? { experienceTemplate } : {}) },
+    ...(entity.slots !== undefined ? { slots: upgradeNodeMap(entity.slots) } : {})
+  }
+}
+
+/**
+ * Upgrades the renameable ExO entity arrays on a resources object to the new
+ * form, leaving all other keys (and entities that were not renamed, such as
+ * dataAssemblies and designTokens) untouched. Idempotent.
+ */
+export function upgradeExoResources<T extends Record<string, any>> (resources: T): T {
+  if (!resources) return resources
+  return {
+    ...resources,
+    ...(Array.isArray(resources.components) ? { components: resources.components.map(upgradeComponent) } : {}),
+    ...(Array.isArray(resources.experienceTemplates) ? { experienceTemplates: resources.experienceTemplates.map(upgradeExperienceTemplate) } : {}),
+    ...(Array.isArray(resources.experienceFragments) ? { experienceFragments: resources.experienceFragments.map(upgradeExperienceFragment) } : {}),
+    ...(Array.isArray(resources.experiences) ? { experiences: resources.experiences.map(upgradeExperience) } : {})
+  }
+}
+
+// Exported for unit testing individual upgrade steps.
+export {
+  upgradeComponent,
+  upgradeExperienceTemplate,
+  upgradeExperienceFragment,
+  upgradeExperience,
+  upgradeNode,
+  upgradeSlotDefinitions,
+  upgradeContentPropertyTypeRefs
+}

--- a/lib/transform/transform-space.ts
+++ b/lib/transform/transform-space.ts
@@ -3,6 +3,7 @@ import { omit, defaults } from 'lodash/object'
 import * as defaultTransformers from './transformers'
 import sortEntries from '../utils/sort-entries'
 import sortLocales from '../utils/sort-locales'
+import { upgradeExoResources } from './exo-rename'
 import { DestinationData, OriginalSourceData, TransformedSourceData } from '../types'
 
 const spaceEntities = [
@@ -17,7 +18,13 @@ export default function (
   sourceData: OriginalSourceData, destinationData: DestinationData, customTransformers?: any, entities = spaceEntities
 ): TransformedSourceData {
   const transformers = defaults(customTransformers, defaultTransformers)
-  const baseSpaceData = omit(sourceData, ...entities)
+  // ExO entities (components, experienceTemplates, experienceFragments,
+  // experiences) are not handled by the per-entity transformers above; they
+  // pass through as-is except for a rename upgrade so exports taken before the
+  // ExO field rename can still be imported. Upgrading here — before
+  // sorting and push — means the rest of the pipeline only ever sees the new
+  // form. The upgrade is idempotent, so already-new-form data is untouched.
+  const baseSpaceData = upgradeExoResources(omit(sourceData, ...entities))
 
   sourceData.locales = sortLocales(sourceData.locales)
   const tagsEnabled = !!destinationData.tags

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,4 +1,7 @@
 import type { AssetProps, ContentTypeProps, EditorInterfaceProps, EntryProps, Link, LocaleProps, TagProps, WebhookProps } from 'contentful-management'
+import type { ComponentProps, DataAssemblyProps, DesignTokenProps, ExperienceProps, ExperienceFragmentProps, ExperienceTemplateProps } from 'contentful-management'
+
+export type { ComponentProps, DataAssemblyProps, DesignTokenProps, ExperienceProps, ExperienceFragmentProps, ExperienceTemplateProps }
 
 export type Resources = {
   contentTypes?: ContentTypeProps[]
@@ -8,6 +11,12 @@ export type Resources = {
   assets?: AssetProps[]
   editorInterfaces?: EditorInterfaceProps[]
   webhooks?: WebhookProps[]
+  components?: ComponentProps[]
+  experienceTemplates?: ExperienceTemplateProps[]
+  experienceFragments?: ExperienceFragmentProps[]
+  dataAssemblies?: DataAssemblyProps[]
+  experiences?: ExperienceProps[]
+  designTokens?: DesignTokenProps[]
 }
 
 export type ResourcesUnion = (ContentTypeProps | TagProps | LocaleProps | EntryProps | AssetProps | EditorInterfaceProps | WebhookProps)[]
@@ -16,7 +25,7 @@ export type DestinationData = Resources
 
 export type TransformedAsset = {
   fields: { file: { upload?: string, uploadFrom: Link<'Upload'> }[] },
-  sys: {id: string}
+  sys: { id: string }
 }
 
 export type EntityTransformed<TransformedType, OriginalType> = {
@@ -36,6 +45,12 @@ export type TransformedSourceData = {
   tags: EntityTransformed<TagProps, any>[]
   webhooks: EntityTransformed<WebhookProps, any>[]
   editorInterfaces: EditorInterfaceProps[]
+  components?: ComponentProps[]
+  experienceTemplates?: ExperienceTemplateProps[]
+  experienceFragments?: ExperienceFragmentProps[]
+  dataAssemblies?: DataAssemblyProps[]
+  experiences?: ExperienceProps[]
+  designTokens?: DesignTokenProps[]
 }
 
 export type TransformedSourceDataUnion = (

--- a/lib/usageParams.ts
+++ b/lib/usageParams.ts
@@ -83,5 +83,10 @@ export default yargs
     type: 'string',
     describe: 'Pass an additional HTTP Header'
   })
+  .option('include-experience-orchestration', {
+    describe: 'Import Experience Orchestration entities (designTokens, components, experienceTemplates, experienceFragments, dataAssemblies, experiences). Requires a space with ExO enabled.',
+    type: 'boolean',
+    default: true
+  })
   .config('config', 'An optional configuration JSON file containing all the options for a single run')
   .argv

--- a/lib/utils/exo-entity-payloads.ts
+++ b/lib/utils/exo-entity-payloads.ts
@@ -1,0 +1,11 @@
+import { DataAssemblyProps } from 'contentful-management'
+
+export function buildDataAssemblySys(entity: DataAssemblyProps, version: number) {
+  return {
+    id: entity.sys.id,
+    type: 'DataAssembly' as const,
+    dataType: entity.sys.dataType,
+    ...(entity.sys.variant ? { variant: entity.sys.variant } : {}),
+    version
+  }
+}

--- a/lib/utils/graphql-schema-backoff.ts
+++ b/lib/utils/graphql-schema-backoff.ts
@@ -1,0 +1,32 @@
+export const GRAPHQL_SCHEMA_STALE_DELAYS_MS = [500, 1500, 6000]
+
+type ContentfulValidationError = {
+  details?: {
+    errors?: Array<{ message?: string }>
+  }
+}
+
+export function isGraphQLSchemaStaleError(err: unknown): boolean {
+  if (!(err instanceof Error)) {
+    return false
+  }
+
+  let parsed: ContentfulValidationError
+  try {
+    parsed = JSON.parse(err.message) as ContentfulValidationError
+  } catch {
+    return false
+  }
+
+  const errors = parsed?.details?.errors
+  if (!Array.isArray(errors)) {
+    return false
+  }
+
+  const matched = errors.some(
+    (e) =>
+      typeof e.message === 'string' &&
+      (e.message.includes('GraphQL validation error') || e.message.includes('Unknown content type') || e.message.includes('Pointer path does not exist for'))
+  )
+  return matched
+}

--- a/lib/utils/import-exo-folders.ts
+++ b/lib/utils/import-exo-folders.ts
@@ -1,0 +1,298 @@
+import { logEmitter } from 'contentful-batch-libs/dist/logging'
+import type { ComponentProps, DesignTokenProps, ExperienceProps, ExperienceFragmentProps, ExperienceTemplateProps } from 'contentful-management'
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+const FOLDER_CONCEPT_PREFIX = 'contentful.folder-'
+
+export const PARENT_FOLDER_GROUP_IDS = {
+  designToken: 'contentful.folder-group-designToken',
+  componentType: 'contentful.folder-group-componentType',
+  template: 'contentful.folder-group-template',
+  fragment: 'contentful.folder-group-fragment',
+  experience: 'contentful.folder-group-experience',
+} as const
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+type ExoFolderEntity = ComponentProps | DesignTokenProps | ExperienceTemplateProps | ExperienceFragmentProps | ExperienceProps
+
+export type SourceEntities = {
+  designTokens?: DesignTokenProps[]
+  components?: ComponentProps[]
+  experienceTemplates?: ExperienceTemplateProps[]
+  experienceFragments?: ExperienceFragmentProps[]
+  experiences?: ExperienceProps[]
+}
+
+// Maps sourceConceptId → { destConceptId, parentGroupId }
+type ChildConceptMap = Map<string, { destConceptId: string; parentGroupId: string }>
+
+// Maps parentGroupId → live scheme object (with sys.version for patching)
+type ParentGroupMap = Map<string, any>
+
+// ─── Private helpers ──────────────────────────────────────────────────────────
+
+const ENTITY_TYPE_TO_PARENT_GROUP_ID: Record<keyof SourceEntities, string> = {
+  designTokens: PARENT_FOLDER_GROUP_IDS.designToken,
+  components: PARENT_FOLDER_GROUP_IDS.componentType,
+  experienceTemplates: PARENT_FOLDER_GROUP_IDS.template,
+  experienceFragments: PARENT_FOLDER_GROUP_IDS.fragment,
+  experiences: PARENT_FOLDER_GROUP_IDS.experience,
+}
+
+function getSourceSpaceId(sourceEntities: SourceEntities): string | undefined {
+  for (const entities of Object.values(sourceEntities)) {
+    for (const entity of entities ?? []) {
+      const spaceId = (entity as any).sys?.space?.sys?.id
+      if (spaceId) return spaceId
+    }
+  }
+  return undefined
+}
+
+// ─── Step 1 ───────────────────────────────────────────────────────────────────
+/**
+ * Ensure all 5 ExO folder group concept schemes exist in the target org.
+ * Returns Map of all conceptSchemes if all are present, empty Map if any are missing.
+ * Return Map is used in step 4 to link child concepts in.
+ */
+export async function ensureParentFolderGroupsExist(
+  plainClient: any,
+  organizationId: string,
+): Promise<ParentGroupMap> {
+  const { items } = await plainClient.conceptScheme.getMany({
+    organizationId,
+    query: { purpose: 'internal' },
+  })
+
+  const existingIds = new Set<string>(items.map((s: any) => s.sys.id))
+  const allParentFolderGroupsExist = Object.values(PARENT_FOLDER_GROUP_IDS).every((id) => existingIds.has(id))
+
+  if (!allParentFolderGroupsExist) {
+    return new Map()
+  }
+
+  const parentGroupIdSet = new Set(Object.values(PARENT_FOLDER_GROUP_IDS))
+  return new Map<string, any>(
+    items.filter((s: any) => parentGroupIdSet.has(s.sys.id)).map((s: any) => [s.sys.id, s])
+  )
+}
+
+// ─── Step 2 ───────────────────────────────────────────────────────────────────
+
+/**
+ * Step 2: Derive the child concept map from source entities.
+ * Scans each source entity's metadata.concepts for folder-prefixed concept IDs
+ * and derives the deterministic destination-scoped concept ID for each.
+ * Returns a Map<sourceConceptId, { destConceptId, parentGroupId }>.
+ * Pure — no API calls.
+ */
+export function deriveChildConceptMap(
+  sourceEntities: SourceEntities,
+  destinationSpaceId: string,
+): ChildConceptMap {
+  const childConceptMap: ChildConceptMap = new Map()
+
+  for (const [entityType, parentGroupId] of Object.entries(ENTITY_TYPE_TO_PARENT_GROUP_ID)) {
+    for (const entity of (sourceEntities[entityType as keyof SourceEntities] ?? []) as ExoFolderEntity[]) {
+      for (const concept of entity.metadata?.concepts ?? []) {
+        if (concept.sys.id.startsWith(FOLDER_CONCEPT_PREFIX) && !childConceptMap.has(concept.sys.id)) {
+          childConceptMap.set(concept.sys.id, {
+            destConceptId: `${concept.sys.id}-${destinationSpaceId}`,
+            parentGroupId,
+          })
+        }
+      }
+    }
+  }
+
+  return childConceptMap
+}
+
+// ─── Step 3 ───────────────────────────────────────────────────────────────────
+
+/**
+ * Step 3: Create or patch each destination child concept.
+ * - If the concept doesn't exist: creates it with purpose:'internal', the source
+ *   concept's prefLabel, and metadata.spaces scoped to the destination space.
+ * - If it already exists: patches in any missing pieces (purpose:'internal' and/or
+ *   the destination space link). Handles concepts created by earlier broken runs.
+ */
+export async function createOrPatchChildConcepts(
+  plainClient: any,
+  organizationId: string,
+  destinationSpaceId: string,
+  childConceptMap: ChildConceptMap,
+): Promise<void> {
+  const spaceLink = { sys: { type: 'Link', linkType: 'Space', id: destinationSpaceId } }
+
+  for (const [sourceConceptId, { destConceptId }] of childConceptMap) {
+    // Fetch the source concept to copy its prefLabel to the destination.
+    let prefLabel: Record<string, string> = { 'en-US': destConceptId }
+    try {
+      const sourceConcept = await plainClient.concept.get({ organizationId, conceptId: sourceConceptId })
+      if (sourceConcept?.prefLabel) prefLabel = sourceConcept.prefLabel
+    } catch {
+      // Non-critical — fall back to the dest concept ID as label
+    }
+
+    // Check whether the destination concept already exists.
+    let existing: any = null
+    try {
+      existing = await plainClient.concept.get({ organizationId, conceptId: destConceptId })
+    } catch (err: any) {
+      if (err?.name !== 'NotFound') {
+        logEmitter.emit('warning', `Could not fetch destination child concept ${destConceptId}: ${err?.message ?? err}`)
+      }
+      // Ignore 404 errors — they just mean the concept doesn't exist yet. Log any other errors.
+    }
+
+    if (!existing) {
+      try {
+        await plainClient.concept.createWithId(
+          { organizationId, conceptId: destConceptId },
+          { purpose: 'internal', prefLabel, metadata: { spaces: [spaceLink] } }
+        )
+        logEmitter.emit('info', `Created child folder concept ${destConceptId}`)
+      } catch (err: any) {
+        logEmitter.emit('error', `Failed to create child folder concept ${destConceptId}: ${err?.message ?? err}`)
+      }
+    } else {
+      const patches: Array<{ op: string; path: string; value: any }> = []
+
+      if ((existing as any).purpose !== 'internal') {
+        patches.push({ op: 'add', path: '/purpose', value: 'internal' })
+      }
+
+      const spaces: Array<{ sys: { id: string } }> = existing.metadata?.spaces ?? []
+      if (!spaces.some((s) => s.sys.id === destinationSpaceId)) {
+        patches.push({ op: 'add', path: '/metadata/spaces/-', value: spaceLink })
+      }
+
+      if (patches.length > 0) {
+        try {
+          await plainClient.concept.patch(
+            { organizationId, conceptId: destConceptId, version: existing.sys.version },
+            patches
+          )
+          logEmitter.emit('info', `Patched child folder concept ${destConceptId} (${patches.map((p) => p.path).join(', ')})`)
+        } catch (err: any) {
+          logEmitter.emit('error', `Failed to patch child folder concept ${destConceptId}: ${err?.message ?? err}`)
+        }
+      }
+    }
+  }
+}
+
+// ─── Step 4 ───────────────────────────────────────────────────────────────────
+
+/**
+ * Step 4: Link each child concept into its parent folder group scheme.
+ * Patches the scheme's concepts[] array if the child is not already listed.
+ * Mutates parentGroups in-place to keep sys.version current across multiple patches
+ * to the same scheme.
+ */
+export async function linkChildConceptsToParentGroups(
+  plainClient: any,
+  organizationId: string,
+  childConceptMap: ChildConceptMap,
+  parentGroups: ParentGroupMap,
+): Promise<void> {
+  for (const [, { destConceptId, parentGroupId }] of childConceptMap) {
+    const parentGroup = parentGroups.get(parentGroupId)
+    if (!parentGroup) continue
+
+    const alreadyLinked = (parentGroup.concepts ?? []).some((c: any) => c.sys.id === destConceptId)
+    if (alreadyLinked) continue
+
+    try {
+      const updated = await plainClient.conceptScheme.patch(
+        { organizationId, conceptSchemeId: parentGroupId, version: parentGroup.sys.version },
+        [{ op: 'add', path: '/concepts/-', value: { sys: { type: 'Link', linkType: 'TaxonomyConcept', id: destConceptId } } }]
+      )
+      parentGroups.set(parentGroupId, updated)
+      logEmitter.emit('info', `Linked child concept ${destConceptId} to parent group ${parentGroupId}`)
+    } catch (err: any) {
+      logEmitter.emit('error', `Failed to link child concept ${destConceptId} to parent group ${parentGroupId}: ${err?.message ?? err}`)
+    }
+  }
+}
+
+// ─── Step 5 ───────────────────────────────────────────────────────────────────
+
+/**
+ * Step 5: Rewrite folder concept IDs on source entities in-place.
+ * Replaces each source concept ID in metadata.concepts[] with the corresponding
+ * destination concept ID. Non-folder concepts are left untouched.
+ * Pure — no API calls. Mutations are picked up by the subsequent entity upserts.
+ */
+export function rewriteEntityFolderConcepts(
+  entities: ExoFolderEntity[],
+  childConceptMap: ChildConceptMap,
+): void {
+  for (const entity of entities) {
+    if (!entity.metadata?.concepts) continue
+    entity.metadata.concepts = entity.metadata.concepts.map((link) => {
+      const entry = childConceptMap.get(link.sys.id)
+      if (!entry) return link
+      return { sys: { ...link.sys, id: entry.destConceptId } }
+    })
+  }
+}
+
+// ─── Orchestrator ─────────────────────────────────────────────────────────────
+
+/**
+ * Orchestrates the full ExO folder import for a cross-space import.
+ * Runs steps 1–5 in sequence. Step 5 mutates sourceEntities in-place so the
+ * subsequent entity upserts in push-to-space carry the correct destination concept IDs.
+ *
+ * Same-space imports are skipped entirely — existing folder concepts are already valid.
+ */
+export async function importExoFolders({
+  plainClient,
+  organizationId,
+  destinationSpaceId,
+  sourceEntities,
+}: {
+  plainClient: any
+  organizationId: string
+  destinationSpaceId: string
+  sourceEntities: SourceEntities
+}): Promise<void> {
+  const sourceSpaceId = getSourceSpaceId(sourceEntities)
+  if (sourceSpaceId === destinationSpaceId) {
+    logEmitter.emit('info', 'Source and destination space are the same — skipping ExO folder import')
+    return
+  }
+
+  // Step 1
+  const parentGroups = await ensureParentFolderGroupsExist(plainClient, organizationId)
+
+  if (parentGroups.size === 0) {
+    return Promise.reject(new Error('One or more ExO folder group concept schemes are missing in the destination org. Please create them before importing.'))
+  }
+
+  // Step 2
+  const childConceptMap = deriveChildConceptMap(sourceEntities, destinationSpaceId)
+  if (childConceptMap.size === 0) return
+
+  logEmitter.emit('info', `Importing ${childConceptMap.size} ExO folder concept(s) into destination space ${destinationSpaceId}`)
+
+  // Step 3
+  await createOrPatchChildConcepts(plainClient, organizationId, destinationSpaceId, childConceptMap)
+
+  // Step 4
+  await linkChildConceptsToParentGroups(plainClient, organizationId, childConceptMap, parentGroups)
+
+  // Step 5
+  const allEntities = [
+    ...(sourceEntities.designTokens ?? []),
+    ...(sourceEntities.components ?? []),
+    ...(sourceEntities.experienceTemplates ?? []),
+    ...(sourceEntities.experienceFragments ?? []),
+    ...(sourceEntities.experiences ?? []),
+  ]
+  rewriteEntityFolderConcepts(allEntities, childConceptMap)
+}

--- a/lib/utils/publish-exo-entities.ts
+++ b/lib/utils/publish-exo-entities.ts
@@ -1,0 +1,102 @@
+import { logEmitter } from 'contentful-batch-libs/dist/logging'
+import { ComponentProps, DataAssemblyProps, ExperienceProps, ExperienceFragmentProps, ExperienceTemplateProps } from 'contentful-management'
+
+type PublishableExoEntity = ComponentProps | ExperienceTemplateProps | ExperienceFragmentProps | DataAssemblyProps | ExperienceProps
+
+/**
+ * Find all ExO entities in source content which are published, and filter the
+ * created/upserted destination entities down to just those. Mirrors publishEntities
+ * in push-to-space.ts, but ExO source entities aren't wrapped in { original, transformed }
+ * and are plain JSON rather than SDK-wrapped instances, so ExO entities get their own gate here.
+ */
+export function filterExoEntitiesToPublish<T extends { sys: { id: string; version: number } }>(
+  entities: T[],
+  sourceEntities: PublishableExoEntity[]
+): T[] {
+  const entityIdsToPublish = new Set(
+    sourceEntities.filter((entity) => entity.sys.publishedVersion).map((entity) => entity.sys.id)
+  )
+  return entities.filter((entity) => entityIdsToPublish.has(entity.sys.id))
+}
+
+/**
+ * Inverse of filterExoEntitiesToPublish. Finds entities that are currently published at the
+ * destination but draft (or absent) in source, so a source-side unpublish propagates on re-import.
+ */
+export function filterExoEntitiesToUnpublish<T extends { sys: { id: string; version: number; publishedVersion?: number } }>(
+  entities: T[],
+  sourceEntities: PublishableExoEntity[]
+): T[] {
+  const entityIdsPublishedInSource = new Set(
+    sourceEntities.filter((entity) => entity.sys.publishedVersion).map((entity) => entity.sys.id)
+  )
+  return entities.filter((entity) => entity.sys.publishedVersion && !entityIdsPublishedInSource.has(entity.sys.id))
+}
+
+export async function publishExoEntity<T>(type: string, entity: { sys: { id: string } }, publish: () => Promise<T>): Promise<T | null> {
+  try {
+    const result = await publish()
+    logEmitter.emit('info', `PUBLISH ${type} ${entity.sys.id}`)
+    return result
+  } catch (err: any) {
+    err.entity = entity
+    logEmitter.emit('error', err)
+    return null
+  }
+}
+
+export async function unpublishExoEntity<T>(type: string, entity: { sys: { id: string } }, unpublish: () => Promise<T>): Promise<T | null> {
+  try {
+    const result = await unpublish()
+    logEmitter.emit('info', `UNPUBLISH ${type} ${entity.sys.id}`)
+    return result
+  } catch (err) {
+    logEmitter.emit('error', err)
+    return null
+  }
+}
+
+export function isExoEntitlementError (err: unknown): boolean {
+  if (!(err instanceof Error)) {
+    return false
+  }
+  try {
+    const parsed = JSON.parse(err.message)
+    return parsed?.status === 403 && parsed?.details?.reasons === 'exoM1 entitlement required'
+  } catch {
+    return false
+  }
+}
+
+const EXO_M1_FEATURE = 'exoM1'
+
+type OrganizationEntitlementSet = {
+  features?: Record<string, { value?: boolean } | undefined>
+}
+
+/**
+ * Checks the destination space's org for the exoM1 entitlement via the public CMA
+ * GET /organizations/{orgId}/organization_entitlement_set endpoint — same endpoint/pattern
+ * as contentful-mcp-server's hasExoM1Entitlement (AIS-191), scoped to the one org we already
+ * know instead of every org the token can see.
+ *
+ * Returns `null` only when the check itself couldn't complete (space lookup or entitlement
+ * request failed) — callers must treat that as inconclusive and still attempt the real fetch,
+ * not as "not entitled" (unlike the MCP server, which fails closed since its risk is exposing
+ * unentitled write tools; ours is silently dropping data we could have read).
+ */
+export async function spaceHasExoM1Entitlement (plainClient: any, spaceId: string): Promise<boolean | null> {
+  try {
+    const space = await plainClient.space.get({ spaceId })
+    const organizationId = space.sys.organization?.sys?.id
+    if (!organizationId) {
+      return null
+    }
+    const entitlements: OrganizationEntitlementSet = await plainClient.raw.get(
+      `/organizations/${organizationId}/organization_entitlement_set`
+    )
+    return entitlements.features?.[EXO_M1_FEATURE]?.value === true
+  } catch {
+    return null
+  }
+}

--- a/lib/utils/sort-components.ts
+++ b/lib/utils/sort-components.ts
@@ -1,0 +1,69 @@
+type ComponentLike = { sys: { id: string }; componentTree?: any[] }
+
+/**
+ * Topologically sorts components so that any component referenced
+ * inside another's componentTree is guaranteed to appear earlier in the list.
+ * This ensures creates succeed in dependency order.
+ *
+ * Uses Kahn's algorithm. Cycles are broken by appending the remaining nodes
+ * at the end so import can still proceed.
+ */
+export default function sortComponents<T extends ComponentLike>(components: T[]): T[] {
+  const idToIndex = new Map<string, number>()
+  components.forEach((ct, i) => idToIndex.set(ct.sys.id, i))
+
+  // Entities are upgraded to the new form (see transform/exo-rename) before
+  // sorting, so URNs always use the current `components/` path segment.
+  const URN_PATTERN = /components\/([^"\\]+)/g
+
+  function getDeps(ct: any): string[] {
+    const ids = new Set<string>()
+    const tree = JSON.stringify(ct.componentTree || [])
+    let match: RegExpExecArray | null
+    while ((match = URN_PATTERN.exec(tree)) !== null) {
+      const dep = match[1]
+      if (dep !== ct.sys.id && idToIndex.has(dep)) {
+        ids.add(dep)
+      }
+    }
+    return [...ids]
+  }
+
+  // Build adjacency: dep -> list of nodes that depend on dep
+  const dependents = new Map<string, string[]>()
+  const inDegree = new Map<string, number>()
+
+  components.forEach((ct) => {
+    inDegree.set(ct.sys.id, 0)
+    dependents.set(ct.sys.id, [])
+  })
+
+  components.forEach((ct) => {
+    for (const dep of getDeps(ct)) {
+      dependents.get(dep)!.push(ct.sys.id)
+      inDegree.set(ct.sys.id, (inDegree.get(ct.sys.id) ?? 0) + 1)
+    }
+  })
+
+  const queue = components
+    .filter((ct) => inDegree.get(ct.sys.id) === 0)
+    .map((ct) => ct.sys.id)
+
+  const sorted: T[] = []
+  while (queue.length > 0) {
+    const id = queue.shift()!
+    sorted.push(components[idToIndex.get(id)!])
+    for (const dependent of dependents.get(id) ?? []) {
+      const deg = (inDegree.get(dependent) ?? 1) - 1
+      inDegree.set(dependent, deg)
+      if (deg === 0) queue.push(dependent)
+    }
+  }
+
+  // Append anything left (cycles) so we don't silently drop them
+  components.forEach((ct) => {
+    if (!sorted.includes(ct)) sorted.push(ct)
+  })
+
+  return sorted
+}

--- a/lib/utils/sort-experience-fragments.ts
+++ b/lib/utils/sort-experience-fragments.ts
@@ -1,0 +1,66 @@
+type ExperienceFragmentLike = { sys: { id: string }; componentTree?: any; slots?: any }
+
+/**
+ * Topologically sorts experience fragments so that any experience fragment
+ * referenced in another's slots appears earlier in the list.
+ *
+ * Uses Kahn's algorithm. Cycles are broken by appending remaining nodes
+ * at the end so import can still proceed.
+ */
+export default function sortExperienceFragments<T extends ExperienceFragmentLike>(experienceFragments: T[]): T[] {
+  const idToIndex = new Map<string, number>()
+  experienceFragments.forEach((f, i) => idToIndex.set(f.sys.id, i))
+
+  // Entities are upgraded to the new form (see transform/exo-rename) before
+  // sorting, so URNs always use the current `experienceFragments/` path segment.
+  const FRAGMENT_URN_PATTERN = /experienceFragments\/([^"\\]+)/g
+
+  function getDeps(fragment: T): string[] {
+    const ids = new Set<string>()
+    const json = JSON.stringify({ slots: fragment.slots || [], componentTree: fragment.componentTree || [] })
+    let match: RegExpExecArray | null
+    while ((match = FRAGMENT_URN_PATTERN.exec(json)) !== null) {
+      const dep = match[1]
+      if (dep !== fragment.sys.id && idToIndex.has(dep)) {
+        ids.add(dep)
+      }
+    }
+    return [...ids]
+  }
+
+  const dependents = new Map<string, string[]>()
+  const inDegree = new Map<string, number>()
+
+  experienceFragments.forEach((f) => {
+    inDegree.set(f.sys.id, 0)
+    dependents.set(f.sys.id, [])
+  })
+
+  experienceFragments.forEach((f) => {
+    for (const dep of getDeps(f)) {
+      dependents.get(dep)!.push(f.sys.id)
+      inDegree.set(f.sys.id, (inDegree.get(f.sys.id) ?? 0) + 1)
+    }
+  })
+
+  const queue = experienceFragments
+    .filter((f) => inDegree.get(f.sys.id) === 0)
+    .map((f) => f.sys.id)
+
+  const sorted: T[] = []
+  while (queue.length > 0) {
+    const id = queue.shift()!
+    sorted.push(experienceFragments[idToIndex.get(id)!])
+    for (const dependent of dependents.get(id) ?? []) {
+      const deg = (inDegree.get(dependent) ?? 1) - 1
+      inDegree.set(dependent, deg)
+      if (deg === 0) queue.push(dependent)
+    }
+  }
+
+  experienceFragments.forEach((f) => {
+    if (!sorted.includes(f)) sorted.push(f)
+  })
+
+  return sorted
+}

--- a/lib/utils/sort-or-report.ts
+++ b/lib/utils/sort-or-report.ts
@@ -1,0 +1,18 @@
+import { logEmitter } from 'contentful-batch-libs/dist/logging'
+
+/**
+ * Runs a topological sort (sortComponents/sortExperienceFragments) that executes outside the
+ * per-entity try/catch in push-to-space.ts, directly inside wrapTask. An uncaught throw there
+ * (e.g. malformed componentTree/slots data) would bubble through wrapTask and abort the run
+ * without ever reaching the logEmitter-driven report. This logs the failure before rethrowing,
+ * preserving today's abort-on-failure behavior while ensuring the error is visible in the
+ * final report.
+ */
+export function sortOrReport<T>(sortFn: () => T[]): T[] {
+  try {
+    return sortFn()
+  } catch (err) {
+    logEmitter.emit('error', err)
+    throw err
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "bluebird": "^3.7.2",
         "cli-table3": "^0.6.5",
         "contentful-batch-libs": "^9.7.0",
-        "contentful-management": "^12.8.0",
+        "contentful-management": "^12.13.0",
         "date-fns": "^2.30.0",
         "joi": "^18.2.3",
         "listr": "^0.14.3",
@@ -4984,9 +4984,9 @@
       }
     },
     "node_modules/contentful-management": {
-      "version": "12.8.0",
-      "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-12.8.0.tgz",
-      "integrity": "sha512-lARtEZYn2MYf80hz9nCYiLbJWvg95TTnOWmCZouMZtgNS1273dN27Vaz7weHQ3oSQuk7LeYXaXdGFhFPKlpilw==",
+      "version": "12.13.0",
+      "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-12.13.0.tgz",
+      "integrity": "sha512-hkMtWFTQQvLKu0XpYWHmnox4LwS0quuxQkQxOcK+mQpJRhQ0E7axvTiybDaUfw+POOPHbWL9SLO1BuIrfvSEZg==",
       "license": "MIT",
       "dependencies": {
         "@contentful/rich-text-types": "^16.6.1",
@@ -19968,9 +19968,9 @@
       }
     },
     "contentful-management": {
-      "version": "12.8.0",
-      "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-12.8.0.tgz",
-      "integrity": "sha512-lARtEZYn2MYf80hz9nCYiLbJWvg95TTnOWmCZouMZtgNS1273dN27Vaz7weHQ3oSQuk7LeYXaXdGFhFPKlpilw==",
+      "version": "12.13.0",
+      "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-12.13.0.tgz",
+      "integrity": "sha512-hkMtWFTQQvLKu0XpYWHmnox4LwS0quuxQkQxOcK+mQpJRhQ0E7axvTiybDaUfw+POOPHbWL9SLO1BuIrfvSEZg==",
       "requires": {
         "@contentful/rich-text-types": "^16.6.1",
         "axios": "^1.15.0",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "bluebird": "^3.7.2",
     "cli-table3": "^0.6.5",
     "contentful-batch-libs": "^9.7.0",
-    "contentful-management": "^12.8.0",
+    "contentful-management": "^12.13.0",
     "date-fns": "^2.30.0",
     "joi": "^18.2.3",
     "listr": "^0.14.3",

--- a/test/integration/import-exo.test.ts
+++ b/test/integration/import-exo.test.ts
@@ -1,0 +1,190 @@
+import { createClient } from 'contentful-management'
+
+import runContentfulImport from '../../dist/index'
+import { buildExoContent, buildUnpublishedComponentContent, EXO_FIXTURE_IDS } from './utils/exo.utils'
+
+const managementToken = process.env.MANAGEMENT_TOKEN as string
+const orgId = process.env.ORG_ID as string
+const environmentId = 'master'
+
+jest.setTimeout(2 * 60 * 1000) // 2min timeout - covers space create/delete + 6 ExO entity types + publish
+
+// Each describe block below creates its own throwaway space (same pattern as
+// import-lib.test.ts) and deletes it in afterAll.
+
+// Covers: "Import of an ExO export file creates all 6 entity types in destination",
+// "URN rewriting: cross-space import produces valid URNs pointing to destination space/env",
+// and "Publish state is preserved" - one import run, multiple assertions, since all three
+// ACs are properties of the same operation rather than independent scenarios.
+describe('Importing an ExO export with all 6 entity types', () => {
+  let spaceId: string
+  let plainClient
+
+  beforeAll(async () => {
+    const legacyClient = createClient({ accessToken: managementToken }, { type: 'legacy' })
+    const space = await legacyClient.createSpace({ name: 'IMPORT [AUTO] TOOL EXO TMP' }, orgId)
+    spaceId = space.sys.id
+    plainClient = createClient({ accessToken: managementToken })
+
+    await runContentfulImport({
+      spaceId,
+      environmentId,
+      managementToken,
+      content: buildExoContent(EXO_FIXTURE_IDS),
+      includeExperienceOrchestration: true,
+      useVerboseRenderer: true
+    })
+  })
+
+  afterAll(async () => {
+    const legacyClient = createClient({ accessToken: managementToken }, { type: 'legacy' })
+    const space = await legacyClient.getSpace(spaceId)
+    await space.delete()
+  })
+
+  test('creates the DesignToken', async () => {
+    const designToken = await plainClient.designToken.get({ spaceId, environmentId, designTokenId: EXO_FIXTURE_IDS.designTokenId })
+    expect(designToken.sys.type).toBe('DesignToken')
+    expect(designToken.type).toBe('DTCG.Color')
+  })
+
+  test('creates and publishes the Component', async () => {
+    const component = await plainClient.component.get({ spaceId, environmentId, componentId: EXO_FIXTURE_IDS.componentId })
+    expect(component.sys.type).toBe('Component')
+    expect(component.sys.publishedVersion).toBeDefined()
+  })
+
+  test('creates the DataAssembly as draft', async () => {
+    const dataAssembly = await plainClient.dataAssembly.get({ spaceId, environmentId, dataAssemblyId: EXO_FIXTURE_IDS.dataAssemblyId })
+    expect(dataAssembly.sys.type).toBe('DataAssembly')
+    expect(dataAssembly.sys.publishedVersion).toBeUndefined()
+  })
+
+  test('creates and publishes the ExperienceTemplate', async () => {
+    const experienceTemplate = await plainClient.experienceTemplate.get({ spaceId, environmentId, experienceTemplateId: EXO_FIXTURE_IDS.experienceTemplateId })
+    expect(experienceTemplate.sys.type).toBe('ExperienceTemplate')
+    expect(experienceTemplate.sys.publishedVersion).toBeDefined()
+  })
+
+  test('creates the ExperienceFragment as draft, with its Component reference intact', async () => {
+    const fragment = await plainClient.experienceFragment.get({ spaceId, environmentId, experienceFragmentId: EXO_FIXTURE_IDS.experienceFragmentId })
+    expect(fragment.sys.type).toBe('ExperienceFragment')
+    expect(fragment.sys.publishedVersion).toBeUndefined()
+
+    // URN stays $self-relative (no rewriting) and still resolves to the sibling Component
+    // that was imported alongside it, in this same destination space/environment.
+    expect(fragment.sys.component.sys.urn).toBe(
+      `crn:contentful:::experience:spaces/$self/environments/$self/components/${EXO_FIXTURE_IDS.componentId}`
+    )
+    const referencedComponent = await plainClient.component.get({ spaceId, environmentId, componentId: EXO_FIXTURE_IDS.componentId })
+    expect(referencedComponent.sys.id).toBe(EXO_FIXTURE_IDS.componentId)
+  })
+
+  test('creates and publishes the Experience, with its ExperienceTemplate reference intact', async () => {
+    const experience = await plainClient.experience.get({ spaceId, environmentId, experienceId: EXO_FIXTURE_IDS.experienceId })
+    expect(experience.sys.type).toBe('Experience')
+    expect(experience.sys.publishedVersion).toBeDefined()
+
+    expect(experience.sys.experienceTemplate.sys.urn).toBe(
+      `crn:contentful:::experience:spaces/$self/environments/$self/experienceTemplates/${EXO_FIXTURE_IDS.experienceTemplateId}`
+    )
+    const referencedTemplate = await plainClient.experienceTemplate.get({ spaceId, environmentId, experienceTemplateId: EXO_FIXTURE_IDS.experienceTemplateId })
+    expect(referencedTemplate.sys.id).toBe(EXO_FIXTURE_IDS.experienceTemplateId)
+  })
+
+  // Both tests below run after the six above and re-import into the same space, exercising
+  // the UPDATE path (not covered elsewhere in this file) - guards against two real bugs
+  // AIS-385 found that only surfaced against the live API, not mocks: sending an immutable
+  // field on UPDATE 400ing, and unpublish never propagating on re-import.
+
+  test('re-imports the same content again without error', async () => {
+    const result = await runContentfulImport({
+      spaceId,
+      environmentId,
+      managementToken,
+      content: buildExoContent(EXO_FIXTURE_IDS),
+      includeExperienceOrchestration: true,
+      useVerboseRenderer: true
+    })
+
+    expect(result).toBeDefined()
+  })
+
+  test('propagates an unpublish from source to destination on re-import', async () => {
+    await runContentfulImport({
+      spaceId,
+      environmentId,
+      managementToken,
+      content: buildUnpublishedComponentContent(EXO_FIXTURE_IDS),
+      includeExperienceOrchestration: true,
+      useVerboseRenderer: true
+    })
+
+    const component = await plainClient.component.get({ spaceId, environmentId, componentId: EXO_FIXTURE_IDS.componentId })
+    expect(component.sys.publishedVersion).toBeUndefined()
+  })
+})
+
+describe('Importing with includeExperienceOrchestration: false', () => {
+  let spaceId: string
+  let plainClient
+
+  beforeAll(async () => {
+    const legacyClient = createClient({ accessToken: managementToken }, { type: 'legacy' })
+    const space = await legacyClient.createSpace({ name: 'IMPORT [AUTO] TOOL EXO SKIP TMP' }, orgId)
+    spaceId = space.sys.id
+    plainClient = createClient({ accessToken: managementToken })
+  })
+
+  afterAll(async () => {
+    const legacyClient = createClient({ accessToken: managementToken }, { type: 'legacy' })
+    const space = await legacyClient.getSpace(spaceId)
+    await space.delete()
+  })
+
+  test('does not create any ExO entities even though the source file has ExO data', async () => {
+    await runContentfulImport({
+      spaceId,
+      environmentId,
+      managementToken,
+      content: buildExoContent(EXO_FIXTURE_IDS),
+      includeExperienceOrchestration: false,
+      useVerboseRenderer: true
+    })
+
+    await expect(
+      plainClient.component.get({ spaceId, environmentId, componentId: EXO_FIXTURE_IDS.componentId })
+    ).rejects.toThrow('The resource could not be found')
+  })
+})
+
+// Covers: "Import of an old export file (no ExO arrays) completes without errors"
+describe('Importing a legacy export file with no ExO entity arrays', () => {
+  let spaceId: string
+
+  beforeAll(async () => {
+    const legacyClient = createClient({ accessToken: managementToken }, { type: 'legacy' })
+    const space = await legacyClient.createSpace({ name: 'IMPORT [AUTO] TOOL EXO LEGACY TMP' }, orgId)
+    spaceId = space.sys.id
+  })
+
+  afterAll(async () => {
+    const legacyClient = createClient({ accessToken: managementToken }, { type: 'legacy' })
+    const space = await legacyClient.getSpace(spaceId)
+    await space.delete()
+  })
+
+  test('completes without error', async () => {
+    // If this rejects, Jest fails the test - that IS the "completes without errors" assertion.
+    const result = await runContentfulImport({
+      spaceId,
+      environmentId,
+      managementToken,
+      content: {},
+      includeExperienceOrchestration: true,
+      useVerboseRenderer: true
+    })
+
+    expect(result).toBeDefined()
+  })
+})

--- a/test/integration/utils/exo.utils.ts
+++ b/test/integration/utils/exo.utils.ts
@@ -1,0 +1,158 @@
+export const TEST_PREFIX = '[Exo Integration Test]'
+
+// $self-relative CRN format for same-space/environment ExO ResourceLinks -
+// see reference_exo_resource_link_urns memory / exo-rename.ts for the canonical form.
+const EXO_CRN_PREFIX = 'crn:contentful:::experience:spaces/$self/environments/$self'
+
+const entityPaths: Record<string, string> = {
+  'Contentful:Component': 'components',
+  'Contentful:ExperienceTemplate': 'experienceTemplates'
+}
+
+export function makeResourceLink (linkType: keyof typeof entityPaths, id: string) {
+  return {
+    sys: {
+      type: 'ResourceLink' as const,
+      linkType,
+      urn: `${EXO_CRN_PREFIX}/${entityPaths[linkType]}/${id}`
+    }
+  }
+}
+
+export const testViewport = {
+  id: 'desktop',
+  query: '(min-width: 1024px)',
+  displayName: 'Desktop',
+  previewSize: '100%'
+}
+
+export type ExoFixtureIds = {
+  designTokenId: string
+  componentId: string
+  dataAssemblyId: string
+  experienceTemplateId: string
+  experienceFragmentId: string
+  experienceId: string
+}
+
+// Each describe block in import-exo.test.ts creates and deletes its own throwaway space
+// (same pattern as import-lib.test.ts), so there's no cross-run collision risk - literal,
+// stable IDs are fine and easier to read/debug than generated ones.
+export const EXO_FIXTURE_IDS: ExoFixtureIds = {
+  designTokenId: 'exo-design-token',
+  componentId: 'exo-component',
+  dataAssemblyId: 'exo-data-assembly',
+  experienceTemplateId: 'exo-experience-template',
+  experienceFragmentId: 'exo-experience-fragment',
+  experienceId: 'exo-experience'
+}
+
+/**
+ * Builds an export-shaped content payload covering all 6 ExO entity types, in the same
+ * "read" shape contentful-export would produce: cross-entity references (ExperienceFragment
+ * -> Component, Experience -> ExperienceTemplate) live under `sys`, as returned by the CMA,
+ * not at the top level (that's the CREATE-payload shape push-to-space.ts builds from this).
+ *
+ * DesignToken, DataAssembly and ExperienceFragment are left draft; Component,
+ * ExperienceTemplate and Experience are published - covers publish-state preservation
+ * with a single import run instead of a dedicated one per state.
+ */
+export function buildExoContent (ids: ExoFixtureIds) {
+  return {
+    designTokens: [
+      {
+        sys: { id: ids.designTokenId, type: 'DesignToken', version: 1 },
+        name: `${TEST_PREFIX} Design Token`,
+        type: 'DTCG.Color'
+      }
+    ],
+    components: [
+      {
+        sys: { id: ids.componentId, type: 'Component', version: 1, publishedVersion: 1 },
+        name: `${TEST_PREFIX} Component`,
+        description: 'Created by an ExO import integration test',
+        viewports: [testViewport],
+        contentProperties: [{ id: 'title', name: 'Title', type: 'String', required: false }],
+        designProperties: [{ id: 'color', name: 'Color', type: 'String' }]
+      }
+    ],
+    dataAssemblies: [
+      {
+        sys: {
+          id: ids.dataAssemblyId,
+          type: 'DataAssembly',
+          version: 1,
+          dataType: [{ id: 'title', name: 'Title', type: 'String', required: false }]
+        },
+        metadata: { tags: [] },
+        name: `${TEST_PREFIX} Data Assembly`,
+        description: 'Created by an ExO import integration test',
+        parameters: {},
+        resolvers: {},
+        return: {}
+      }
+    ],
+    experienceTemplates: [
+      {
+        sys: { id: ids.experienceTemplateId, type: 'ExperienceTemplate', version: 1, publishedVersion: 1 },
+        name: `${TEST_PREFIX} Experience Template`,
+        description: 'Created by an ExO import integration test',
+        viewports: [testViewport],
+        contentProperties: [],
+        designProperties: []
+      }
+    ],
+    experienceFragments: [
+      {
+        sys: {
+          id: ids.experienceFragmentId,
+          type: 'ExperienceFragment',
+          version: 1,
+          component: makeResourceLink('Contentful:Component', ids.componentId)
+        },
+        name: `${TEST_PREFIX} Experience Fragment`,
+        description: 'Created by an ExO import integration test',
+        viewports: [testViewport],
+        designProperties: {}
+      }
+    ],
+    experiences: [
+      {
+        sys: {
+          id: ids.experienceId,
+          type: 'Experience',
+          version: 1,
+          publishedVersion: 1,
+          experienceTemplate: makeResourceLink('Contentful:ExperienceTemplate', ids.experienceTemplateId)
+        },
+        name: `${TEST_PREFIX} Experience`,
+        description: 'Created by an ExO import integration test',
+        viewports: [testViewport],
+        designProperties: {}
+      }
+    ]
+  }
+}
+
+/**
+ * A re-import payload for just the Component from buildExoContent, with no
+ * publishedVersion - i.e. "this entity was unpublished in the source since the last
+ * export." Only the Component key is set; every other entity type defaults to empty and
+ * is left untouched by the import. Used to verify that an unpublish in the source
+ * propagates to the destination on re-import (see push-to-space.ts's "Unpublishing
+ * Components" task).
+ */
+export function buildUnpublishedComponentContent (ids: ExoFixtureIds) {
+  return {
+    components: [
+      {
+        sys: { id: ids.componentId, type: 'Component', version: 1 },
+        name: `${TEST_PREFIX} Component`,
+        description: 'Created by an ExO import integration test',
+        viewports: [testViewport],
+        contentProperties: [{ id: 'title', name: 'Title', type: 'String', required: false }],
+        designProperties: [{ id: 'color', name: 'Color', type: 'String' }]
+      }
+    ]
+  }
+}

--- a/test/unit/graphql-schema-backoff.test.ts
+++ b/test/unit/graphql-schema-backoff.test.ts
@@ -1,0 +1,83 @@
+import { isGraphQLSchemaStaleError } from '../../lib/utils/graphql-schema-backoff'
+
+function makeContentfulError(details: object, name = 'ValidationFailed'): Error {
+  const err = new Error(
+    JSON.stringify({
+      status: 422,
+      statusText: '',
+      message: 'Validation error',
+      details,
+    })
+  )
+  err.name = name
+  return err
+}
+
+const GRAPHQL_VALIDATION_ERROR = {
+  errors: [{ message: 'GraphQL validation error: Cannot query field "foo" on type "Query".' }],
+}
+
+const UNKNOWN_CONTENT_TYPE_ERROR = {
+  errors: [{ message: 'Unknown content type "myContentType".' }],
+}
+
+const MIXED_ERRORS = {
+  errors: [
+    { message: 'Pointer path does not exist for ...' },
+    { message: 'GraphQL validation error: Cannot query field "bar" on type "Query".' },
+    { message: 'Unknown content type "anotherType".' },
+  ],
+}
+
+const UNRELATED_ERRORS = {
+  errors: [{ message: 'Some other validation error unrelated to GraphQL schema.' }],
+}
+
+describe('isGraphQLSchemaStaleError', () => {
+  describe('returns true', () => {
+    test('for a GraphQL validation error', () => {
+      expect(isGraphQLSchemaStaleError(makeContentfulError(GRAPHQL_VALIDATION_ERROR))).toBe(true)
+    })
+
+    test('for an Unknown content type error', () => {
+      expect(isGraphQLSchemaStaleError(makeContentfulError(UNKNOWN_CONTENT_TYPE_ERROR))).toBe(true)
+    })
+
+    test('when stale schema message is mixed with other errors', () => {
+      expect(isGraphQLSchemaStaleError(makeContentfulError(MIXED_ERRORS))).toBe(true)
+    })
+  })
+
+  describe('returns false', () => {
+    test('for an unrelated validation error', () => {
+      expect(isGraphQLSchemaStaleError(makeContentfulError(UNRELATED_ERRORS))).toBe(false)
+    })
+
+    test('when details.errors is missing', () => {
+      expect(isGraphQLSchemaStaleError(makeContentfulError({}))).toBe(false)
+    })
+
+    test('when details.errors is not an array', () => {
+      expect(isGraphQLSchemaStaleError(makeContentfulError({ errors: 'not an array' }))).toBe(false)
+    })
+
+    test('when err is not an Error instance', () => {
+      expect(isGraphQLSchemaStaleError({ message: 'GraphQL validation error' })).toBe(false)
+    })
+
+    test('when err is null', () => {
+      expect(isGraphQLSchemaStaleError(null)).toBe(false)
+    })
+
+    test('when err.message is not JSON', () => {
+      const err = new Error('plain string message, not JSON')
+      expect(isGraphQLSchemaStaleError(err)).toBe(false)
+    })
+
+    test('when the error name is different but message matches', () => {
+      // Confirm we match on message content, not error name
+      const err = makeContentfulError(GRAPHQL_VALIDATION_ERROR, 'SomeOtherError')
+      expect(isGraphQLSchemaStaleError(err)).toBe(true)
+    })
+  })
+})

--- a/test/unit/index.test.ts
+++ b/test/unit/index.test.ts
@@ -59,9 +59,13 @@ jest.mock('../../lib/transform/transform-space', () => {
   return jest.fn((data) => data)
 })
 jest.mock('../../lib/tasks/init-client', () => {
-  return jest.fn(() => (
-    { source: { delivery: {} }, destination: { management: {} } }
-  ))
+  return {
+    __esModule: true,
+    default: jest.fn(() => (
+      { source: { delivery: {} }, destination: { management: {} } }
+    )),
+    initPlainClient: jest.fn(() => ({}))
+  }
 })
 
 afterEach(() => {
@@ -161,7 +165,8 @@ test('Runs Contentful Import', () => {
       expect(introTable.push.mock.calls[5][0]).toEqual(['Editor Interfaces', 2])
       expect(introTable.push.mock.calls[6][0]).toEqual(['Locales', 2])
       expect(introTable.push.mock.calls[7][0]).toEqual(['Webhooks', 0])
-      expect(introTable.push.mock.calls).toHaveLength(8)
+      expect(introTable.push.mock.calls[8][0]).toEqual(['Design Tokens', 0])
+      expect(introTable.push.mock.calls).toHaveLength(14)
 
       const resultTable = (TableStub as jest.Mock).mock.instances[1]
       expect(resultTable.push.mock.calls[0][0]).toEqual([{ colSpan: 2, content: 'Imported entities' }])
@@ -172,7 +177,8 @@ test('Runs Contentful Import', () => {
       expect(resultTable.push.mock.calls[5][0]).toEqual(['Editor Interfaces', 2])
       expect(resultTable.push.mock.calls[6][0]).toEqual(['Locales', 2])
       expect(resultTable.push.mock.calls[7][0]).toEqual(['Webhooks', 0])
-      expect(resultTable.push.mock.calls).toHaveLength(8)
+      expect(resultTable.push.mock.calls[8][0]).toEqual(['Design Tokens', 0])
+      expect(resultTable.push.mock.calls).toHaveLength(14)
     })
 })
 
@@ -244,7 +250,8 @@ test('Intro CLI table respects skipContentModel', () => {
       expect(introTable.push.mock.calls[3][0]).toEqual(['Locales', 2])
       expect(introTable.push.mock.calls[4][0]).toEqual(['Tags', 0])
       expect(introTable.push.mock.calls[5][0]).toEqual(['Webhooks', 0])
-      expect(introTable.push.mock.calls).toHaveLength(6)
+      expect(introTable.push.mock.calls[6][0]).toEqual(['Design Tokens', 0])
+      expect(introTable.push.mock.calls).toHaveLength(12)
     })
 })
 

--- a/test/unit/parseOptions.test.ts
+++ b/test/unit/parseOptions.test.ts
@@ -95,11 +95,17 @@ test('parseOptions sets correct default options', async () => {
   expect(options.uploadAssets).toBe(false)
   expect(options.content).toEqual({
     assets: [],
+    components: [],
     contentTypes: [],
+    dataAssemblies: [],
+    designTokens: [],
     editorInterfaces: [],
-    tags: [],
     entries: [],
+    experienceFragments: [],
+    experienceTemplates: [],
+    experiences: [],
     locales: [],
+    tags: [],
     webhooks: [],
     ...require(contentFile)
   })
@@ -186,7 +192,7 @@ test('parseOption cleans up content to only include supported entity types', asy
     }
   })
   const content = options.content
-  expect(Object.keys(content)).toHaveLength(7)
+  expect(Object.keys(content)).toHaveLength(13)
   expect(content.invalid).toBeUndefined()
 })
 

--- a/test/unit/sort-experience-fragments.test.ts
+++ b/test/unit/sort-experience-fragments.test.ts
@@ -1,0 +1,100 @@
+import sortExperienceFragments from '../../lib/utils/sort-experience-fragments'
+
+function idx(sorted: { sys: { id: string } }[], id: string) {
+  return sorted.findIndex((f) => f.sys.id === id)
+}
+
+function frag(id: string, slots?: object, componentTree?: object) {
+  return { sys: { id }, ...(slots ? { slots } : {}), ...(componentTree ? { componentTree } : {}) }
+}
+
+// Embed a fragment URN reference into a slots/componentTree structure
+function ref(id: string) {
+  return [{ urn: `urn:contentful:experienceFragments/${id}` }]
+}
+
+test('returns empty array when given empty input', () => {
+  expect(sortExperienceFragments([])).toEqual([])
+})
+
+test('returns single fragment unchanged', () => {
+  const result = sortExperienceFragments([frag('a')])
+  expect(result).toHaveLength(1)
+  expect(result[0].sys.id).toBe('a')
+})
+
+test('sorts two fragments so dependency via slots comes first', () => {
+  const a = frag('a', ref('b'))
+  const b = frag('b')
+  const result = sortExperienceFragments([a, b])
+  expect(idx(result, 'b')).toBeLessThan(idx(result, 'a'))
+  expect(result).toHaveLength(2)
+})
+
+test('sorts two fragments so dependency via componentTree comes first', () => {
+  const a = frag('a', undefined, ref('b'))
+  const b = frag('b')
+  const result = sortExperienceFragments([a, b])
+  expect(idx(result, 'b')).toBeLessThan(idx(result, 'a'))
+})
+
+test('sorts a linear chain A→B→C so C comes first', () => {
+  const a = frag('a', ref('b'))
+  const b = frag('b', ref('c'))
+  const c = frag('c')
+  const result = sortExperienceFragments([a, b, c])
+  expect(idx(result, 'c')).toBeLessThan(idx(result, 'b'))
+  expect(idx(result, 'b')).toBeLessThan(idx(result, 'a'))
+  expect(result).toHaveLength(3)
+})
+
+test('preserves relative order of independent fragments', () => {
+  const a = frag('a')
+  const b = frag('b')
+  const c = frag('c')
+  const result = sortExperienceFragments([a, b, c])
+  expect(idx(result, 'a')).toBeLessThan(idx(result, 'b'))
+  expect(idx(result, 'b')).toBeLessThan(idx(result, 'c'))
+})
+
+test('ignores self-references', () => {
+  const a = frag('a', ref('a'))
+  const result = sortExperienceFragments([a])
+  expect(result).toHaveLength(1)
+  expect(result[0].sys.id).toBe('a')
+})
+
+test('ignores references to fragments not in the list', () => {
+  const a = frag('a', ref('unknown'))
+  const b = frag('b')
+  const result = sortExperienceFragments([a, b])
+  expect(result).toHaveLength(2)
+})
+
+test('handles a cycle without throwing and includes all fragments', () => {
+  const a = frag('a', ref('b'))
+  const b = frag('b', ref('a'))
+  const result = sortExperienceFragments([a, b])
+  expect(result).toHaveLength(2)
+  expect(result.map((f) => f.sys.id)).toEqual(expect.arrayContaining(['a', 'b']))
+})
+
+test('diamond dependency: A and B both depend on C, D depends on A and B', () => {
+  const c = frag('c')
+  const a = frag('a', ref('c'))
+  const b = frag('b', ref('c'))
+  const d = frag('d', [...ref('a'), ...ref('b')])
+  const result = sortExperienceFragments([d, b, a, c])
+  expect(idx(result, 'c')).toBeLessThan(idx(result, 'a'))
+  expect(idx(result, 'c')).toBeLessThan(idx(result, 'b'))
+  expect(idx(result, 'a')).toBeLessThan(idx(result, 'd'))
+  expect(idx(result, 'b')).toBeLessThan(idx(result, 'd'))
+  expect(result).toHaveLength(4)
+})
+
+test('fragment with no slots or componentTree fields is treated as having no deps', () => {
+  const a = frag('a')
+  const b = frag('b', ref('a'))
+  const result = sortExperienceFragments([b, a])
+  expect(idx(result, 'a')).toBeLessThan(idx(result, 'b'))
+})

--- a/test/unit/tasks/get-destination-data-exo.test.ts
+++ b/test/unit/tasks/get-destination-data-exo.test.ts
@@ -1,0 +1,655 @@
+import PQueue from 'p-queue'
+
+import { logEmitter } from 'contentful-batch-libs/dist/logging'
+
+import getDestinationData from '../../../lib/tasks/get-destination-data'
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeEntity(id: string) {
+  return { sys: { id, version: 1 } }
+}
+
+// Simulates a cursor-paginated ExO endpoint: returns items in pages of `pageSize`,
+// encoding a `pageNext` token when more pages exist.
+function makeCursorResolver(items: any[], pageSize = 100) {
+  return jest.fn(({ query }: { query: any }) => {
+    const token = query?.pageNext ? parseInt(query.pageNext, 10) : 0
+    const page = items.slice(token, token + pageSize)
+    const next = token + pageSize < items.length ? String(token + pageSize) : undefined
+    return Promise.resolve({ items: page, pages: next ? { next } : undefined })
+  })
+}
+
+function makeOffsetResolver(items: any[]) {
+  return jest.fn((query: any) => {
+    const skip = query?.skip ?? 0
+    const limit = query?.limit ?? 100
+    return Promise.resolve({ items: items.slice(skip, skip + limit), total: items.length })
+  })
+}
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const exoItems = {
+  designTokens: Array.from({ length: 7 }, (_, i) => makeEntity(`dt-${i}`)),
+  components: Array.from({ length: 5 }, (_, i) => makeEntity(`ct-${i}`)),
+  experienceTemplates: Array.from({ length: 3 }, (_, i) => makeEntity(`tmpl-${i}`)),
+  experienceFragments: Array.from({ length: 4 }, (_, i) => makeEntity(`frag-${i}`)),
+  dataAssemblies: Array.from({ length: 2 }, (_, i) => makeEntity(`da-${i}`)),
+  experiences: Array.from({ length: 6 }, (_, i) => makeEntity(`exp-${i}`))
+}
+
+// The ExO fetch block is now gated on the source content actually containing that entity
+// type (mirrors how entries/assets/locales are gated), so tests that expect a given ExO
+// fetch to fire must include a source entity of that type.
+const exoSourceData = {
+  designTokens: [makeEntity('src-dt') as any],
+  components: [makeEntity('src-ct') as any],
+  experienceTemplates: [makeEntity('src-tmpl') as any],
+  experienceFragments: [makeEntity('src-frag') as any],
+  dataAssemblies: [makeEntity('src-da') as any],
+  experiences: [makeEntity('src-exp') as any]
+}
+
+function makePlainClientMock() {
+  return {
+    designToken: { getMany: makeCursorResolver(exoItems.designTokens) },
+    component: { getMany: makeCursorResolver(exoItems.components) },
+    experienceTemplate: { getMany: makeCursorResolver(exoItems.experienceTemplates) },
+    experienceFragment: { getMany: makeCursorResolver(exoItems.experienceFragments) },
+    dataAssembly: { getMany: makeCursorResolver(exoItems.dataAssemblies) },
+    experience: { getMany: makeCursorResolver(exoItems.experiences) }
+  }
+}
+
+const mockEnvironment = {
+  getContentTypes: jest.fn((q: any) =>
+    Promise.resolve({ items: (q['sys.id[in]'] as string).split(',').map((id) => ({ sys: { id } })) })
+  ),
+  getEntries: jest.fn(() => Promise.resolve({ items: [] })),
+  getAssets: jest.fn(() => Promise.resolve({ items: [] })),
+  getLocales: jest.fn(makeOffsetResolver([])),
+  getTags: jest.fn(makeOffsetResolver([]))
+}
+
+const mockSpace = {
+  getEnvironment: jest.fn(() => Promise.resolve(mockEnvironment))
+}
+
+const mockClient = {
+  getSpace: jest.fn(() => Promise.resolve(mockSpace))
+}
+
+let requestQueue: PQueue
+
+beforeEach(() => {
+  requestQueue = new PQueue({ interval: 1000, intervalCap: 1000 })
+  jest.clearAllMocks()
+  mockEnvironment.getContentTypes.mockImplementation((q: any) =>
+    Promise.resolve({ items: (q['sys.id[in]'] as string).split(',').map((id) => ({ sys: { id } })) })
+  )
+  mockEnvironment.getEntries.mockResolvedValue({ items: [] })
+  mockEnvironment.getAssets.mockResolvedValue({ items: [] })
+  mockEnvironment.getLocales.mockImplementation(makeOffsetResolver([]))
+  mockEnvironment.getTags.mockImplementation(makeOffsetResolver([]))
+  mockSpace.getEnvironment.mockResolvedValue(mockEnvironment)
+  mockClient.getSpace.mockResolvedValue(mockSpace)
+})
+
+// ─── Cursor pagination is only used for ExO entities ─────────────────────────
+
+test('uses cursor pagination for ExO entities, not for standard entities', async () => {
+  const plainClient = makePlainClientMock()
+  await getDestinationData({
+    client: mockClient,
+    plainClient,
+    spaceId: 'space-1',
+    environmentId: 'master',
+    sourceData: { contentTypes: [makeEntity('ct-x') as any], ...exoSourceData },
+    includeExperienceOrchestration: true,
+    requestQueue
+  })
+
+  // Standard entity: environment method was called (offset-based)
+  expect(mockEnvironment.getContentTypes).toHaveBeenCalled()
+  // ExO entity: plainClient cursor method was called, NOT an environment method
+  expect(plainClient.component.getMany).toHaveBeenCalled()
+  // Cursor query shape: must include a `limit`, never a `skip`
+  const callArg = plainClient.component.getMany.mock.calls[0][0] as any
+  expect(callArg.query).toHaveProperty('limit')
+  expect(callArg.query).not.toHaveProperty('skip')
+})
+
+test('does NOT call plainClient ExO methods when includeExperienceOrchestration is false', async () => {
+  const plainClient = makePlainClientMock()
+  await getDestinationData({
+    client: mockClient,
+    plainClient,
+    spaceId: 'space-1',
+    environmentId: 'master',
+    sourceData: exoSourceData,
+    includeExperienceOrchestration: false,
+    requestQueue
+  })
+
+  expect(plainClient.designToken.getMany).not.toHaveBeenCalled()
+  expect(plainClient.component.getMany).not.toHaveBeenCalled()
+  expect(plainClient.experienceTemplate.getMany).not.toHaveBeenCalled()
+  expect(plainClient.experienceFragment.getMany).not.toHaveBeenCalled()
+  expect(plainClient.dataAssembly.getMany).not.toHaveBeenCalled()
+  expect(plainClient.experience.getMany).not.toHaveBeenCalled()
+})
+
+test('follows pageNext cursor across multiple pages', async () => {
+  // 150 items, page size 100 → 2 pages
+  const manyItems = Array.from({ length: 150 }, (_, i) => makeEntity(`ct-${i}`))
+  const plainClient = {
+    ...makePlainClientMock(),
+    component: { getMany: makeCursorResolver(manyItems, 100) }
+  }
+
+  const result = await getDestinationData({
+    client: mockClient,
+    plainClient,
+    spaceId: 'space-1',
+    environmentId: 'master',
+    sourceData: { components: exoSourceData.components },
+    includeExperienceOrchestration: true,
+    requestQueue
+  })
+
+  expect(plainClient.component.getMany).toHaveBeenCalledTimes(2)
+  expect(result.components).toHaveLength(150)
+})
+
+// ─── Returns destination data for all ExO entities ───────────────────────────
+
+test('returns destination designTokens fetched via cursor pagination', async () => {
+  const plainClient = makePlainClientMock()
+  const result = await getDestinationData({
+    client: mockClient,
+    plainClient,
+    spaceId: 'space-1',
+    environmentId: 'master',
+    sourceData: { designTokens: exoSourceData.designTokens },
+    includeExperienceOrchestration: true,
+    requestQueue
+  })
+
+  expect(result.designTokens).toHaveLength(exoItems.designTokens.length)
+  expect(result.designTokens![0].sys.id).toBe('dt-0')
+})
+
+test('returns destination components fetched via cursor pagination', async () => {
+  const plainClient = makePlainClientMock()
+  const result = await getDestinationData({
+    client: mockClient,
+    plainClient,
+    spaceId: 'space-1',
+    environmentId: 'master',
+    sourceData: { components: exoSourceData.components },
+    includeExperienceOrchestration: true,
+    requestQueue
+  })
+
+  expect(result.components).toHaveLength(exoItems.components.length)
+  expect(result.components![0].sys.id).toBe('ct-0')
+})
+
+test('returns destination experienceTemplates fetched via cursor pagination', async () => {
+  const plainClient = makePlainClientMock()
+  const result = await getDestinationData({
+    client: mockClient,
+    plainClient,
+    spaceId: 'space-1',
+    environmentId: 'master',
+    sourceData: { experienceTemplates: exoSourceData.experienceTemplates },
+    includeExperienceOrchestration: true,
+    requestQueue
+  })
+
+  expect(result.experienceTemplates).toHaveLength(exoItems.experienceTemplates.length)
+  expect(result.experienceTemplates![0].sys.id).toBe('tmpl-0')
+})
+
+test('returns destination experienceFragments fetched via cursor pagination', async () => {
+  const plainClient = makePlainClientMock()
+  const result = await getDestinationData({
+    client: mockClient,
+    plainClient,
+    spaceId: 'space-1',
+    environmentId: 'master',
+    sourceData: { experienceFragments: exoSourceData.experienceFragments },
+    includeExperienceOrchestration: true,
+    requestQueue
+  })
+
+  expect(result.experienceFragments).toHaveLength(exoItems.experienceFragments.length)
+  expect(result.experienceFragments![0].sys.id).toBe('frag-0')
+})
+
+test('returns destination dataAssemblies fetched via cursor pagination', async () => {
+  const plainClient = makePlainClientMock()
+  const result = await getDestinationData({
+    client: mockClient,
+    plainClient,
+    spaceId: 'space-1',
+    environmentId: 'master',
+    sourceData: { dataAssemblies: exoSourceData.dataAssemblies },
+    includeExperienceOrchestration: true,
+    requestQueue
+  })
+
+  expect(result.dataAssemblies).toHaveLength(exoItems.dataAssemblies.length)
+  expect(result.dataAssemblies![0].sys.id).toBe('da-0')
+})
+
+test('returns destination experiences fetched via cursor pagination', async () => {
+  const plainClient = makePlainClientMock()
+  const result = await getDestinationData({
+    client: mockClient,
+    plainClient,
+    spaceId: 'space-1',
+    environmentId: 'master',
+    sourceData: { experiences: exoSourceData.experiences },
+    includeExperienceOrchestration: true,
+    requestQueue
+  })
+
+  expect(result.experiences).toHaveLength(exoItems.experiences.length)
+  expect(result.experiences![0].sys.id).toBe('exp-0')
+})
+
+test('returns empty arrays for all ExO entities when none exist in destination', async () => {
+  const emptyPlainClient = {
+    designToken: { getMany: jest.fn(() => Promise.resolve({ items: [] })) },
+    component: { getMany: jest.fn(() => Promise.resolve({ items: [] })) },
+    experienceTemplate: { getMany: jest.fn(() => Promise.resolve({ items: [] })) },
+    experienceFragment: { getMany: jest.fn(() => Promise.resolve({ items: [] })) },
+    dataAssembly: { getMany: jest.fn(() => Promise.resolve({ items: [] })) },
+    experience: { getMany: jest.fn(() => Promise.resolve({ items: [] })) }
+  }
+
+  const result = await getDestinationData({
+    client: mockClient,
+    plainClient: emptyPlainClient,
+    spaceId: 'space-1',
+    environmentId: 'master',
+    sourceData: exoSourceData,
+    includeExperienceOrchestration: true,
+    requestQueue
+  })
+
+  expect(result.designTokens).toHaveLength(0)
+  expect(result.components).toHaveLength(0)
+  expect(result.experienceTemplates).toHaveLength(0)
+  expect(result.experienceFragments).toHaveLength(0)
+  expect(result.dataAssemblies).toHaveLength(0)
+  expect(result.experiences).toHaveLength(0)
+})
+
+// ─── ExO fetches are gated on source content, like entries/assets/locales ────
+
+test('does not call any plainClient ExO methods when the source content has no ExO entities', async () => {
+  const plainClient = makePlainClientMock()
+
+  await getDestinationData({
+    client: mockClient,
+    plainClient,
+    spaceId: 'space-1',
+    environmentId: 'master',
+    sourceData: { contentTypes: [makeEntity('ct-x') as any] },
+    includeExperienceOrchestration: true,
+    requestQueue
+  })
+
+  expect(plainClient.designToken.getMany).not.toHaveBeenCalled()
+  expect(plainClient.component.getMany).not.toHaveBeenCalled()
+  expect(plainClient.experienceTemplate.getMany).not.toHaveBeenCalled()
+  expect(plainClient.experienceFragment.getMany).not.toHaveBeenCalled()
+  expect(plainClient.dataAssembly.getMany).not.toHaveBeenCalled()
+  expect(plainClient.experience.getMany).not.toHaveBeenCalled()
+})
+
+test('only fetches the ExO entity types actually present in source content', async () => {
+  const plainClient = makePlainClientMock()
+
+  const result = await getDestinationData({
+    client: mockClient,
+    plainClient,
+    spaceId: 'space-1',
+    environmentId: 'master',
+    sourceData: { designTokens: exoSourceData.designTokens },
+    includeExperienceOrchestration: true,
+    requestQueue
+  })
+
+  expect(plainClient.designToken.getMany).toHaveBeenCalled()
+  expect(plainClient.component.getMany).not.toHaveBeenCalled()
+  expect(plainClient.experienceTemplate.getMany).not.toHaveBeenCalled()
+  expect(plainClient.experienceFragment.getMany).not.toHaveBeenCalled()
+  expect(plainClient.dataAssembly.getMany).not.toHaveBeenCalled()
+  expect(plainClient.experience.getMany).not.toHaveBeenCalled()
+  expect(result.designTokens).toHaveLength(exoItems.designTokens.length)
+  expect(result.components).toEqual([])
+})
+
+// ─── Destination space without the ExO entitlement (AIS-141) ────────────────
+// A destination space without exoM1 403s on every ExO endpoint. This must not abort the
+// whole destination-data fetch, since the rest of the import (entries, assets, content
+// types, etc.) has nothing to do with ExO.
+
+// Mirrors the real CMA SDK error shape confirmed live against a space without exoM1 (AIS-141):
+// error.message is a JSON-stringified envelope, not a plain string.
+function makeExoEntitlementError() {
+  return new Error(JSON.stringify({
+    status: 403,
+    statusText: '',
+    message: 'Forbidden',
+    details: { reasons: 'exoM1 entitlement required' },
+    request: { url: 'https://api.contentful.com/spaces/space-1/environments/master/components' }
+  }))
+}
+
+function makeForbiddenPlainClientMock() {
+  const forbidden = jest.fn(() => Promise.reject(makeExoEntitlementError()))
+  return {
+    designToken: { getMany: forbidden },
+    component: { getMany: forbidden },
+    experienceTemplate: { getMany: forbidden },
+    experienceFragment: { getMany: forbidden },
+    dataAssembly: { getMany: forbidden },
+    experience: { getMany: forbidden }
+  }
+}
+
+test('does not abort destination-data fetch when the destination space lacks the ExO entitlement', async () => {
+  const plainClient = makeForbiddenPlainClientMock()
+  const onError = () => {}
+  logEmitter.on('error', onError)
+
+  let result
+  try {
+    result = await getDestinationData({
+      client: mockClient,
+      plainClient,
+      spaceId: 'space-1',
+      environmentId: 'master',
+      sourceData: exoSourceData,
+      includeExperienceOrchestration: true,
+      requestQueue
+    })
+  } finally {
+    logEmitter.off('error', onError)
+  }
+
+  expect(result.designTokens).toEqual([])
+  expect(result.components).toEqual([])
+  expect(result.experienceTemplates).toEqual([])
+  expect(result.experienceFragments).toEqual([])
+  expect(result.dataAssemblies).toEqual([])
+  expect(result.experiences).toEqual([])
+})
+
+test('logs once per ExO entity type as an error when the destination space lacks the ExO entitlement', async () => {
+  const plainClient = makeForbiddenPlainClientMock()
+  const errors: Error[] = []
+  const onError = (error: Error) => errors.push(error)
+  logEmitter.on('error', onError)
+
+  try {
+    await getDestinationData({
+      client: mockClient,
+      plainClient,
+      spaceId: 'space-1',
+      environmentId: 'master',
+      sourceData: exoSourceData,
+      includeExperienceOrchestration: true,
+      requestQueue
+    })
+  } finally {
+    logEmitter.off('error', onError)
+  }
+
+  expect(errors).toHaveLength(6)
+  expect(errors.some((e) => e.message.includes('design tokens') && e.message.includes('Experience Orchestration (ExO) is not enabled for this space'))).toBe(true)
+  expect(errors.some((e) => e.message.includes('components'))).toBe(true)
+  expect(errors.some((e) => e.message.includes('experience templates'))).toBe(true)
+  expect(errors.some((e) => e.message.includes('experience fragments'))).toBe(true)
+  expect(errors.some((e) => e.message.includes('data assemblies'))).toBe(true)
+  expect(errors.some((e) => e.message.includes('experiences'))).toBe(true)
+})
+
+test('translates the exoM1-entitlement 403 into a friendly message, not the raw JSON error blob', async () => {
+  const plainClient = makeForbiddenPlainClientMock()
+  const errors: Error[] = []
+  const onError = (error: Error) => errors.push(error)
+  logEmitter.on('error', onError)
+
+  try {
+    await getDestinationData({
+      client: mockClient,
+      plainClient,
+      spaceId: 'space-1',
+      environmentId: 'master',
+      sourceData: exoSourceData,
+      includeExperienceOrchestration: true,
+      requestQueue
+    })
+  } finally {
+    logEmitter.off('error', onError)
+  }
+
+  for (const error of errors) {
+    expect(error.message).toContain('Experience Orchestration (ExO) is not enabled for this space')
+    expect(error.message).not.toContain('exoM1 entitlement required')
+    expect(error.message).not.toContain('{"status":403')
+  }
+})
+
+test('leaves non-entitlement errors as-is instead of swallowing them into the friendly message', async () => {
+  const plainClient = {
+    ...makePlainClientMock(),
+    designToken: { getMany: jest.fn(() => Promise.reject(new Error('socket hang up'))) }
+  }
+  const errors: Error[] = []
+  const onError = (error: Error) => errors.push(error)
+  logEmitter.on('error', onError)
+
+  try {
+    await getDestinationData({
+      client: mockClient,
+      plainClient,
+      spaceId: 'space-1',
+      environmentId: 'master',
+      sourceData: { designTokens: exoSourceData.designTokens },
+      includeExperienceOrchestration: true,
+      requestQueue
+    })
+  } finally {
+    logEmitter.off('error', onError)
+  }
+
+  expect(errors).toHaveLength(1)
+  expect(errors[0].message).toContain('socket hang up')
+  expect(errors[0].message).not.toContain('Experience Orchestration (ExO) is not enabled for this space')
+})
+
+test('still fetches non-ExO destination content when the destination space lacks the ExO entitlement', async () => {
+  const plainClient = makeForbiddenPlainClientMock()
+  const onError = () => {}
+  logEmitter.on('error', onError)
+
+  let result
+  try {
+    result = await getDestinationData({
+      client: mockClient,
+      plainClient,
+      spaceId: 'space-1',
+      environmentId: 'master',
+      sourceData: { contentTypes: [makeEntity('ct-x') as any], ...exoSourceData },
+      includeExperienceOrchestration: true,
+      requestQueue
+    })
+  } finally {
+    logEmitter.off('error', onError)
+  }
+
+  expect(mockEnvironment.getContentTypes).toHaveBeenCalled()
+  expect(result.contentTypes).toHaveLength(1)
+})
+
+test('a non-entitlement error on one ExO type does not block the others from resolving', async () => {
+  const plainClient = {
+    ...makePlainClientMock(),
+    designToken: { getMany: jest.fn(() => Promise.reject(new Error('exoM1 entitlement required'))) }
+  }
+  const onError = () => {}
+  logEmitter.on('error', onError)
+
+  let result
+  try {
+    result = await getDestinationData({
+      client: mockClient,
+      plainClient,
+      spaceId: 'space-1',
+      environmentId: 'master',
+      sourceData: { designTokens: exoSourceData.designTokens, components: exoSourceData.components },
+      includeExperienceOrchestration: true,
+      requestQueue
+    })
+  } finally {
+    logEmitter.off('error', onError)
+  }
+
+  expect(result.designTokens).toEqual([])
+  expect(result.components).toHaveLength(exoItems.components.length)
+})
+
+// ─── Proactive entitlement check (AIS-141 / AIS-191 pattern) ────────────────
+// Composes with, and is nested inside, the content gate above: the entitlement check
+// only runs at all when source has at least one of the 5 exoM1-gated types, and its
+// "definitely missing" answer short-circuits those 5 in one shot instead of letting
+// each 403 independently. dataAssemblies is excluded — confirmed live (AIS-141) that
+// it isn't actually gated by exoM1 the same way, so it always fetches independently.
+
+function makePlainClientWithEntitlement(entitledResponse: () => Promise<any>) {
+  return {
+    ...makePlainClientMock(),
+    space: { get: jest.fn(() => Promise.resolve({ sys: { organization: { sys: { id: 'org-1' } } } })) },
+    raw: { get: jest.fn(entitledResponse) }
+  }
+}
+
+test('skips all exoM1-gated types with a single error when the entitlement check confirms it is missing', async () => {
+  const plainClient = makePlainClientWithEntitlement(() => Promise.resolve({ features: { exoM1: { value: false } } }))
+  const errors: Error[] = []
+  const onError = (error: Error) => errors.push(error)
+  logEmitter.on('error', onError)
+
+  let result
+  try {
+    result = await getDestinationData({
+      client: mockClient,
+      plainClient,
+      spaceId: 'space-1',
+      environmentId: 'master',
+      sourceData: { designTokens: exoSourceData.designTokens, components: exoSourceData.components, experiences: exoSourceData.experiences },
+      includeExperienceOrchestration: true,
+      requestQueue
+    })
+  } finally {
+    logEmitter.off('error', onError)
+  }
+
+  expect(plainClient.designToken.getMany).not.toHaveBeenCalled()
+  expect(plainClient.component.getMany).not.toHaveBeenCalled()
+  expect(plainClient.experience.getMany).not.toHaveBeenCalled()
+  expect(result.designTokens).toEqual([])
+  expect(result.components).toEqual([])
+  expect(result.experiences).toEqual([])
+  expect(errors).toHaveLength(1)
+  expect(errors[0].message).toContain('Experience Orchestration (ExO) is not enabled for this space')
+})
+
+test('still fetches dataAssemblies independently when the entitlement check confirms exoM1 is missing for the other types', async () => {
+  const plainClient = makePlainClientWithEntitlement(() => Promise.resolve({ features: { exoM1: { value: false } } }))
+  const onError = () => {}
+  logEmitter.on('error', onError)
+
+  let result
+  try {
+    result = await getDestinationData({
+      client: mockClient,
+      plainClient,
+      spaceId: 'space-1',
+      environmentId: 'master',
+      sourceData: { designTokens: exoSourceData.designTokens, dataAssemblies: exoSourceData.dataAssemblies },
+      includeExperienceOrchestration: true,
+      requestQueue
+    })
+  } finally {
+    logEmitter.off('error', onError)
+  }
+
+  expect(plainClient.designToken.getMany).not.toHaveBeenCalled()
+  expect(plainClient.dataAssembly.getMany).toHaveBeenCalled()
+  expect(result.dataAssemblies).toHaveLength(exoItems.dataAssemblies.length)
+})
+
+test('does not call the entitlement check at all when source has only dataAssemblies', async () => {
+  const plainClient = makePlainClientWithEntitlement(() => Promise.resolve({ features: { exoM1: { value: false } } }))
+
+  const result = await getDestinationData({
+    client: mockClient,
+    plainClient,
+    spaceId: 'space-1',
+    environmentId: 'master',
+    sourceData: { dataAssemblies: exoSourceData.dataAssemblies },
+    includeExperienceOrchestration: true,
+    requestQueue
+  })
+
+  expect(plainClient.space.get).not.toHaveBeenCalled()
+  expect(plainClient.dataAssembly.getMany).toHaveBeenCalled()
+  expect(result.dataAssemblies).toHaveLength(exoItems.dataAssemblies.length)
+})
+
+test('proceeds with the normal per-type fetches when the entitlement check confirms exoM1 is present', async () => {
+  const plainClient = makePlainClientWithEntitlement(() => Promise.resolve({ features: { exoM1: { value: true } } }))
+
+  const result = await getDestinationData({
+    client: mockClient,
+    plainClient,
+    spaceId: 'space-1',
+    environmentId: 'master',
+    sourceData: { designTokens: exoSourceData.designTokens },
+    includeExperienceOrchestration: true,
+    requestQueue
+  })
+
+  expect(plainClient.designToken.getMany).toHaveBeenCalled()
+  expect(result.designTokens).toHaveLength(exoItems.designTokens.length)
+})
+
+test('falls back to the per-type fetch-and-catch when the entitlement check itself is inconclusive', async () => {
+  const plainClient = {
+    ...makePlainClientMock(),
+    space: { get: jest.fn(() => Promise.reject(new Error('network error'))) },
+    raw: { get: jest.fn() }
+  }
+
+  const result = await getDestinationData({
+    client: mockClient,
+    plainClient,
+    spaceId: 'space-1',
+    environmentId: 'master',
+    sourceData: { designTokens: exoSourceData.designTokens },
+    includeExperienceOrchestration: true,
+    requestQueue
+  })
+
+  expect(plainClient.designToken.getMany).toHaveBeenCalled()
+  expect(result.designTokens).toHaveLength(exoItems.designTokens.length)
+})

--- a/test/unit/tasks/push/push-to-space-exo-sort-errors.test.ts
+++ b/test/unit/tasks/push/push-to-space-exo-sort-errors.test.ts
@@ -1,0 +1,123 @@
+import PQueue from 'p-queue'
+
+import { logEmitter } from 'contentful-batch-libs/dist/logging'
+
+import { PARENT_FOLDER_GROUP_IDS } from '../../../../lib/utils/import-exo-folders'
+
+// logEmitter is a plain node:events EventEmitter. Node treats 'error' as a special
+// event name and throws synchronously if it's emitted with no listener attached, so
+// register a no-op listener before any test exercises an error/log-and-continue path.
+logEmitter.on('error', () => {})
+
+jest.mock('../../../../lib/utils/sort-components', () => ({
+  __esModule: true,
+  default: jest.fn(() => {
+    throw new Error('malformed componentTree')
+  })
+}))
+jest.mock('../../../../lib/utils/sort-experience-fragments', () => ({
+  __esModule: true,
+  default: jest.fn(() => {
+    throw new Error('malformed slots')
+  })
+}))
+
+// Imported after the mocks above so push-to-space picks up the mocked sort modules.
+import pushToSpace from '../../../../lib/tasks/push-to-space/push-to-space'
+
+const baseSourceData = {
+  locales: [],
+  contentTypes: [],
+  assets: [],
+  editorInterfaces: [],
+  entries: [],
+  tags: [],
+  webhooks: []
+}
+
+const baseDestinationData = {}
+
+function makeClientMock() {
+  return {
+    getSpace: jest.fn(() => Promise.resolve({
+      getEnvironment: jest.fn(() => Promise.resolve({
+        getEditorInterfaceForContentType: jest.fn(() => Promise.resolve({ update: jest.fn() }))
+      })),
+      sys: { organization: { sys: { id: 'org-1' } } }
+    }))
+  }
+}
+
+function makePlainClientMock() {
+  return {
+    component: { upsert: jest.fn(), publish: jest.fn() },
+    experienceFragment: { upsert: jest.fn(), publish: jest.fn() },
+    conceptScheme: {
+      getMany: jest.fn(() => Promise.resolve({
+        items: Object.values(PARENT_FOLDER_GROUP_IDS).map((id) => ({
+          sys: { id, version: 1 },
+          prefLabel: { 'en-US': id },
+          concepts: []
+        }))
+      }))
+    }
+  }
+}
+
+let requestQueue: PQueue
+
+beforeEach(() => {
+  requestQueue = new PQueue({ interval: 1000, intervalCap: 1000 })
+})
+
+describe('Importing Components: setup-code failures', () => {
+  const entity: any = { sys: { id: 'ct-1', type: 'Component', version: 1 }, name: 'Hero' }
+
+  test('logs the sort failure via logEmitter and still aborts the run', async () => {
+    const plainClient = makePlainClientMock()
+    const emitSpy = jest.spyOn(logEmitter, 'emit')
+
+    await expect(pushToSpace({
+      sourceData: { ...baseSourceData, components: [entity] } as any,
+      destinationData: { ...baseDestinationData, components: [] },
+      client: makeClientMock(),
+      plainClient,
+      spaceId: 'space-1',
+      environmentId: 'master',
+      includeExperienceOrchestration: true,
+      requestQueue
+    }).run({ data: {} })).rejects.toThrow()
+
+    const errorCall = emitSpy.mock.calls.find((args) => args[0] === 'error')
+    expect(errorCall?.[1]).toBeInstanceOf(Error)
+    expect((errorCall?.[1] as Error).message).toBe('malformed componentTree')
+    expect(plainClient.component.upsert).not.toHaveBeenCalled()
+    emitSpy.mockRestore()
+  })
+})
+
+describe('Importing Experience Fragments: setup-code failures', () => {
+  const entity: any = { sys: { id: 'frag-1', type: 'ExperienceFragment', version: 1 }, name: 'Hero Fragment' }
+
+  test('logs the sort failure via logEmitter and still aborts the run', async () => {
+    const plainClient = makePlainClientMock()
+    const emitSpy = jest.spyOn(logEmitter, 'emit')
+
+    await expect(pushToSpace({
+      sourceData: { ...baseSourceData, experienceFragments: [entity] } as any,
+      destinationData: { ...baseDestinationData, experienceFragments: [] },
+      client: makeClientMock(),
+      plainClient,
+      spaceId: 'space-1',
+      environmentId: 'master',
+      includeExperienceOrchestration: true,
+      requestQueue
+    }).run({ data: {} })).rejects.toThrow()
+
+    const errorCall = emitSpy.mock.calls.find((args) => args[0] === 'error')
+    expect(errorCall?.[1]).toBeInstanceOf(Error)
+    expect((errorCall?.[1] as Error).message).toBe('malformed slots')
+    expect(plainClient.experienceFragment.upsert).not.toHaveBeenCalled()
+    emitSpy.mockRestore()
+  })
+})

--- a/test/unit/tasks/push/push-to-space-exo.test.ts
+++ b/test/unit/tasks/push/push-to-space-exo.test.ts
@@ -1,0 +1,1146 @@
+import PQueue from 'p-queue'
+
+import pushToSpace from '../../../../lib/tasks/push-to-space/push-to-space'
+import { logEmitter } from 'contentful-batch-libs/dist/logging'
+
+// logEmitter is a plain node:events EventEmitter. Node treats 'error' as a special
+// event name and throws synchronously if it's emitted with no listener attached, so
+// register a no-op listener before any test exercises an error/log-and-continue path.
+logEmitter.on('error', () => { })
+
+// Minimal base source data needed to satisfy the Listr tasks that always run
+const baseSourceData = {
+  locales: [],
+  contentTypes: [],
+  assets: [],
+  editorInterfaces: [],
+  entries: [],
+  tags: [],
+  webhooks: []
+}
+
+const baseDestinationData = {}
+
+function makeClientMock() {
+  return {
+    getSpace: jest.fn(() => Promise.resolve({
+      sys: { organization: { sys: { id: 'org-1' } } },
+      getEnvironment: jest.fn(() => Promise.resolve({
+        getEditorInterfaceForContentType: jest.fn(() => Promise.resolve({ update: jest.fn() }))
+      }))
+    }))
+  }
+}
+
+// Upsert/update mocks echo back the version from the payload (as the real API does on
+// both create and update) so downstream Publishing tasks see a realistic sys.version.
+function echoVersion(id: string) {
+  return jest.fn((_params: any, payload: any) => Promise.resolve({ sys: { id, version: payload.sys.version ?? 1 } }))
+}
+
+const ALL_PARENT_GROUP_IDS = [
+  'contentful.folder-group-designToken',
+  'contentful.folder-group-componentType',
+  'contentful.folder-group-template',
+  'contentful.folder-group-fragment',
+  'contentful.folder-group-experience',
+]
+
+function makePlainClientMock() {
+  return {
+    conceptScheme: {
+      getMany: jest.fn(() => Promise.resolve({
+        items: ALL_PARENT_GROUP_IDS.map((id) => ({ sys: { id, version: 1 }, concepts: [] }))
+      })),
+      patch: jest.fn(({ version }: any) => Promise.resolve({ sys: { version: version + 1 }, concepts: [] })),
+    },
+    designToken: {
+      create: jest.fn(() => Promise.resolve({ sys: { id: 'dt-1' } })),
+      upsert: echoVersion('dt-1')
+    },
+    concept: {
+      get: jest.fn(() => Promise.resolve({ sys: { id: 'folder-1', version: 0 }, metadata: { spaces: [] } })),
+      patch: jest.fn(() => Promise.resolve({})),
+    },
+    component: {
+      create: jest.fn(() => Promise.resolve({ sys: { id: 'ct-1' } })),
+      upsert: echoVersion('ct-1'),
+      publish: jest.fn(() => Promise.resolve({ sys: { id: 'ct-1' } })),
+      unpublish: jest.fn(() => Promise.resolve({ sys: { id: 'ct-1' } }))
+    },
+    experienceTemplate: {
+      create: jest.fn(() => Promise.resolve({ sys: { id: 'tmpl-1' } })),
+      upsert: echoVersion('tmpl-1'),
+      publish: jest.fn(() => Promise.resolve({ sys: { id: 'tmpl-1' } })),
+      unpublish: jest.fn(() => Promise.resolve({ sys: { id: 'tmpl-1' } }))
+    },
+    experienceFragment: {
+      create: jest.fn(() => Promise.resolve({ sys: { id: 'frag-1' } })),
+      upsert: echoVersion('frag-1'),
+      publish: jest.fn(() => Promise.resolve({ sys: { id: 'frag-1' } })),
+      unpublish: jest.fn(() => Promise.resolve({ sys: { id: 'frag-1' } }))
+    },
+    dataAssembly: {
+      update: echoVersion('da-1'),
+      create: jest.fn(() => Promise.resolve({ sys: { id: 'da-1' } })),
+      publish: jest.fn(() => Promise.resolve({ sys: { id: 'da-1' } })),
+      unpublish: jest.fn(() => Promise.resolve({ sys: { id: 'da-1' } }))
+    },
+    experience: {
+      create: jest.fn(() => Promise.resolve({ sys: { id: 'exp-1' } })),
+      upsert: echoVersion('exp-1'),
+      publish: jest.fn(() => Promise.resolve({ sys: { id: 'exp-1' } })),
+      unpublish: jest.fn(() => Promise.resolve({ sys: { id: 'exp-1' } }))
+    }
+  }
+}
+
+let requestQueue: PQueue
+
+beforeEach(() => {
+  requestQueue = new PQueue({ interval: 1000, intervalCap: 1000 })
+})
+
+// ─── Component ────────────────────────────────────────────────────────────
+
+describe('Importing Components', () => {
+  const entity: any = { sys: { id: 'ct-1', type: 'Component', version: 3 }, name: 'Hero' }
+
+  test('CREATE: calls upsert with id in sys when entity does not exist in destination', async () => {
+    const plainClient = makePlainClientMock()
+    await pushToSpace({
+      sourceData: { ...baseSourceData, components: [entity] } as any,
+      destinationData: { ...baseDestinationData, components: [] },
+      client: makeClientMock(),
+      plainClient,
+      spaceId: 'space-1',
+      environmentId: 'master',
+      includeExperienceOrchestration: true,
+      requestQueue
+    }).run({ data: {} })
+
+    expect(plainClient.component.upsert).toHaveBeenCalledTimes(1)
+    expect(plainClient.component.create).not.toHaveBeenCalled()
+    const [params, payload] = plainClient.component.upsert.mock.calls[0] as unknown as [any, any]
+    expect(params).toEqual({ spaceId: 'space-1', environmentId: 'master', componentId: 'ct-1' })
+    expect(payload.sys.id).toBe('ct-1')
+    expect(payload.sys.type).toBe('Component')
+    expect(payload.sys).not.toHaveProperty('version')
+    expect(payload.name).toBe('Hero')
+  })
+
+  test('UPDATE: calls upsert with destination sys.version when entity exists in destination', async () => {
+    const plainClient = makePlainClientMock()
+    const destinationEntity: any = { sys: { id: 'ct-1', type: 'Component', version: 7 } }
+    await pushToSpace({
+      sourceData: { ...baseSourceData, components: [entity] } as any,
+      destinationData: { ...baseDestinationData, components: [destinationEntity] },
+      client: makeClientMock(),
+      plainClient,
+      spaceId: 'space-1',
+      environmentId: 'master',
+      includeExperienceOrchestration: true,
+      requestQueue
+    }).run({ data: {} })
+
+    expect(plainClient.component.upsert).toHaveBeenCalledTimes(1)
+    const [params, payload] = plainClient.component.upsert.mock.calls[0] as unknown as [any, any]
+    expect(params).toEqual({ spaceId: 'space-1', environmentId: 'master', componentId: 'ct-1' })
+    expect(payload.sys.version).toBe(7)
+    expect(payload.name).toBe('Hero')
+  })
+
+  test('skips task when includeExperienceOrchestration is false', async () => {
+    const plainClient = makePlainClientMock()
+    await pushToSpace({
+      sourceData: { ...baseSourceData, components: [entity] } as any,
+      destinationData: baseDestinationData,
+      client: makeClientMock(),
+      plainClient,
+      spaceId: 'space-1',
+      environmentId: 'master',
+      includeExperienceOrchestration: false,
+      requestQueue
+    }).run({ data: {} })
+
+    expect(plainClient.component.upsert).not.toHaveBeenCalled()
+  })
+
+  test('attaches the entity to the error before emitting, and continues on failure', async () => {
+    const plainClient = makePlainClientMock()
+    const upsertError = new Error('422 validation failed')
+    plainClient.component.upsert = jest.fn((_params, _payload) => Promise.reject(upsertError))
+    const emitSpy = jest.spyOn(logEmitter, 'emit')
+
+    await expect(pushToSpace({
+      sourceData: { ...baseSourceData, components: [entity] } as any,
+      destinationData: { ...baseDestinationData, components: [] },
+      client: makeClientMock(),
+      plainClient,
+      spaceId: 'space-1',
+      environmentId: 'master',
+      includeExperienceOrchestration: true,
+      requestQueue
+    }).run({ data: {} })).resolves.not.toThrow()
+
+    const errorCall = emitSpy.mock.calls.find((args) => args[0] === 'error')
+    expect(errorCall?.[1]).toBe(upsertError)
+    expect((errorCall?.[1] as any).entity).toBe(entity)
+    emitSpy.mockRestore()
+  })
+})
+
+describe('Publishing Components', () => {
+  const publishedEntity: any = { sys: { id: 'ct-1', type: 'Component', version: 2, publishedVersion: 2 }, name: 'Hero' }
+  const draftEntity: any = { sys: { id: 'ct-1', type: 'Component', version: 3 }, name: 'Hero' }
+  const destinationEntity: any = { sys: { id: 'ct-1', type: 'Component', version: 7 } }
+
+  test('publishes an entity that was published in the source, at the destination version', async () => {
+    const plainClient = makePlainClientMock()
+    await pushToSpace({
+      sourceData: { ...baseSourceData, components: [publishedEntity] } as any,
+      destinationData: { ...baseDestinationData, components: [destinationEntity] },
+      client: makeClientMock(),
+      plainClient,
+      spaceId: 'space-1',
+      environmentId: 'master',
+      includeExperienceOrchestration: true,
+      requestQueue
+    }).run({ data: {} })
+
+    expect(plainClient.component.publish).toHaveBeenCalledTimes(1)
+    expect(plainClient.component.publish).toHaveBeenCalledWith(
+      { spaceId: 'space-1', environmentId: 'master', componentId: 'ct-1', version: 7 }
+    )
+  })
+
+  test('does not publish an entity that was draft in the source', async () => {
+    const plainClient = makePlainClientMock()
+    await pushToSpace({
+      sourceData: { ...baseSourceData, components: [draftEntity] } as any,
+      destinationData: { ...baseDestinationData, components: [destinationEntity] },
+      client: makeClientMock(),
+      plainClient,
+      spaceId: 'space-1',
+      environmentId: 'master',
+      includeExperienceOrchestration: true,
+      requestQueue
+    }).run({ data: {} })
+
+    expect(plainClient.component.publish).not.toHaveBeenCalled()
+  })
+
+  test('skips publishing when skipContentPublishing is set', async () => {
+    const plainClient = makePlainClientMock()
+    await pushToSpace({
+      sourceData: { ...baseSourceData, components: [publishedEntity] } as any,
+      destinationData: { ...baseDestinationData, components: [destinationEntity] },
+      client: makeClientMock(),
+      plainClient,
+      spaceId: 'space-1',
+      environmentId: 'master',
+      includeExperienceOrchestration: true,
+      skipContentPublishing: true,
+      requestQueue
+    }).run({ data: {} })
+
+    expect(plainClient.component.publish).not.toHaveBeenCalled()
+  })
+
+  test('logs and continues when publish fails, without throwing', async () => {
+    const plainClient = makePlainClientMock()
+    const publishError = new Error('422 validation failed')
+    plainClient.component.publish = jest.fn(() => Promise.reject(publishError))
+    const emitSpy = jest.spyOn(logEmitter, 'emit')
+
+    await expect(pushToSpace({
+      sourceData: { ...baseSourceData, components: [publishedEntity] } as any,
+      destinationData: { ...baseDestinationData, components: [destinationEntity] },
+      client: makeClientMock(),
+      plainClient,
+      spaceId: 'space-1',
+      environmentId: 'master',
+      includeExperienceOrchestration: true,
+      requestQueue
+    }).run({ data: {} })).resolves.not.toThrow()
+
+    const errorCall = emitSpy.mock.calls.find((args) => args[0] === 'error')
+    expect(errorCall?.[1]).toBe(publishError)
+    expect((errorCall?.[1] as any).entity.sys.id).toBe('ct-1')
+    emitSpy.mockRestore()
+  })
+})
+
+// ─── ExperienceTemplate ─────────────────────────────────────────────────────────────────
+
+describe('Importing Experience Templates', () => {
+  const entity: any = { sys: { id: 'tmpl-1', type: 'ExperienceTemplate', version: 2 }, name: 'Landing Page' }
+
+  test('CREATE: calls upsert with id in sys when entity does not exist in destination', async () => {
+    const plainClient = makePlainClientMock()
+    await pushToSpace({
+      sourceData: { ...baseSourceData, experienceTemplates: [entity] } as any,
+      destinationData: { ...baseDestinationData, experienceTemplates: [] },
+      client: makeClientMock(),
+      plainClient,
+      spaceId: 'space-1',
+      environmentId: 'master',
+      includeExperienceOrchestration: true,
+      requestQueue
+    }).run({ data: {} })
+
+    expect(plainClient.experienceTemplate.upsert).toHaveBeenCalledTimes(1)
+    expect(plainClient.experienceTemplate.create).not.toHaveBeenCalled()
+    const [params, payload] = plainClient.experienceTemplate.upsert.mock.calls[0] as unknown as [any, any]
+    expect(params).toEqual({ spaceId: 'space-1', environmentId: 'master', experienceTemplateId: 'tmpl-1' })
+    expect(payload.sys.id).toBe('tmpl-1')
+    expect(payload.sys.type).toBe('ExperienceTemplate')
+    expect(payload.sys).not.toHaveProperty('version')
+    expect(payload.name).toBe('Landing Page')
+  })
+
+  test('UPDATE: calls upsert with destination sys.version when entity exists in destination', async () => {
+    const plainClient = makePlainClientMock()
+    const destinationEntity: any = { sys: { id: 'tmpl-1', type: 'ExperienceTemplate', version: 5 } }
+    await pushToSpace({
+      sourceData: { ...baseSourceData, experienceTemplates: [entity] } as any,
+      destinationData: { ...baseDestinationData, experienceTemplates: [destinationEntity] },
+      client: makeClientMock(),
+      plainClient,
+      spaceId: 'space-1',
+      environmentId: 'master',
+      includeExperienceOrchestration: true,
+      requestQueue
+    }).run({ data: {} })
+
+    const [params, payload] = plainClient.experienceTemplate.upsert.mock.calls[0] as unknown as [any, any]
+    expect(params).toEqual({ spaceId: 'space-1', environmentId: 'master', experienceTemplateId: 'tmpl-1' })
+    expect(payload.sys.version).toBe(5)
+    expect(payload.name).toBe('Landing Page')
+  })
+
+  test('attaches the entity to the error before emitting, and continues on failure', async () => {
+    const plainClient = makePlainClientMock()
+    const upsertError = new Error('422 validation failed')
+    plainClient.experienceTemplate.upsert = jest.fn((_params, _payload) => Promise.reject(upsertError))
+    const emitSpy = jest.spyOn(logEmitter, 'emit')
+
+    await expect(pushToSpace({
+      sourceData: { ...baseSourceData, experienceTemplates: [entity] } as any,
+      destinationData: { ...baseDestinationData, experienceTemplates: [] },
+      client: makeClientMock(),
+      plainClient,
+      spaceId: 'space-1',
+      environmentId: 'master',
+      includeExperienceOrchestration: true,
+      requestQueue
+    }).run({ data: {} })).resolves.not.toThrow()
+
+    const errorCall = emitSpy.mock.calls.find((args) => args[0] === 'error')
+    expect(errorCall?.[1]).toBe(upsertError)
+    expect((errorCall?.[1] as any).entity).toBe(entity)
+    emitSpy.mockRestore()
+  })
+})
+
+describe('Publishing Experience Templates', () => {
+  const publishedEntity: any = { sys: { id: 'tmpl-1', type: 'ExperienceTemplate', version: 1, publishedVersion: 1 }, name: 'Landing Page' }
+  const draftEntity: any = { sys: { id: 'tmpl-1', type: 'ExperienceTemplate', version: 2 }, name: 'Landing Page' }
+  const destinationEntity: any = { sys: { id: 'tmpl-1', type: 'ExperienceTemplate', version: 5 } }
+
+  test('publishes an entity that was published in the source, at the destination version', async () => {
+    const plainClient = makePlainClientMock()
+    await pushToSpace({
+      sourceData: { ...baseSourceData, experienceTemplates: [publishedEntity] } as any,
+      destinationData: { ...baseDestinationData, experienceTemplates: [destinationEntity] },
+      client: makeClientMock(),
+      plainClient,
+      spaceId: 'space-1',
+      environmentId: 'master',
+      includeExperienceOrchestration: true,
+      requestQueue
+    }).run({ data: {} })
+
+    expect(plainClient.experienceTemplate.publish).toHaveBeenCalledWith(
+      { spaceId: 'space-1', environmentId: 'master', experienceTemplateId: 'tmpl-1', version: 5 }
+    )
+  })
+
+  test('does not publish an entity that was draft in the source', async () => {
+    const plainClient = makePlainClientMock()
+    await pushToSpace({
+      sourceData: { ...baseSourceData, experienceTemplates: [draftEntity] } as any,
+      destinationData: { ...baseDestinationData, experienceTemplates: [destinationEntity] },
+      client: makeClientMock(),
+      plainClient,
+      spaceId: 'space-1',
+      environmentId: 'master',
+      includeExperienceOrchestration: true,
+      requestQueue
+    }).run({ data: {} })
+
+    expect(plainClient.experienceTemplate.publish).not.toHaveBeenCalled()
+  })
+
+  test('logs and continues when publish fails, without throwing', async () => {
+    const plainClient = makePlainClientMock()
+    const publishError = new Error('422 validation failed')
+    plainClient.experienceTemplate.publish = jest.fn(() => Promise.reject(publishError))
+    const emitSpy = jest.spyOn(logEmitter, 'emit')
+
+    await expect(pushToSpace({
+      sourceData: { ...baseSourceData, experienceTemplates: [publishedEntity] } as any,
+      destinationData: { ...baseDestinationData, experienceTemplates: [destinationEntity] },
+      client: makeClientMock(),
+      plainClient,
+      spaceId: 'space-1',
+      environmentId: 'master',
+      includeExperienceOrchestration: true,
+      requestQueue
+    }).run({ data: {} })).resolves.not.toThrow()
+
+    const errorCall = emitSpy.mock.calls.find((args) => args[0] === 'error')
+    expect(errorCall?.[1]).toBe(publishError)
+    expect((errorCall?.[1] as any).entity.sys.id).toBe('tmpl-1')
+    emitSpy.mockRestore()
+  })
+})
+
+// ─── ExperienceFragment ─────────────────────────────────────────────────────────────────
+
+describe('Importing Experience Fragments', () => {
+  const component = { sys: { type: 'ResourceLink', linkType: 'Contentful:Component', urn: 'crn:contentful:::experience:spaces/$self/environments/$self/components/hero' } }
+  const entity: any = { sys: { id: 'frag-1', type: 'ExperienceFragment', version: 1, component }, name: 'Hero Fragment' }
+
+  test('CREATE: calls upsert with id in sys and component hoisted from sys', async () => {
+    const plainClient = makePlainClientMock()
+    await pushToSpace({
+      sourceData: { ...baseSourceData, experienceFragments: [entity] } as any,
+      destinationData: { ...baseDestinationData, experienceFragments: [] },
+      client: makeClientMock(),
+      plainClient,
+      spaceId: 'space-1',
+      environmentId: 'master',
+      includeExperienceOrchestration: true,
+      requestQueue
+    }).run({ data: {} })
+
+    expect(plainClient.experienceFragment.upsert).toHaveBeenCalledTimes(1)
+    expect(plainClient.experienceFragment.create).not.toHaveBeenCalled()
+    const [params, payload] = plainClient.experienceFragment.upsert.mock.calls[0] as unknown as [any, any]
+    expect(params).toEqual({ spaceId: 'space-1', environmentId: 'master', experienceFragmentId: 'frag-1' })
+    expect(payload.sys.id).toBe('frag-1')
+    expect(payload.sys.type).toBe('ExperienceFragment')
+    expect(payload.sys).not.toHaveProperty('version')
+    expect(payload.component).toEqual(component)
+    expect(payload.name).toBe('Hero Fragment')
+  })
+
+  test('UPDATE: calls upsert with destination sys.version and omits component (once an ExperienceFragment is created, its component cannot be changed to a different component)', async () => {
+    const plainClient = makePlainClientMock()
+    const destinationEntity: any = { sys: { id: 'frag-1', type: 'ExperienceFragment', version: 4 } }
+    await pushToSpace({
+      sourceData: { ...baseSourceData, experienceFragments: [entity] } as any,
+      destinationData: { ...baseDestinationData, experienceFragments: [destinationEntity] },
+      client: makeClientMock(),
+      plainClient,
+      spaceId: 'space-1',
+      environmentId: 'master',
+      includeExperienceOrchestration: true,
+      requestQueue
+    }).run({ data: {} })
+
+    const [params, payload] = plainClient.experienceFragment.upsert.mock.calls[0] as unknown as [any, any]
+    expect(params).toEqual({ spaceId: 'space-1', environmentId: 'master', experienceFragmentId: 'frag-1' })
+    expect(payload.sys.version).toBe(4)
+    expect(payload).not.toHaveProperty('component')
+  })
+
+  test('attaches the entity to the error before emitting, and continues on failure', async () => {
+    const plainClient = makePlainClientMock()
+    const upsertError = new Error('422 validation failed')
+    plainClient.experienceFragment.upsert = jest.fn((_params, _payload) => Promise.reject(upsertError))
+    const emitSpy = jest.spyOn(logEmitter, 'emit')
+
+    await expect(pushToSpace({
+      sourceData: { ...baseSourceData, experienceFragments: [entity] } as any,
+      destinationData: { ...baseDestinationData, experienceFragments: [] },
+      client: makeClientMock(),
+      plainClient,
+      spaceId: 'space-1',
+      environmentId: 'master',
+      includeExperienceOrchestration: true,
+      requestQueue
+    }).run({ data: {} })).resolves.not.toThrow()
+
+    const errorCall = emitSpy.mock.calls.find((args) => args[0] === 'error')
+    expect(errorCall?.[1]).toBe(upsertError)
+    expect((errorCall?.[1] as any).entity).toBe(entity)
+    emitSpy.mockRestore()
+  })
+})
+
+describe('Publishing Experience Fragments', () => {
+  const publishedEntity: any = { sys: { id: 'frag-1', type: 'ExperienceFragment', version: 1, publishedVersion: 1 }, name: 'Hero Fragment' }
+  const draftEntity: any = { sys: { id: 'frag-1', type: 'ExperienceFragment', version: 1 }, name: 'Hero Fragment' }
+  const destinationEntity: any = { sys: { id: 'frag-1', type: 'ExperienceFragment', version: 4 } }
+
+  test('publishes an entity that was published in the source, at the destination version', async () => {
+    const plainClient = makePlainClientMock()
+    await pushToSpace({
+      sourceData: { ...baseSourceData, experienceFragments: [publishedEntity] } as any,
+      destinationData: { ...baseDestinationData, experienceFragments: [destinationEntity] },
+      client: makeClientMock(),
+      plainClient,
+      spaceId: 'space-1',
+      environmentId: 'master',
+      includeExperienceOrchestration: true,
+      requestQueue
+    }).run({ data: {} })
+
+    expect(plainClient.experienceFragment.publish).toHaveBeenCalledWith(
+      { spaceId: 'space-1', environmentId: 'master', experienceFragmentId: 'frag-1', version: 4 }
+    )
+  })
+
+  test('does not publish an entity that was draft in the source', async () => {
+    const plainClient = makePlainClientMock()
+    await pushToSpace({
+      sourceData: { ...baseSourceData, experienceFragments: [draftEntity] } as any,
+      destinationData: { ...baseDestinationData, experienceFragments: [destinationEntity] },
+      client: makeClientMock(),
+      plainClient,
+      spaceId: 'space-1',
+      environmentId: 'master',
+      includeExperienceOrchestration: true,
+      requestQueue
+    }).run({ data: {} })
+
+    expect(plainClient.experienceFragment.publish).not.toHaveBeenCalled()
+  })
+
+  test('logs and continues when publish fails, without throwing', async () => {
+    const plainClient = makePlainClientMock()
+    const publishError = new Error('422 validation failed')
+    plainClient.experienceFragment.publish = jest.fn(() => Promise.reject(publishError))
+    const emitSpy = jest.spyOn(logEmitter, 'emit')
+
+    await expect(pushToSpace({
+      sourceData: { ...baseSourceData, experienceFragments: [publishedEntity] } as any,
+      destinationData: { ...baseDestinationData, experienceFragments: [destinationEntity] },
+      client: makeClientMock(),
+      plainClient,
+      spaceId: 'space-1',
+      environmentId: 'master',
+      includeExperienceOrchestration: true,
+      requestQueue
+    }).run({ data: {} })).resolves.not.toThrow()
+
+    const errorCall = emitSpy.mock.calls.find((args) => args[0] === 'error')
+    expect(errorCall?.[1]).toBe(publishError)
+    expect((errorCall?.[1] as any).entity.sys.id).toBe('frag-1')
+    emitSpy.mockRestore()
+  })
+})
+
+// ─── DataAssembly ─────────────────────────────────────────────────────────────
+
+describe('Importing Data Assemblies', () => {
+  const entity: any = { sys: { id: 'da-1', type: 'DataAssembly', version: 2, dataType: [{ id: 'headline', name: 'Headline', type: 'Symbol' }] }, name: 'My Assembly' }
+
+  test('CREATE: calls dataAssembly.update with version 0 to preserve id when entity does not exist in destination', async () => {
+    const plainClient = makePlainClientMock()
+    await pushToSpace({
+      sourceData: { ...baseSourceData, dataAssemblies: [entity] } as any,
+      destinationData: { ...baseDestinationData, dataAssemblies: [] },
+      client: makeClientMock(),
+      plainClient,
+      spaceId: 'space-1',
+      environmentId: 'master',
+      includeExperienceOrchestration: true,
+      requestQueue
+    }).run({ data: {} })
+
+    expect(plainClient.dataAssembly.update).toHaveBeenCalledTimes(1)
+    expect(plainClient.dataAssembly.create).not.toHaveBeenCalled()
+    const [params, payload] = plainClient.dataAssembly.update.mock.calls[0] as unknown as [any, any]
+    expect(params).toEqual({ spaceId: 'space-1', environmentId: 'master', dataAssemblyId: 'da-1' })
+    expect(payload.sys.id).toBe('da-1')
+    expect(payload.sys.type).toBe('DataAssembly')
+    expect(payload.sys.version).toBe(0)
+    expect(payload.sys.dataType).toEqual(entity.sys.dataType)
+    expect(payload.name).toBe('My Assembly')
+  })
+
+  test('UPDATE: calls dataAssembly.update (not create) with destination sys.version when entity exists', async () => {
+    const plainClient = makePlainClientMock()
+    const destinationEntity: any = { sys: { id: 'da-1', type: 'DataAssembly', version: 9 } }
+    await pushToSpace({
+      sourceData: { ...baseSourceData, dataAssemblies: [entity] } as any,
+      destinationData: { ...baseDestinationData, dataAssemblies: [destinationEntity] },
+      client: makeClientMock(),
+      plainClient,
+      spaceId: 'space-1',
+      environmentId: 'master',
+      includeExperienceOrchestration: true,
+      requestQueue
+    }).run({ data: {} })
+
+    expect(plainClient.dataAssembly.update).toHaveBeenCalledTimes(1)
+    expect(plainClient.dataAssembly.create).not.toHaveBeenCalled()
+    const [params, payload] = plainClient.dataAssembly.update.mock.calls[0] as unknown as [any, any]
+    expect(params).toEqual({ spaceId: 'space-1', environmentId: 'master', dataAssemblyId: 'da-1' })
+    expect(payload.sys.version).toBe(9)
+    expect(payload.name).toBe('My Assembly')
+  })
+
+  test('UPDATE: strips server-managed sys fields from a published source entity', async () => {
+    const plainClient = makePlainClientMock()
+    const publishedEntity: any = {
+      sys: {
+        id: 'da-1',
+        type: 'DataAssembly',
+        version: 3,
+        dataType: [{ id: 'headline', name: 'Headline', type: 'Symbol' }],
+        publishedVersion: 2,
+        publishedAt: '2026-01-01T00:00:00.000Z',
+        publishedCounter: 1,
+        createdAt: '2026-01-01T00:00:00.000Z',
+        createdBy: { sys: { type: 'Link', linkType: 'User', id: 'user-1' } }
+      },
+      name: 'My Assembly'
+    }
+    const destinationEntity: any = { sys: { id: 'da-1', type: 'DataAssembly', version: 9 } }
+    await pushToSpace({
+      sourceData: { ...baseSourceData, dataAssemblies: [publishedEntity] } as any,
+      destinationData: { ...baseDestinationData, dataAssemblies: [destinationEntity] },
+      client: makeClientMock(),
+      plainClient,
+      spaceId: 'space-1',
+      environmentId: 'master',
+      includeExperienceOrchestration: true,
+      requestQueue
+    }).run({ data: {} })
+
+    const [, payload] = plainClient.dataAssembly.update.mock.calls[0] as unknown as [any, any]
+    expect(payload.sys).toEqual({ id: 'da-1', type: 'DataAssembly', dataType: publishedEntity.sys.dataType, version: 9 })
+  })
+
+  test('attaches the entity to the error before emitting, and continues on failure', async () => {
+    const plainClient = makePlainClientMock()
+    const updateError = new Error('422 validation failed')
+    plainClient.dataAssembly.update = jest.fn((_params, _payload) => Promise.reject(updateError))
+    const emitSpy = jest.spyOn(logEmitter, 'emit')
+
+    await expect(pushToSpace({
+      sourceData: { ...baseSourceData, dataAssemblies: [entity] } as any,
+      destinationData: { ...baseDestinationData, dataAssemblies: [] },
+      client: makeClientMock(),
+      plainClient,
+      spaceId: 'space-1',
+      environmentId: 'master',
+      includeExperienceOrchestration: true,
+      requestQueue
+    }).run({ data: {} })).resolves.not.toThrow()
+
+    const errorCall = emitSpy.mock.calls.find((args) => args[0] === 'error')
+    expect(errorCall?.[1]).toBe(updateError)
+    expect((errorCall?.[1] as any).entity).toBe(entity)
+    emitSpy.mockRestore()
+  })
+})
+
+describe('Publishing Data Assemblies', () => {
+  const publishedEntity: any = { sys: { id: 'da-1', type: 'DataAssembly', version: 2, publishedVersion: 2, dataType: [{ id: 'headline', name: 'Headline', type: 'Symbol' }] }, name: 'My Assembly' }
+  const draftEntity: any = { sys: { id: 'da-1', type: 'DataAssembly', version: 2, dataType: [{ id: 'headline', name: 'Headline', type: 'Symbol' }] }, name: 'My Assembly' }
+  const destinationEntity: any = { sys: { id: 'da-1', type: 'DataAssembly', version: 9 } }
+
+  test('publishes an entity that was published in the source, at the destination version', async () => {
+    const plainClient = makePlainClientMock()
+    await pushToSpace({
+      sourceData: { ...baseSourceData, dataAssemblies: [publishedEntity] } as any,
+      destinationData: { ...baseDestinationData, dataAssemblies: [destinationEntity] },
+      client: makeClientMock(),
+      plainClient,
+      spaceId: 'space-1',
+      environmentId: 'master',
+      includeExperienceOrchestration: true,
+      requestQueue
+    }).run({ data: {} })
+
+    expect(plainClient.dataAssembly.publish).toHaveBeenCalledWith(
+      { spaceId: 'space-1', environmentId: 'master', dataAssemblyId: 'da-1', version: 9 }
+    )
+  })
+
+  test('does not publish an entity that was draft in the source', async () => {
+    const plainClient = makePlainClientMock()
+    await pushToSpace({
+      sourceData: { ...baseSourceData, dataAssemblies: [draftEntity] } as any,
+      destinationData: { ...baseDestinationData, dataAssemblies: [destinationEntity] },
+      client: makeClientMock(),
+      plainClient,
+      spaceId: 'space-1',
+      environmentId: 'master',
+      includeExperienceOrchestration: true,
+      requestQueue
+    }).run({ data: {} })
+
+    expect(plainClient.dataAssembly.publish).not.toHaveBeenCalled()
+  })
+
+  test('logs and continues when publish fails, without throwing', async () => {
+    const plainClient = makePlainClientMock()
+    const publishError = new Error('422 validation failed')
+    plainClient.dataAssembly.publish = jest.fn(() => Promise.reject(publishError))
+    const emitSpy = jest.spyOn(logEmitter, 'emit')
+
+    await expect(pushToSpace({
+      sourceData: { ...baseSourceData, dataAssemblies: [publishedEntity] } as any,
+      destinationData: { ...baseDestinationData, dataAssemblies: [destinationEntity] },
+      client: makeClientMock(),
+      plainClient,
+      spaceId: 'space-1',
+      environmentId: 'master',
+      includeExperienceOrchestration: true,
+      requestQueue
+    }).run({ data: {} })).resolves.not.toThrow()
+
+    const errorCall = emitSpy.mock.calls.find((args) => args[0] === 'error')
+    expect(errorCall?.[1]).toBe(publishError)
+    expect((errorCall?.[1] as any).entity.sys.id).toBe('da-1')
+    emitSpy.mockRestore()
+  })
+})
+
+// ─── DesignToken ──────────────────────────────────────────────────────────────
+
+describe('Importing Design Tokens', () => {
+  const entity: any = { sys: { id: 'dt-1', type: 'DesignToken', version: 2 }, name: 'Primary Blue', type: 'DTCG.Color' }
+
+  test('CREATE: calls upsert with id in sys when entity does not exist in destination', async () => {
+    const plainClient = makePlainClientMock()
+    await pushToSpace({
+      sourceData: { ...baseSourceData, designTokens: [entity] } as any,
+      destinationData: { ...baseDestinationData, designTokens: [] },
+      client: makeClientMock(),
+      plainClient,
+      spaceId: 'space-1',
+      environmentId: 'master',
+      includeExperienceOrchestration: true,
+      requestQueue
+    }).run({ data: {} })
+
+    expect(plainClient.designToken.upsert).toHaveBeenCalledTimes(1)
+    expect(plainClient.designToken.create).not.toHaveBeenCalled()
+    const [params, payload] = plainClient.designToken.upsert.mock.calls[0] as unknown as [any, any]
+    expect(params).toEqual({ spaceId: 'space-1', environmentId: 'master', designTokenId: 'dt-1' })
+    expect(payload.sys.id).toBe('dt-1')
+    expect(payload.sys.type).toBe('DesignToken')
+    expect(payload.sys).not.toHaveProperty('version')
+    expect(payload.name).toBe('Primary Blue')
+    expect(payload.type).toBe('DTCG.Color')
+  })
+
+  test('UPDATE: calls upsert with destination sys.version when entity exists in destination', async () => {
+    const plainClient = makePlainClientMock()
+    const destinationEntity: any = { sys: { id: 'dt-1', type: 'DesignToken', version: 7 } }
+    await pushToSpace({
+      sourceData: { ...baseSourceData, designTokens: [entity] } as any,
+      destinationData: { ...baseDestinationData, designTokens: [destinationEntity] },
+      client: makeClientMock(),
+      plainClient,
+      spaceId: 'space-1',
+      environmentId: 'master',
+      includeExperienceOrchestration: true,
+      requestQueue
+    }).run({ data: {} })
+
+    expect(plainClient.designToken.upsert).toHaveBeenCalledTimes(1)
+    const [params, payload] = plainClient.designToken.upsert.mock.calls[0] as unknown as [any, any]
+    expect(params).toEqual({ spaceId: 'space-1', environmentId: 'master', designTokenId: 'dt-1' })
+    expect(payload.sys.version).toBe(7)
+    expect(payload.name).toBe('Primary Blue')
+  })
+
+  test('skips task when includeExperienceOrchestration is false', async () => {
+    const plainClient = makePlainClientMock()
+    await pushToSpace({
+      sourceData: { ...baseSourceData, designTokens: [entity] } as any,
+      destinationData: baseDestinationData,
+      client: makeClientMock(),
+      plainClient,
+      spaceId: 'space-1',
+      environmentId: 'master',
+      includeExperienceOrchestration: false,
+      requestQueue
+    }).run({ data: {} })
+
+    expect(plainClient.designToken.upsert).not.toHaveBeenCalled()
+  })
+
+  test('attaches the entity to the error before emitting, and continues on failure', async () => {
+    const plainClient = makePlainClientMock()
+    const upsertError = new Error('422 validation failed')
+    plainClient.designToken.upsert = jest.fn((_params, _payload) => Promise.reject(upsertError))
+    const emitSpy = jest.spyOn(logEmitter, 'emit')
+
+    await expect(pushToSpace({
+      sourceData: { ...baseSourceData, designTokens: [entity] } as any,
+      destinationData: { ...baseDestinationData, designTokens: [] },
+      client: makeClientMock(),
+      plainClient,
+      spaceId: 'space-1',
+      environmentId: 'master',
+      includeExperienceOrchestration: true,
+      requestQueue
+    }).run({ data: {} })).resolves.not.toThrow()
+
+    const errorCall = emitSpy.mock.calls.find((args) => args[0] === 'error')
+    expect(errorCall?.[1]).toBe(upsertError)
+    expect((errorCall?.[1] as any).entity).toBe(entity)
+    emitSpy.mockRestore()
+  })
+})
+
+// ─── Experience ───────────────────────────────────────────────────────────────
+
+describe('Importing Experiences', () => {
+  const experienceTemplate = { sys: { type: 'ResourceLink', linkType: 'Contentful:ExperienceTemplate', urn: 'crn:contentful:::experience:spaces/$self/environments/$self/experienceTemplates/press-release' } }
+  const entity: any = { sys: { id: 'exp-1', type: 'Experience', version: 1, experienceTemplate }, name: 'My Experience' }
+
+  test('CREATE: calls upsert with id in sys and experienceTemplate hoisted from sys', async () => {
+    const plainClient = makePlainClientMock()
+    await pushToSpace({
+      sourceData: { ...baseSourceData, experiences: [entity] } as any,
+      destinationData: { ...baseDestinationData, experiences: [] },
+      client: makeClientMock(),
+      plainClient,
+      spaceId: 'space-1',
+      environmentId: 'master',
+      includeExperienceOrchestration: true,
+      requestQueue
+    }).run({ data: {} })
+
+    expect(plainClient.experience.upsert).toHaveBeenCalledTimes(1)
+    expect(plainClient.experience.create).not.toHaveBeenCalled()
+    const [params, payload] = plainClient.experience.upsert.mock.calls[0] as unknown as [any, any]
+    expect(params).toEqual({ spaceId: 'space-1', environmentId: 'master', experienceId: 'exp-1' })
+    expect(payload.sys.id).toBe('exp-1')
+    expect(payload.sys.type).toBe('Experience')
+    expect(payload.sys).not.toHaveProperty('version')
+    expect(payload.experienceTemplate).toEqual(experienceTemplate)
+    expect(payload.name).toBe('My Experience')
+  })
+
+  test('UPDATE: calls upsert with destination sys.version and omits experienceTemplate (once an Experience is created, its experienceTemplate cannot be changed to a different experienceTemplate)', async () => {
+    const plainClient = makePlainClientMock()
+    const destinationEntity: any = { sys: { id: 'exp-1', type: 'Experience', version: 6 } }
+    await pushToSpace({
+      sourceData: { ...baseSourceData, experiences: [entity] } as any,
+      destinationData: { ...baseDestinationData, experiences: [destinationEntity] },
+      client: makeClientMock(),
+      plainClient,
+      spaceId: 'space-1',
+      environmentId: 'master',
+      includeExperienceOrchestration: true,
+      requestQueue
+    }).run({ data: {} })
+
+    const [params, payload] = plainClient.experience.upsert.mock.calls[0] as unknown as [any, any]
+    expect(params).toEqual({ spaceId: 'space-1', environmentId: 'master', experienceId: 'exp-1' })
+    expect(payload.sys.version).toBe(6)
+    expect(payload).not.toHaveProperty('experienceTemplate')
+    expect(payload.name).toBe('My Experience')
+  })
+
+  test('attaches the entity to the error before emitting, and continues on failure', async () => {
+    const plainClient = makePlainClientMock()
+    const upsertError = new Error('422 validation failed')
+    plainClient.experience.upsert = jest.fn((_params, _payload) => Promise.reject(upsertError))
+    const emitSpy = jest.spyOn(logEmitter, 'emit')
+
+    await expect(pushToSpace({
+      sourceData: { ...baseSourceData, experiences: [entity] } as any,
+      destinationData: { ...baseDestinationData, experiences: [] },
+      client: makeClientMock(),
+      plainClient,
+      spaceId: 'space-1',
+      environmentId: 'master',
+      includeExperienceOrchestration: true,
+      requestQueue
+    }).run({ data: {} })).resolves.not.toThrow()
+
+    const errorCall = emitSpy.mock.calls.find((args) => args[0] === 'error')
+    expect(errorCall?.[1]).toBe(upsertError)
+    expect((errorCall?.[1] as any).entity).toBe(entity)
+    emitSpy.mockRestore()
+  })
+})
+
+describe('Publishing Experiences', () => {
+  const experienceTemplate = { sys: { type: 'ResourceLink', linkType: 'Contentful:ExperienceTemplate', urn: 'crn:contentful:::experience:spaces/$self/environments/$self/experienceTemplates/press-release' } }
+  const publishedEntity: any = { sys: { id: 'exp-1', type: 'Experience', version: 1, publishedVersion: 1, experienceTemplate }, name: 'My Experience' }
+  const draftEntity: any = { sys: { id: 'exp-1', type: 'Experience', version: 1, experienceTemplate }, name: 'My Experience' }
+  const destinationEntity: any = { sys: { id: 'exp-1', type: 'Experience', version: 6 } }
+
+  test('publishes an entity that was published in the source, at the destination version', async () => {
+    const plainClient = makePlainClientMock()
+    await pushToSpace({
+      sourceData: { ...baseSourceData, experiences: [publishedEntity] } as any,
+      destinationData: { ...baseDestinationData, experiences: [destinationEntity] },
+      client: makeClientMock(),
+      plainClient,
+      spaceId: 'space-1',
+      environmentId: 'master',
+      includeExperienceOrchestration: true,
+      requestQueue
+    }).run({ data: {} })
+
+    expect(plainClient.experience.publish).toHaveBeenCalledWith(
+      { spaceId: 'space-1', environmentId: 'master', experienceId: 'exp-1', version: 6 }
+    )
+  })
+
+  test('does not publish an entity that was draft in the source', async () => {
+    const plainClient = makePlainClientMock()
+    await pushToSpace({
+      sourceData: { ...baseSourceData, experiences: [draftEntity] } as any,
+      destinationData: { ...baseDestinationData, experiences: [destinationEntity] },
+      client: makeClientMock(),
+      plainClient,
+      spaceId: 'space-1',
+      environmentId: 'master',
+      includeExperienceOrchestration: true,
+      requestQueue
+    }).run({ data: {} })
+
+    expect(plainClient.experience.publish).not.toHaveBeenCalled()
+  })
+
+  test('does not attempt to publish when no experiences are present in the import payload', async () => {
+    const plainClient = makePlainClientMock()
+    await pushToSpace({
+      sourceData: { ...baseSourceData, experiences: [] } as any,
+      destinationData: { ...baseDestinationData, experiences: [] },
+      client: makeClientMock(),
+      plainClient,
+      spaceId: 'space-1',
+      environmentId: 'master',
+      includeExperienceOrchestration: true,
+      requestQueue
+    }).run({ data: {} })
+
+    expect(plainClient.experience.publish).not.toHaveBeenCalled()
+  })
+
+  test('logs and continues when publish fails, without throwing', async () => {
+    const plainClient = makePlainClientMock()
+    const publishError = new Error('422 validation failed')
+    plainClient.experience.publish = jest.fn(() => Promise.reject(publishError))
+    const emitSpy = jest.spyOn(logEmitter, 'emit')
+
+    await expect(pushToSpace({
+      sourceData: { ...baseSourceData, experiences: [publishedEntity] } as any,
+      destinationData: { ...baseDestinationData, experiences: [destinationEntity] },
+      client: makeClientMock(),
+      plainClient,
+      spaceId: 'space-1',
+      environmentId: 'master',
+      includeExperienceOrchestration: true,
+      requestQueue
+    }).run({ data: {} })).resolves.not.toThrow()
+
+    const errorCall = emitSpy.mock.calls.find((args) => args[0] === 'error')
+    expect(errorCall?.[1]).toBe(publishError)
+    expect((errorCall?.[1] as any).entity.sys.id).toBe('exp-1')
+    emitSpy.mockRestore()
+  })
+})
+
+// ─── Unpublishing ───────────────────────────────────────────────────────────────────────
+// Covers the fix for the bug where a source-side unpublish never propagated on re-import:
+// no unpublish task existed at all for any ExO entity type before this change.
+
+describe('Unpublishing Components', () => {
+  const draftInSource: any = { sys: { id: 'ct-1', type: 'Component', version: 3 }, name: 'Hero' }
+  const publishedInSource: any = { sys: { id: 'ct-1', type: 'Component', version: 3, publishedVersion: 3 }, name: 'Hero' }
+
+  function makePlainClientWithPublishedDestination() {
+    const plainClient = makePlainClientMock()
+    plainClient.component.upsert = jest.fn((_params: any, _payload: any) => Promise.resolve({ sys: { id: 'ct-1', version: 7, publishedVersion: 7 } }))
+    return plainClient
+  }
+
+  test('unpublishes an entity that is published at the destination but draft in the source', async () => {
+    const plainClient = makePlainClientWithPublishedDestination()
+    const destinationEntity: any = { sys: { id: 'ct-1', type: 'Component', version: 7, publishedVersion: 7 } }
+    await pushToSpace({
+      sourceData: { ...baseSourceData, components: [draftInSource] } as any,
+      destinationData: { ...baseDestinationData, components: [destinationEntity] },
+      client: makeClientMock(),
+      plainClient,
+      spaceId: 'space-1',
+      environmentId: 'master',
+      includeExperienceOrchestration: true,
+      requestQueue
+    }).run({ data: {} })
+
+    expect(plainClient.component.unpublish).toHaveBeenCalledTimes(1)
+    expect(plainClient.component.unpublish).toHaveBeenCalledWith(
+      { spaceId: 'space-1', environmentId: 'master', componentId: 'ct-1', version: 7 }
+    )
+  })
+
+  test('does not unpublish an entity that is published in both source and destination', async () => {
+    const plainClient = makePlainClientWithPublishedDestination()
+    const destinationEntity: any = { sys: { id: 'ct-1', type: 'Component', version: 7, publishedVersion: 7 } }
+    await pushToSpace({
+      sourceData: { ...baseSourceData, components: [publishedInSource] } as any,
+      destinationData: { ...baseDestinationData, components: [destinationEntity] },
+      client: makeClientMock(),
+      plainClient,
+      spaceId: 'space-1',
+      environmentId: 'master',
+      includeExperienceOrchestration: true,
+      requestQueue
+    }).run({ data: {} })
+
+    expect(plainClient.component.unpublish).not.toHaveBeenCalled()
+  })
+
+  test('does not unpublish an entity that was never published at the destination', async () => {
+    const plainClient = makePlainClientMock()
+    const destinationEntity: any = { sys: { id: 'ct-1', type: 'Component', version: 3 } }
+    await pushToSpace({
+      sourceData: { ...baseSourceData, components: [draftInSource] } as any,
+      destinationData: { ...baseDestinationData, components: [destinationEntity] },
+      client: makeClientMock(),
+      plainClient,
+      spaceId: 'space-1',
+      environmentId: 'master',
+      includeExperienceOrchestration: true,
+      requestQueue
+    }).run({ data: {} })
+
+    expect(plainClient.component.unpublish).not.toHaveBeenCalled()
+  })
+
+  test('skips unpublishing when skipContentPublishing is set', async () => {
+    const plainClient = makePlainClientWithPublishedDestination()
+    const destinationEntity: any = { sys: { id: 'ct-1', type: 'Component', version: 7, publishedVersion: 7 } }
+    await pushToSpace({
+      sourceData: { ...baseSourceData, components: [draftInSource] } as any,
+      destinationData: { ...baseDestinationData, components: [destinationEntity] },
+      client: makeClientMock(),
+      plainClient,
+      spaceId: 'space-1',
+      environmentId: 'master',
+      includeExperienceOrchestration: true,
+      skipContentPublishing: true,
+      requestQueue
+    }).run({ data: {} })
+
+    expect(plainClient.component.unpublish).not.toHaveBeenCalled()
+  })
+})
+
+describe('Unpublishing Data Assemblies', () => {
+  test('unpublishes an entity that is published at the destination but draft in the source', async () => {
+    const plainClient = makePlainClientMock()
+    plainClient.dataAssembly.update = jest.fn((_params: any, _payload: any) => Promise.resolve({ sys: { id: 'da-1', version: 5, publishedVersion: 5 } }))
+    const draftInSource: any = { sys: { id: 'da-1', type: 'DataAssembly', version: 5, dataType: [] }, name: 'Assembly', metadata: { tags: [] }, parameters: {}, resolvers: {}, return: { $literal: null } }
+    const destinationEntity: any = { sys: { id: 'da-1', type: 'DataAssembly', version: 5, publishedVersion: 5, dataType: [] } }
+    await pushToSpace({
+      sourceData: { ...baseSourceData, dataAssemblies: [draftInSource] } as any,
+      destinationData: { ...baseDestinationData, dataAssemblies: [destinationEntity] },
+      client: makeClientMock(),
+      plainClient,
+      spaceId: 'space-1',
+      environmentId: 'master',
+      includeExperienceOrchestration: true,
+      requestQueue
+    }).run({ data: {} })
+
+    expect(plainClient.dataAssembly.unpublish).toHaveBeenCalledTimes(1)
+    expect(plainClient.dataAssembly.unpublish).toHaveBeenCalledWith(
+      { spaceId: 'space-1', environmentId: 'master', dataAssemblyId: 'da-1', version: 5 }
+    )
+  })
+})
+
+describe('Unpublishing Experience Templates', () => {
+  test('unpublishes an entity that is published at the destination but draft in the source', async () => {
+    const plainClient = makePlainClientMock()
+    plainClient.experienceTemplate.upsert = jest.fn((_params: any, _payload: any) => Promise.resolve({ sys: { id: 'tmpl-1', version: 4, publishedVersion: 4 } }))
+    const draftInSource: any = { sys: { id: 'tmpl-1', type: 'ExperienceTemplate', version: 4 }, name: 'Press Release' }
+    const destinationEntity: any = { sys: { id: 'tmpl-1', type: 'ExperienceTemplate', version: 4, publishedVersion: 4 } }
+    await pushToSpace({
+      sourceData: { ...baseSourceData, experienceTemplates: [draftInSource] } as any,
+      destinationData: { ...baseDestinationData, experienceTemplates: [destinationEntity] },
+      client: makeClientMock(),
+      plainClient,
+      spaceId: 'space-1',
+      environmentId: 'master',
+      includeExperienceOrchestration: true,
+      requestQueue
+    }).run({ data: {} })
+
+    expect(plainClient.experienceTemplate.unpublish).toHaveBeenCalledTimes(1)
+    expect(plainClient.experienceTemplate.unpublish).toHaveBeenCalledWith(
+      { spaceId: 'space-1', environmentId: 'master', experienceTemplateId: 'tmpl-1', version: 4 }
+    )
+  })
+})
+
+describe('Unpublishing Experience Fragments', () => {
+  const component = { sys: { type: 'ResourceLink', linkType: 'Contentful:Component', urn: 'crn:contentful:::experience:spaces/$self/environments/$self/components/hero' } }
+
+  test('unpublishes an entity that is published at the destination but draft in the source', async () => {
+    const plainClient = makePlainClientMock()
+    plainClient.experienceFragment.upsert = jest.fn((_params: any, _payload: any) => Promise.resolve({ sys: { id: 'frag-1', version: 4, publishedVersion: 4 } }))
+    const draftInSource: any = { sys: { id: 'frag-1', type: 'ExperienceFragment', version: 4, component }, name: 'Hero Fragment' }
+    const destinationEntity: any = { sys: { id: 'frag-1', type: 'ExperienceFragment', version: 4, publishedVersion: 4 } }
+    await pushToSpace({
+      sourceData: { ...baseSourceData, experienceFragments: [draftInSource] } as any,
+      destinationData: { ...baseDestinationData, experienceFragments: [destinationEntity] },
+      client: makeClientMock(),
+      plainClient,
+      spaceId: 'space-1',
+      environmentId: 'master',
+      includeExperienceOrchestration: true,
+      requestQueue
+    }).run({ data: {} })
+
+    expect(plainClient.experienceFragment.unpublish).toHaveBeenCalledTimes(1)
+    expect(plainClient.experienceFragment.unpublish).toHaveBeenCalledWith(
+      { spaceId: 'space-1', environmentId: 'master', experienceFragmentId: 'frag-1', version: 4 }
+    )
+  })
+})
+
+describe('Unpublishing Experiences', () => {
+  const experienceTemplate = { sys: { type: 'ResourceLink', linkType: 'Contentful:ExperienceTemplate', urn: 'crn:contentful:::experience:spaces/$self/environments/$self/experienceTemplates/press-release' } }
+
+  test('unpublishes an entity that is published at the destination but draft in the source', async () => {
+    const plainClient = makePlainClientMock()
+    plainClient.experience.upsert = jest.fn((_params: any, _payload: any) => Promise.resolve({ sys: { id: 'exp-1', version: 8, publishedVersion: 8 } }))
+    const draftInSource: any = { sys: { id: 'exp-1', type: 'Experience', version: 8, experienceTemplate }, name: 'My Experience' }
+    const destinationEntity: any = { sys: { id: 'exp-1', type: 'Experience', version: 8, publishedVersion: 8 } }
+    await pushToSpace({
+      sourceData: { ...baseSourceData, experiences: [draftInSource] } as any,
+      destinationData: { ...baseDestinationData, experiences: [destinationEntity] },
+      client: makeClientMock(),
+      plainClient,
+      spaceId: 'space-1',
+      environmentId: 'master',
+      includeExperienceOrchestration: true,
+      requestQueue
+    }).run({ data: {} })
+
+    expect(plainClient.experience.unpublish).toHaveBeenCalledTimes(1)
+    expect(plainClient.experience.unpublish).toHaveBeenCalledWith(
+      { spaceId: 'space-1', environmentId: 'master', experienceId: 'exp-1', version: 8 }
+    )
+  })
+})

--- a/test/unit/tasks/push/push-to-space.test.ts
+++ b/test/unit/tasks/push/push-to-space.test.ts
@@ -2,11 +2,17 @@ import PQueue from 'p-queue'
 import { each } from 'lodash/collection'
 
 import pushToSpace from '../../../../lib/tasks/push-to-space/push-to-space'
-
+import { logEmitter } from 'contentful-batch-libs/dist/logging'
 import { createEntities, createEntries, createLocales } from '../../../../lib/tasks/push-to-space/creation'
 import { archiveEntities, publishEntities } from '../../../../lib/tasks/push-to-space/publishing'
 import { getAssetStreamForURL, processAssets } from '../../../../lib/tasks/push-to-space/assets'
 import { EntityTransformed, TransformedAsset, TransformedSourceData } from '../../../../lib/types'
+
+// logEmitter is a plain node:events EventEmitter. Node treats 'error' as a special
+// event name and throws synchronously if it's emitted with no listener attached, so
+// register a no-op listener before any test exercises an error/log-and-continue path.
+logEmitter.on('error', () => {})
+
 // We group together these functions into objects manually instead of
 // using wildcard imports (*). This ensures that during the `afterEach` cleanup,
 // Jest's mock clearing mechanism does not attempt to invoke `mockClear`
@@ -283,5 +289,75 @@ test('Upload each local asset file before pushing to space', () => {
       expect(assets.getAssetStreamForURL).toHaveBeenCalledWith('https://images/contentful-de.jpg', 'assets')
       expect(transformedAssets[0].transformed.fields.file['en-US']).not.toHaveProperty('upload')
       expect(transformedAssets[0].transformed.fields.file['en-US']).toHaveProperty('uploadFrom')
+    })
+})
+
+test('Editor interface update failure is logged and does not abort the run', () => {
+  const failingUpdateMock = jest.fn(() => Promise.reject(new Error('422 validation failed')))
+  const succeedingUpdateMock = jest.fn(() => Promise.resolve())
+
+  const twoContentTypesSourceData = {
+    ...transformedSourceData,
+    contentTypes: [
+      ...transformedSourceData.contentTypes,
+      { original: { sys: { id: 'otherId', type: 'ContentType', publishedVersion: 1 } } }
+    ],
+    editorInterfaces: [
+      {
+        sys: { type: 'EditorInterface', contentType: { sys: { id: 'someId' } } }
+      },
+      {
+        sys: { type: 'EditorInterface', contentType: { sys: { id: 'otherId' } } }
+      }
+    ]
+  } as unknown as TransformedSourceData
+
+  ;(creation.createEntities as jest.Mock).mockImplementationOnce(({ context }) => {
+    if (context.type === 'ContentType') {
+      return Promise.resolve([
+        { sys: { id: 'someId', type: 'ContentType', publishedVersion: 1 } },
+        { sys: { id: 'otherId', type: 'ContentType', publishedVersion: 1 } }
+      ])
+    }
+    return Promise.resolve([])
+  })
+  ;(publishing.publishEntities as jest.Mock).mockImplementationOnce(({ entities }) => {
+    if (entities[0] && entities[0].sys.type === 'ContentType') {
+      return Promise.resolve(entities)
+    }
+    return Promise.resolve([])
+  })
+
+  const clientMockWithMixedResults = {
+    getSpace: jest.fn(() => Promise.resolve({
+      getEnvironment: jest.fn(() => Promise.resolve({
+        getEditorInterfaceForContentType: (contentTypeId: string) => {
+          return Promise.resolve({
+            sys: { type: 'EditorInterface', contentType: { sys: { id: contentTypeId } } },
+            update: contentTypeId === 'someId' ? failingUpdateMock : succeedingUpdateMock
+          })
+        },
+        createUpload: () => Promise.resolve({ sys: { id: 'id' } })
+      }))
+    }))
+  }
+
+  const emitSpy = jest.spyOn(logEmitter, 'emit')
+
+  return expect(pushToSpace({
+    sourceData: twoContentTypesSourceData,
+    destinationData,
+    client: clientMockWithMixedResults,
+    spaceId: 'spaceid',
+    environmentId: 'master',
+    requestQueue
+  }).run({ data: {} })).resolves.not.toThrow()
+    .then(() => {
+      expect(failingUpdateMock).toHaveBeenCalledTimes(1)
+      expect(succeedingUpdateMock).toHaveBeenCalledTimes(1)
+      const errorCall = emitSpy.mock.calls.find((args) => args[0] === 'error')
+      expect(errorCall?.[1]).toBeInstanceOf(Error)
+      expect((errorCall?.[1] as Error).message).toBe('422 validation failed')
+      emitSpy.mockRestore()
     })
 })

--- a/test/unit/transform/exo-rename.test.ts
+++ b/test/unit/transform/exo-rename.test.ts
@@ -1,0 +1,238 @@
+import {
+  upgradeExoResources,
+  upgradeComponent,
+  upgradeExperienceTemplate,
+  upgradeExperienceFragment,
+  upgradeExperience,
+  upgradeNode
+} from '../../../lib/transform/exo-rename'
+
+const legacyComponentLink = (id: string) => ({
+  sys: {
+    type: 'ResourceLink',
+    linkType: 'Contentful:ComponentType',
+    urn: `crn:contentful:::experience:spaces/$self/environments/$self/componentTypes/${id}`
+  }
+})
+
+const newComponentLink = (id: string) => ({
+  sys: {
+    type: 'ResourceLink',
+    linkType: 'Contentful:Component',
+    urn: `crn:contentful:::experience:spaces/$self/environments/$self/components/${id}`
+  }
+})
+
+const legacyTemplateLink = (id: string) => ({
+  sys: {
+    type: 'ResourceLink',
+    linkType: 'Contentful:Template',
+    urn: `crn:contentful:::experience:spaces/$self/environments/$self/templates/${id}`
+  }
+})
+
+// ─── Component ──────────────────────────────────────────────────────────────
+
+describe('upgradeComponent', () => {
+  test('rewrites sys.type ComponentType -> Component', () => {
+    const result = upgradeComponent({ sys: { id: 'c1', type: 'ComponentType', version: 1 }, name: 'Hero' })
+    expect(result.sys.type).toBe('Component')
+    expect(result.sys.id).toBe('c1')
+    expect(result.name).toBe('Hero')
+  })
+
+  test('upgrades componentType nodes in the componentTree to component nodes', () => {
+    const result = upgradeComponent({
+      sys: { id: 'c1', type: 'ComponentType' },
+      componentTree: [
+        { id: 'n1', nodeType: 'Component', componentType: legacyComponentLink('hero'), slots: {} }
+      ]
+    })
+    const node = result.componentTree[0]
+    expect(node.nodeType).toBe('Component')
+    expect(node).not.toHaveProperty('componentType')
+    expect(node.component).toEqual(newComponentLink('hero'))
+  })
+
+  test('upgrades nested Fragment reference nodes inside slots', () => {
+    const result = upgradeComponent({
+      sys: { id: 'c1', type: 'ComponentType' },
+      componentTree: [
+        {
+          id: 'n1',
+          nodeType: 'Component',
+          componentType: legacyComponentLink('hero'),
+          slots: {
+            main: [{ id: 'f1', nodeType: 'Fragment', fragment: {
+              sys: { type: 'ResourceLink', linkType: 'Contentful:Fragment', urn: 'crn:...:/fragments/frag-a' }
+            } }]
+          }
+        }
+      ]
+    })
+    const child = result.componentTree[0].slots.main[0]
+    expect(child.nodeType).toBe('ExperienceFragment')
+    expect(child).not.toHaveProperty('fragment')
+    expect(child.experienceFragment.sys.linkType).toBe('Contentful:ExperienceFragment')
+    expect(child.experienceFragment.sys.urn).toContain('/experienceFragments/frag-a')
+  })
+
+  test('upgrades allowedResources in slot definitions', () => {
+    const result = upgradeComponent({
+      sys: { id: 'c1', type: 'ComponentType' },
+      slots: [
+        {
+          id: 's1',
+          name: 'Slot',
+          required: false,
+          validations: [],
+          allowedResources: [{
+            type: 'Contentful:ComponentType',
+            source: 'crn:contentful:::experience:spaces/$self/environments/$self',
+            allowedTypes: ['crn:...:/componentTypes/hero']
+          }]
+        }
+      ]
+    })
+    const resource = result.slots[0].allowedResources[0]
+    expect(resource.type).toBe('Contentful:Component')
+    expect(resource.allowedTypes[0]).toContain('/components/hero')
+  })
+
+  test('upgrades contentProperties TypeRef links (including nested Array items)', () => {
+    const result = upgradeComponent({
+      sys: { id: 'c1', type: 'ComponentType' },
+      contentProperties: [
+        { id: 'p1', name: 'ref', required: false, type: 'TypeRef', ref: legacyComponentLink('hero') },
+        { id: 'p2', name: 'list', required: false, type: 'Array', items: { type: 'TypeRef', ref: legacyComponentLink('card') } }
+      ]
+    })
+    expect(result.contentProperties[0].ref).toEqual(newComponentLink('hero'))
+    expect(result.contentProperties[1].items.ref).toEqual(newComponentLink('card'))
+  })
+
+  test('leaves non-TypeRef content properties untouched', () => {
+    const prop = { id: 'p1', name: 'title', required: true, type: 'String' }
+    const result = upgradeComponent({ sys: { id: 'c1', type: 'ComponentType' }, contentProperties: [prop] })
+    expect(result.contentProperties[0]).toEqual(prop)
+  })
+})
+
+// ─── ExperienceTemplate ───────────────────────────────────────────────────────
+
+describe('upgradeExperienceTemplate', () => {
+  test('rewrites sys.type Template -> ExperienceTemplate and upgrades the tree', () => {
+    const result = upgradeExperienceTemplate({
+      sys: { id: 't1', type: 'Template' },
+      componentTree: [{ id: 'n1', nodeType: 'Component', componentType: legacyComponentLink('hero'), slots: {} }]
+    })
+    expect(result.sys.type).toBe('ExperienceTemplate')
+    expect(result.componentTree[0].component).toEqual(newComponentLink('hero'))
+  })
+})
+
+// ─── ExperienceFragment ───────────────────────────────────────────────────────
+
+describe('upgradeExperienceFragment', () => {
+  test('rewrites sys.type and sys.componentType -> sys.component', () => {
+    const result = upgradeExperienceFragment({
+      sys: { id: 'f1', type: 'Fragment', version: 1, componentType: legacyComponentLink('hero') },
+      name: 'Hero Fragment'
+    })
+    expect(result.sys.type).toBe('ExperienceFragment')
+    expect(result.sys).not.toHaveProperty('componentType')
+    expect(result.sys.component).toEqual(newComponentLink('hero'))
+    expect(result.name).toBe('Hero Fragment')
+  })
+
+  test('upgrades reference nodes inside slots', () => {
+    const result = upgradeExperienceFragment({
+      sys: { id: 'f1', type: 'Fragment', componentType: legacyComponentLink('hero') },
+      slots: {
+        main: [{ id: 'n1', nodeType: 'InlineFragment', componentType: legacyComponentLink('inner'), designProperties: {}, slots: {} }]
+      }
+    })
+    const node = result.slots.main[0]
+    expect(node.nodeType).toBe('InlineExperienceFragment')
+    expect(node).not.toHaveProperty('componentType')
+    expect(node.component).toEqual(newComponentLink('inner'))
+  })
+})
+
+// ─── Experience ─────────────────────────────────────────────────────────────
+
+describe('upgradeExperience', () => {
+  test('rewrites sys.template -> sys.experienceTemplate', () => {
+    const result = upgradeExperience({
+      sys: { id: 'e1', type: 'Experience', version: 1, template: legacyTemplateLink('press') },
+      name: 'My Experience'
+    })
+    expect(result.sys).not.toHaveProperty('template')
+    expect(result.sys.experienceTemplate.sys.linkType).toBe('Contentful:ExperienceTemplate')
+    expect(result.sys.experienceTemplate.sys.urn).toContain('/experienceTemplates/press')
+  })
+})
+
+// ─── Node guard ───────────────────────────────────────────────────────────────
+
+describe('upgradeNode', () => {
+  test('passes Slot nodes through unchanged', () => {
+    const slot = { id: 's1', nodeType: 'Slot', slotId: 'main' }
+    expect(upgradeNode(slot)).toEqual(slot)
+  })
+
+  test('is idempotent on already-new-form Component nodes', () => {
+    const node = { id: 'n1', nodeType: 'Component', component: newComponentLink('hero'), slots: {} }
+    expect(upgradeNode(node)).toEqual(node)
+  })
+})
+
+// ─── upgradeExoResources (top-level) ────────────────────────────────────────
+
+describe('upgradeExoResources', () => {
+  test('upgrades all renameable ExO entity arrays', () => {
+    const result: any = upgradeExoResources({
+      components: [{ sys: { id: 'c1', type: 'ComponentType' } }],
+      experienceTemplates: [{ sys: { id: 't1', type: 'Template' } }],
+      experienceFragments: [{ sys: { id: 'f1', type: 'Fragment', componentType: legacyComponentLink('hero') } }],
+      experiences: [{ sys: { id: 'e1', type: 'Experience', template: legacyTemplateLink('press') } }]
+    } as any)
+    expect(result.components[0].sys.type).toBe('Component')
+    expect(result.experienceTemplates[0].sys.type).toBe('ExperienceTemplate')
+    expect(result.experienceFragments[0].sys.type).toBe('ExperienceFragment')
+    expect(result.experiences[0].sys.experienceTemplate).toBeDefined()
+  })
+
+  test('leaves non-renamed ExO entities (dataAssemblies, designTokens) untouched', () => {
+    const input = {
+      dataAssemblies: [{ sys: { id: 'da1', type: 'DataAssembly' } }],
+      designTokens: [{ sys: { id: 'dt1', type: 'DesignToken' } }]
+    }
+    expect(upgradeExoResources(input)).toEqual(input)
+  })
+
+  test('is idempotent — running twice equals running once', () => {
+    const input = {
+      components: [{ sys: { id: 'c1', type: 'ComponentType' }, componentTree: [{ id: 'n1', nodeType: 'Component', componentType: legacyComponentLink('hero'), slots: {} }] }],
+      experienceFragments: [{ sys: { id: 'f1', type: 'Fragment', componentType: legacyComponentLink('hero') } }],
+      experiences: [{ sys: { id: 'e1', type: 'Experience', template: legacyTemplateLink('press') } }]
+    }
+    const once = upgradeExoResources(input)
+    const twice = upgradeExoResources(once)
+    expect(twice).toEqual(once)
+  })
+
+  test('passes already-new-form entities through unchanged', () => {
+    const input = {
+      components: [{ sys: { id: 'c1', type: 'Component' }, component: newComponentLink('hero') }],
+      experienceFragments: [{ sys: { id: 'f1', type: 'ExperienceFragment', component: newComponentLink('hero') } }]
+    }
+    expect(upgradeExoResources(input)).toEqual(input)
+  })
+
+  test('does not add ExO keys that were not present', () => {
+    const result = upgradeExoResources({ webhooks: [] } as any)
+    expect(result).not.toHaveProperty('components')
+    expect(result).not.toHaveProperty('experiences')
+  })
+})

--- a/test/unit/utils/import-exo-folders.test.ts
+++ b/test/unit/utils/import-exo-folders.test.ts
@@ -1,0 +1,495 @@
+import {
+  ensureParentFolderGroupsExist,
+  deriveChildConceptMap,
+  createOrPatchChildConcepts,
+  linkChildConceptsToParentGroups,
+  rewriteEntityFolderConcepts,
+  importExoFolders,
+  PARENT_FOLDER_GROUP_IDS,
+} from '../../../lib/utils/import-exo-folders'
+import { logEmitter } from 'contentful-batch-libs/dist/logging'
+
+jest.mock('contentful-batch-libs/dist/logging', () => ({
+  logEmitter: { emit: jest.fn() },
+}))
+
+const SOURCE_SPACE = 'space-source'
+const DEST_SPACE = 'space-dest'
+const ORG = 'org-1'
+
+function makeEntity(conceptIds: string[] = [], spaceId = SOURCE_SPACE) {
+  return {
+    sys: { space: { sys: { id: spaceId } } },
+    metadata: {
+      concepts: conceptIds.map((id) => ({ sys: { id, type: 'Link', linkType: 'TaxonomyConcept' } })),
+    },
+  } as any
+}
+
+function makeScheme(id: string, conceptIds: string[] = [], version = 1) {
+  return {
+    sys: { id, version },
+    concepts: conceptIds.map((cid) => ({ sys: { id: cid, type: 'Link', linkType: 'TaxonomyConcept' } })),
+  }
+}
+
+function makeConcept(id: string, { prefLabel = { 'en-US': id }, spaces = [] as string[], purpose = 'internal', version = 1 } = {}) {
+  return {
+    sys: { id, version },
+    purpose,
+    prefLabel,
+    metadata: { spaces: spaces.map((spaceId) => ({ sys: { id: spaceId } })) },
+  }
+}
+
+function makeClient({
+  existingConcepts = new Map<string, any>(),
+  existingSchemes = new Map<string, any>(),
+}: {
+  existingConcepts?: Map<string, any>
+  existingSchemes?: Map<string, any>
+} = {}) {
+  return {
+    concept: {
+      get: jest.fn().mockImplementation(({ conceptId }: { conceptId: string }) => {
+        const c = existingConcepts.get(conceptId)
+        if (c) return Promise.resolve(c)
+        const err: any = new Error('Not Found')
+        err.status = 404
+        return Promise.reject(err)
+      }),
+      createWithId: jest.fn().mockResolvedValue({}),
+      patch: jest.fn().mockResolvedValue({}),
+    },
+    conceptScheme: {
+      getMany: jest.fn().mockResolvedValue({ items: [...existingSchemes.values()] }),
+      createWithId: jest.fn().mockImplementation(({ conceptSchemeId }: { conceptSchemeId: string }) =>
+        Promise.resolve(makeScheme(conceptSchemeId))
+      ),
+      patch: jest.fn().mockImplementation(({ conceptSchemeId, version }: any) => {
+        const scheme = existingSchemes.get(conceptSchemeId) ?? makeScheme(conceptSchemeId)
+        return Promise.resolve({ ...scheme, sys: { ...scheme.sys, version: version + 1 } })
+      }),
+    },
+  }
+}
+
+const ALL_PARENT_GROUPS: Map<string, any> = new Map(
+  Object.values(PARENT_FOLDER_GROUP_IDS).map((id) => [id, makeScheme(id)])
+)
+
+afterEach(() => jest.clearAllMocks())
+
+// ---------------------------------------------------------------------------
+// Step 1: ensureParentFolderGroupsExist
+// ---------------------------------------------------------------------------
+
+describe('ensureParentFolderGroupsExist', () => {
+  it('returns all 5 schemes when all exist', async () => {
+    const client = makeClient({ existingSchemes: ALL_PARENT_GROUPS })
+    const result = await ensureParentFolderGroupsExist(client, ORG)
+
+    expect(result.size).toBe(5)
+    expect(client.conceptScheme.createWithId).not.toHaveBeenCalled()
+  })
+
+  it('returns empty map when any parent group is missing', async () => {
+    const partial = new Map([
+      [PARENT_FOLDER_GROUP_IDS.designToken, makeScheme(PARENT_FOLDER_GROUP_IDS.designToken)],
+      [PARENT_FOLDER_GROUP_IDS.componentType, makeScheme(PARENT_FOLDER_GROUP_IDS.componentType)],
+    ])
+    const client = makeClient({ existingSchemes: partial })
+    const result = await ensureParentFolderGroupsExist(client, ORG)
+
+    expect(result.size).toBe(0)
+    expect(client.conceptScheme.createWithId).not.toHaveBeenCalled()
+  })
+
+  it('returns empty map when no parent groups exist', async () => {
+    const client = makeClient()
+    const result = await ensureParentFolderGroupsExist(client, ORG)
+
+    expect(result.size).toBe(0)
+  })
+
+  it('filters out non-folder-group schemes from the result', async () => {
+    const schemes: Map<string, any> = new Map(ALL_PARENT_GROUPS)
+    schemes.set('some-other-scheme', makeScheme('some-other-scheme'))
+    const client = makeClient({ existingSchemes: schemes })
+    const result = await ensureParentFolderGroupsExist(client, ORG)
+
+    expect(result.size).toBe(5)
+    expect(result.has('some-other-scheme')).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Step 2: deriveChildConceptMap
+// ---------------------------------------------------------------------------
+
+describe('deriveChildConceptMap', () => {
+  it('returns empty map when source entities have no folder concepts', () => {
+    const result = deriveChildConceptMap({ designTokens: [makeEntity(['tag-abc'])] }, DEST_SPACE)
+    expect(result.size).toBe(0)
+  })
+
+  it('returns empty map when source entities are empty', () => {
+    const result = deriveChildConceptMap({}, DEST_SPACE)
+    expect(result.size).toBe(0)
+  })
+
+  it('derives deterministic destination concept ID', () => {
+    const sourceId = 'contentful.folder-brand-colors-cBllAkZ9'
+    const result = deriveChildConceptMap({ designTokens: [makeEntity([sourceId])] }, DEST_SPACE)
+
+    expect(result.get(sourceId)?.destConceptId).toBe(`${sourceId}-${DEST_SPACE}`)
+  })
+
+  it('assigns correct parentGroupId per entity type', () => {
+    const result = deriveChildConceptMap({
+      designTokens: [makeEntity(['contentful.folder-a-AA'])],
+      components: [makeEntity(['contentful.folder-b-BB'])],
+      experienceTemplates: [makeEntity(['contentful.folder-c-CC'])],
+      experienceFragments: [makeEntity(['contentful.folder-d-DD'])],
+      experiences: [makeEntity(['contentful.folder-e-EE'])],
+    }, DEST_SPACE)
+
+    expect(result.get('contentful.folder-a-AA')?.parentGroupId).toBe(PARENT_FOLDER_GROUP_IDS.designToken)
+    expect(result.get('contentful.folder-b-BB')?.parentGroupId).toBe(PARENT_FOLDER_GROUP_IDS.componentType)
+    expect(result.get('contentful.folder-c-CC')?.parentGroupId).toBe(PARENT_FOLDER_GROUP_IDS.template)
+    expect(result.get('contentful.folder-d-DD')?.parentGroupId).toBe(PARENT_FOLDER_GROUP_IDS.fragment)
+    expect(result.get('contentful.folder-e-EE')?.parentGroupId).toBe(PARENT_FOLDER_GROUP_IDS.experience)
+  })
+
+  it('deduplicates the same concept ID across entity types', () => {
+    const sharedId = 'contentful.folder-shared-ABC'
+    const result = deriveChildConceptMap({
+      designTokens: [makeEntity([sharedId])],
+      components: [makeEntity([sharedId])],
+      experiences: [makeEntity([sharedId])],
+    }, DEST_SPACE)
+
+    expect(result.size).toBe(1)
+  })
+
+  it('ignores non-folder-prefixed concepts', () => {
+    const result = deriveChildConceptMap({
+      components: [makeEntity(['tag-abc', 'contentful.folder-hero-XYZ', 'category-def'])],
+    }, DEST_SPACE)
+
+    expect(result.size).toBe(1)
+    expect(result.has('contentful.folder-hero-XYZ')).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Step 3: createOrPatchChildConcepts
+// ---------------------------------------------------------------------------
+
+describe('createOrPatchChildConcepts', () => {
+  it('creates a new concept with purpose, prefLabel, and space link', async () => {
+    const sourceId = 'contentful.folder-brand-colors-cBllAkZ9'
+    const destId = `${sourceId}-${DEST_SPACE}`
+    const sourceConcept = makeConcept(sourceId, { prefLabel: { 'en-US': 'Brand Colors' } })
+    const client = makeClient({ existingConcepts: new Map([[sourceId, sourceConcept]]) })
+
+    const childConceptMap = new Map([[sourceId, { destConceptId: destId, parentGroupId: PARENT_FOLDER_GROUP_IDS.designToken }]])
+    await createOrPatchChildConcepts(client, ORG, DEST_SPACE, childConceptMap)
+
+    expect(client.concept.createWithId).toHaveBeenCalledWith(
+      { organizationId: ORG, conceptId: destId },
+      {
+        purpose: 'internal',
+        prefLabel: { 'en-US': 'Brand Colors' },
+        metadata: { spaces: [{ sys: { type: 'Link', linkType: 'Space', id: DEST_SPACE } }] },
+      }
+    )
+  })
+
+  it('falls back to destConceptId as prefLabel when source concept fetch fails', async () => {
+    const sourceId = 'contentful.folder-missing-src-AA'
+    const destId = `${sourceId}-${DEST_SPACE}`
+    const client = makeClient()
+
+    const childConceptMap = new Map([[sourceId, { destConceptId: destId, parentGroupId: PARENT_FOLDER_GROUP_IDS.designToken }]])
+    await createOrPatchChildConcepts(client, ORG, DEST_SPACE, childConceptMap)
+
+    expect(client.concept.createWithId).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ prefLabel: { 'en-US': destId } })
+    )
+  })
+
+  it('patches purpose when existing concept is missing it', async () => {
+    const sourceId = 'contentful.folder-a-AA'
+    const destId = `${sourceId}-${DEST_SPACE}`
+    const existing = makeConcept(destId, { purpose: 'extension', spaces: [DEST_SPACE] })
+    const client = makeClient({ existingConcepts: new Map([[destId, existing]]) })
+
+    const childConceptMap = new Map([[sourceId, { destConceptId: destId, parentGroupId: PARENT_FOLDER_GROUP_IDS.designToken }]])
+    await createOrPatchChildConcepts(client, ORG, DEST_SPACE, childConceptMap)
+
+    expect(client.concept.createWithId).not.toHaveBeenCalled()
+    expect(client.concept.patch).toHaveBeenCalledWith(
+      expect.objectContaining({ conceptId: destId }),
+      expect.arrayContaining([{ op: 'add', path: '/purpose', value: 'internal' }])
+    )
+  })
+
+  it('patches space link when existing concept is missing destination space', async () => {
+    const sourceId = 'contentful.folder-a-AA'
+    const destId = `${sourceId}-${DEST_SPACE}`
+    const existing = makeConcept(destId, { spaces: ['some-other-space'] })
+    const client = makeClient({ existingConcepts: new Map([[destId, existing]]) })
+
+    const childConceptMap = new Map([[sourceId, { destConceptId: destId, parentGroupId: PARENT_FOLDER_GROUP_IDS.designToken }]])
+    await createOrPatchChildConcepts(client, ORG, DEST_SPACE, childConceptMap)
+
+    expect(client.concept.createWithId).not.toHaveBeenCalled()
+    expect(client.concept.patch).toHaveBeenCalledWith(
+      expect.objectContaining({ conceptId: destId }),
+      expect.arrayContaining([
+        { op: 'add', path: '/metadata/spaces/-', value: { sys: { type: 'Link', linkType: 'Space', id: DEST_SPACE } } },
+      ])
+    )
+  })
+
+  it('patches both purpose and space in a single call when both are missing', async () => {
+    const sourceId = 'contentful.folder-a-AA'
+    const destId = `${sourceId}-${DEST_SPACE}`
+    const existing = makeConcept(destId, { purpose: 'extension', spaces: [] })
+    const client = makeClient({ existingConcepts: new Map([[destId, existing]]) })
+
+    const childConceptMap = new Map([[sourceId, { destConceptId: destId, parentGroupId: PARENT_FOLDER_GROUP_IDS.designToken }]])
+    await createOrPatchChildConcepts(client, ORG, DEST_SPACE, childConceptMap)
+
+    expect(client.concept.patch).toHaveBeenCalledTimes(1)
+    const patches = client.concept.patch.mock.calls[0][1]
+    expect(patches).toHaveLength(2)
+  })
+
+  it('does not patch when existing concept is already up to date', async () => {
+    const sourceId = 'contentful.folder-a-AA'
+    const destId = `${sourceId}-${DEST_SPACE}`
+    const existing = makeConcept(destId, { spaces: [DEST_SPACE] })
+    const client = makeClient({ existingConcepts: new Map([[destId, existing]]) })
+
+    const childConceptMap = new Map([[sourceId, { destConceptId: destId, parentGroupId: PARENT_FOLDER_GROUP_IDS.designToken }]])
+    await createOrPatchChildConcepts(client, ORG, DEST_SPACE, childConceptMap)
+
+    expect(client.concept.createWithId).not.toHaveBeenCalled()
+    expect(client.concept.patch).not.toHaveBeenCalled()
+  })
+
+  it('logs a warning and continues when createWithId fails', async () => {
+    const client = makeClient()
+    client.concept.createWithId
+      .mockRejectedValueOnce(new Error('create failed'))
+      .mockResolvedValue({})
+
+    const childConceptMap = new Map([
+      ['contentful.folder-a-AA', { destConceptId: `contentful.folder-a-AA-${DEST_SPACE}`, parentGroupId: PARENT_FOLDER_GROUP_IDS.designToken }],
+      ['contentful.folder-b-BB', { destConceptId: `contentful.folder-b-BB-${DEST_SPACE}`, parentGroupId: PARENT_FOLDER_GROUP_IDS.designToken }],
+    ])
+    await createOrPatchChildConcepts(client, ORG, DEST_SPACE, childConceptMap)
+
+    expect(client.concept.createWithId).toHaveBeenCalledTimes(2)
+    expect(logEmitter.emit).toHaveBeenCalledWith('error', expect.stringContaining('Failed to create child folder concept'))
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Step 4: linkChildConceptsToParentGroups
+// ---------------------------------------------------------------------------
+
+describe('linkChildConceptsToParentGroups', () => {
+  it('links a child concept to its parent group', async () => {
+    const destId = `contentful.folder-a-AA-${DEST_SPACE}`
+    const parentGroups = new Map(ALL_PARENT_GROUPS)
+    const client = makeClient()
+
+    const childConceptMap = new Map([
+      ['contentful.folder-a-AA', { destConceptId: destId, parentGroupId: PARENT_FOLDER_GROUP_IDS.designToken }],
+    ])
+    await linkChildConceptsToParentGroups(client, ORG, childConceptMap, parentGroups)
+
+    expect(client.conceptScheme.patch).toHaveBeenCalledWith(
+      expect.objectContaining({ conceptSchemeId: PARENT_FOLDER_GROUP_IDS.designToken }),
+      [{ op: 'add', path: '/concepts/-', value: { sys: { type: 'Link', linkType: 'TaxonomyConcept', id: destId } } }]
+    )
+  })
+
+  it('skips linking when concept is already in the scheme', async () => {
+    const destId = `contentful.folder-a-AA-${DEST_SPACE}`
+    const parentGroups = new Map([
+      [PARENT_FOLDER_GROUP_IDS.designToken, makeScheme(PARENT_FOLDER_GROUP_IDS.designToken, [destId])],
+    ])
+    const client = makeClient()
+
+    const childConceptMap = new Map([
+      ['contentful.folder-a-AA', { destConceptId: destId, parentGroupId: PARENT_FOLDER_GROUP_IDS.designToken }],
+    ])
+    await linkChildConceptsToParentGroups(client, ORG, childConceptMap, parentGroups)
+
+    expect(client.conceptScheme.patch).not.toHaveBeenCalled()
+  })
+
+  it('keeps scheme version current across multiple patches to the same scheme', async () => {
+    const destId1 = `contentful.folder-a-AA-${DEST_SPACE}`
+    const destId2 = `contentful.folder-b-BB-${DEST_SPACE}`
+    const parentGroups = new Map([[PARENT_FOLDER_GROUP_IDS.designToken, makeScheme(PARENT_FOLDER_GROUP_IDS.designToken, [], 1)]])
+    const client = makeClient()
+
+    const childConceptMap = new Map([
+      ['contentful.folder-a-AA', { destConceptId: destId1, parentGroupId: PARENT_FOLDER_GROUP_IDS.designToken }],
+      ['contentful.folder-b-BB', { destConceptId: destId2, parentGroupId: PARENT_FOLDER_GROUP_IDS.designToken }],
+    ])
+    await linkChildConceptsToParentGroups(client, ORG, childConceptMap, parentGroups)
+
+    const calls = client.conceptScheme.patch.mock.calls
+    expect(calls[0][0].version).toBe(1)
+    expect(calls[1][0].version).toBe(2) // incremented after first patch
+  })
+
+  it('skips when parentGroup is not in the map', async () => {
+    const client = makeClient()
+    const childConceptMap = new Map([
+      ['contentful.folder-a-AA', { destConceptId: `contentful.folder-a-AA-${DEST_SPACE}`, parentGroupId: PARENT_FOLDER_GROUP_IDS.designToken }],
+    ])
+    await linkChildConceptsToParentGroups(client, ORG, childConceptMap, new Map())
+
+    expect(client.conceptScheme.patch).not.toHaveBeenCalled()
+  })
+
+  it('logs warning and continues when patch fails', async () => {
+    const client = makeClient()
+    client.conceptScheme.patch.mockRejectedValueOnce(new Error('patch failed'))
+
+    const destId = `contentful.folder-a-AA-${DEST_SPACE}`
+    const parentGroups = new Map([[PARENT_FOLDER_GROUP_IDS.designToken, makeScheme(PARENT_FOLDER_GROUP_IDS.designToken)]])
+    const childConceptMap = new Map([
+      ['contentful.folder-a-AA', { destConceptId: destId, parentGroupId: PARENT_FOLDER_GROUP_IDS.designToken }],
+    ])
+    await linkChildConceptsToParentGroups(client, ORG, childConceptMap, parentGroups)
+
+    expect(logEmitter.emit).toHaveBeenCalledWith('error', expect.stringContaining('Failed to link child concept'))
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Step 5: rewriteEntityFolderConcepts
+// ---------------------------------------------------------------------------
+
+describe('rewriteEntityFolderConcepts', () => {
+  function makeChildConceptMap(entries: [string, string][]) {
+    return new Map(entries.map(([src, dest]) => [src, { destConceptId: dest, parentGroupId: PARENT_FOLDER_GROUP_IDS.designToken }]))
+  }
+
+  it('rewrites folder concept IDs in entity metadata', () => {
+    const sourceId = 'contentful.folder-brand-colors-cBllAkZ9'
+    const destId = `${sourceId}-${DEST_SPACE}`
+    const entity = makeEntity([sourceId, 'some-non-folder-tag'])
+
+    rewriteEntityFolderConcepts([entity], makeChildConceptMap([[sourceId, destId]]))
+
+    expect(entity.metadata.concepts[0].sys.id).toBe(destId)
+    expect(entity.metadata.concepts[1].sys.id).toBe('some-non-folder-tag')
+  })
+
+  it('leaves entities without metadata untouched', () => {
+    const entity = { sys: {} } as any
+    rewriteEntityFolderConcepts([entity], makeChildConceptMap([['contentful.folder-a-AA', 'dest']]))
+    expect(entity.metadata).toBeUndefined()
+  })
+
+  it('does nothing when the map is empty', () => {
+    const entity = makeEntity(['contentful.folder-abc-XYZ'])
+    rewriteEntityFolderConcepts([entity], new Map())
+    expect(entity.metadata.concepts[0].sys.id).toBe('contentful.folder-abc-XYZ')
+  })
+
+  it('rewrites concepts across multiple entities', () => {
+    const e1 = makeEntity(['contentful.folder-a-AA'])
+    const e2 = makeEntity(['contentful.folder-b-BB'])
+    rewriteEntityFolderConcepts([e1, e2], makeChildConceptMap([
+      ['contentful.folder-a-AA', 'contentful.folder-a-AA-dest'],
+      ['contentful.folder-b-BB', 'contentful.folder-b-BB-dest'],
+    ]))
+
+    expect(e1.metadata.concepts[0].sys.id).toBe('contentful.folder-a-AA-dest')
+    expect(e2.metadata.concepts[0].sys.id).toBe('contentful.folder-b-BB-dest')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Orchestrator: importExoFolders
+// ---------------------------------------------------------------------------
+
+describe('importExoFolders', () => {
+  const BASE_ARGS = { organizationId: ORG, destinationSpaceId: DEST_SPACE }
+
+  it('skips all work when source and destination space are the same', async () => {
+    const client = makeClient({ existingSchemes: ALL_PARENT_GROUPS })
+    await importExoFolders({
+      plainClient: client,
+      ...BASE_ARGS,
+      destinationSpaceId: SOURCE_SPACE,
+      sourceEntities: { designTokens: [makeEntity(['contentful.folder-a-AA'])] },
+    })
+
+    expect(client.conceptScheme.getMany).not.toHaveBeenCalled()
+    expect(logEmitter.emit).toHaveBeenCalledWith('info', expect.stringContaining('same'))
+  })
+
+  it('skips concept work when no folder concepts are referenced', async () => {
+    const client = makeClient({ existingSchemes: ALL_PARENT_GROUPS })
+    await importExoFolders({
+      plainClient: client,
+      ...BASE_ARGS,
+      sourceEntities: { designTokens: [makeEntity(['tag-abc'])] },
+    })
+
+    expect(client.concept.get).not.toHaveBeenCalled()
+  })
+
+  it('rejects when parent groups are missing', async () => {
+    const client = makeClient()
+    await expect(
+      importExoFolders({
+        plainClient: client,
+        ...BASE_ARGS,
+        sourceEntities: { designTokens: [makeEntity(['contentful.folder-a-AA'])] },
+      })
+    ).rejects.toThrow()
+  })
+
+  it('runs all steps in sequence: creates concept, links to scheme, rewrites entity metadata', async () => {
+    const sourceId = 'contentful.folder-brand-colors-cBllAkZ9'
+    const destId = `${sourceId}-${DEST_SPACE}`
+    const sourceConcept = makeConcept(sourceId, { prefLabel: { 'en-US': 'Brand Colors' } })
+    const client = makeClient({
+      existingSchemes: ALL_PARENT_GROUPS,
+      existingConcepts: new Map([[sourceId, sourceConcept]]),
+    })
+    const entity = makeEntity([sourceId])
+
+    await importExoFolders({
+      plainClient: client,
+      ...BASE_ARGS,
+      sourceEntities: { designTokens: [entity] },
+    })
+
+    // Step 3: created the dest concept
+    expect(client.concept.createWithId).toHaveBeenCalledWith(
+      { organizationId: ORG, conceptId: destId },
+      expect.objectContaining({ purpose: 'internal', prefLabel: { 'en-US': 'Brand Colors' } })
+    )
+    // Step 4: linked to parent group
+    expect(client.conceptScheme.patch).toHaveBeenCalledWith(
+      expect.objectContaining({ conceptSchemeId: PARENT_FOLDER_GROUP_IDS.designToken }),
+      expect.arrayContaining([expect.objectContaining({ value: expect.objectContaining({ sys: expect.objectContaining({ id: destId }) }) })])
+    )
+    // Step 5: entity metadata rewritten in-place
+    expect(entity.metadata.concepts[0].sys.id).toBe(destId)
+  })
+})

--- a/test/unit/utils/publish-exo-entities.test.ts
+++ b/test/unit/utils/publish-exo-entities.test.ts
@@ -1,0 +1,71 @@
+import { spaceHasExoM1Entitlement } from '../../../lib/utils/publish-exo-entities'
+
+function makePlainClient({ spaceGet, rawGet }: { spaceGet: () => Promise<any>, rawGet: () => Promise<any> }) {
+  return {
+    space: { get: spaceGet },
+    raw: { get: rawGet }
+  }
+}
+
+test('returns true when the org entitlement set has exoM1.value === true', async () => {
+  const plainClient = makePlainClient({
+    spaceGet: () => Promise.resolve({ sys: { organization: { sys: { id: 'org-1' } } } }),
+    rawGet: () => Promise.resolve({ features: { exoM1: { value: true } } })
+  })
+
+  await expect(spaceHasExoM1Entitlement(plainClient, 'space-1')).resolves.toBe(true)
+})
+
+test('returns false when the org entitlement set has exoM1.value === false', async () => {
+  const plainClient = makePlainClient({
+    spaceGet: () => Promise.resolve({ sys: { organization: { sys: { id: 'org-1' } } } }),
+    rawGet: () => Promise.resolve({ features: { exoM1: { value: false } } })
+  })
+
+  await expect(spaceHasExoM1Entitlement(plainClient, 'space-1')).resolves.toBe(false)
+})
+
+test('returns false (not null) when the exoM1 key is entirely absent from a well-formed response', async () => {
+  const plainClient = makePlainClient({
+    spaceGet: () => Promise.resolve({ sys: { organization: { sys: { id: 'org-1' } } } }),
+    rawGet: () => Promise.resolve({ features: { someOtherFeature: { value: true } } })
+  })
+
+  await expect(spaceHasExoM1Entitlement(plainClient, 'space-1')).resolves.toBe(false)
+})
+
+test('returns false when the entitlement set has no features at all', async () => {
+  const plainClient = makePlainClient({
+    spaceGet: () => Promise.resolve({ sys: { organization: { sys: { id: 'org-1' } } } }),
+    rawGet: () => Promise.resolve({})
+  })
+
+  await expect(spaceHasExoM1Entitlement(plainClient, 'space-1')).resolves.toBe(false)
+})
+
+test('returns null when the space lookup fails', async () => {
+  const plainClient = makePlainClient({
+    spaceGet: () => Promise.reject(new Error('network error')),
+    rawGet: () => Promise.resolve({ features: { exoM1: { value: true } } })
+  })
+
+  await expect(spaceHasExoM1Entitlement(plainClient, 'space-1')).resolves.toBeNull()
+})
+
+test('returns null when the space has no organization link', async () => {
+  const plainClient = makePlainClient({
+    spaceGet: () => Promise.resolve({ sys: {} }),
+    rawGet: () => Promise.resolve({ features: { exoM1: { value: true } } })
+  })
+
+  await expect(spaceHasExoM1Entitlement(plainClient, 'space-1')).resolves.toBeNull()
+})
+
+test('returns null when the entitlement request itself fails', async () => {
+  const plainClient = makePlainClient({
+    spaceGet: () => Promise.resolve({ sys: { organization: { sys: { id: 'org-1' } } } }),
+    rawGet: () => Promise.reject(new Error('403 Forbidden'))
+  })
+
+  await expect(spaceHasExoM1Entitlement(plainClient, 'space-1')).resolves.toBeNull()
+})

--- a/test/unit/utils/sort-components.test.ts
+++ b/test/unit/utils/sort-components.test.ts
@@ -1,0 +1,61 @@
+import sortComponents from '../../../lib/utils/sort-components'
+
+function makeRef(id: string) {
+  return { sys: { type: 'ResourceLink', urn: `crn:..../components/${id}` } }
+}
+
+function makeCT(id: string, deps: string[] = []) {
+  return {
+    sys: { id },
+    componentTree: deps.map((dep) => ({
+      component: makeRef(dep)
+    }))
+  }
+}
+
+test('returns empty array unchanged', () => {
+  expect(sortComponents([])).toEqual([])
+})
+
+test('returns single item unchanged', () => {
+  const cts = [makeCT('a')]
+  expect(sortComponents(cts).map((c) => c.sys.id)).toEqual(['a'])
+})
+
+test('leaf nodes come before nodes that reference them', () => {
+  const cts = [makeCT('composite', ['leaf']), makeCT('leaf')]
+  const sorted = sortComponents(cts).map((c) => c.sys.id)
+  expect(sorted.indexOf('leaf')).toBeLessThan(sorted.indexOf('composite'))
+})
+
+test('handles multi-level dependency chain', () => {
+  const cts = [makeCT('c', ['b']), makeCT('b', ['a']), makeCT('a')]
+  const sorted = sortComponents(cts).map((c) => c.sys.id)
+  expect(sorted.indexOf('a')).toBeLessThan(sorted.indexOf('b'))
+  expect(sorted.indexOf('b')).toBeLessThan(sorted.indexOf('c'))
+})
+
+test('handles multiple independent deps', () => {
+  const cts = [
+    makeCT('top', ['left', 'right']),
+    makeCT('right'),
+    makeCT('left'),
+  ]
+  const sorted = sortComponents(cts).map((c) => c.sys.id)
+  expect(sorted.indexOf('left')).toBeLessThan(sorted.indexOf('top'))
+  expect(sorted.indexOf('right')).toBeLessThan(sorted.indexOf('top'))
+})
+
+test('does not drop nodes involved in a cycle', () => {
+  const cts = [makeCT('a', ['b']), makeCT('b', ['a'])]
+  const sorted = sortComponents(cts).map((c) => c.sys.id)
+  expect(sorted).toHaveLength(2)
+  expect(sorted).toContain('a')
+  expect(sorted).toContain('b')
+})
+
+test('ignores self-references', () => {
+  const cts = [makeCT('a', ['a']), makeCT('b')]
+  const sorted = sortComponents(cts).map((c) => c.sys.id)
+  expect(sorted).toHaveLength(2)
+})

--- a/test/unit/utils/sort-or-report.test.ts
+++ b/test/unit/utils/sort-or-report.test.ts
@@ -1,0 +1,19 @@
+import { logEmitter } from 'contentful-batch-libs/dist/logging'
+import { sortOrReport } from '../../../lib/utils/sort-or-report'
+
+test('returns the sort result unchanged when the sort function succeeds', () => {
+  const result = sortOrReport(() => [3, 1, 2])
+  expect(result).toEqual([3, 1, 2])
+})
+
+test('logs the error via logEmitter and rethrows when the sort function throws', () => {
+  const sortError = new Error('malformed data')
+  const emitSpy = jest.spyOn(logEmitter, 'emit').mockImplementation(() => true)
+
+  expect(() => sortOrReport(() => {
+    throw sortError
+  })).toThrow(sortError)
+
+  expect(emitSpy).toHaveBeenCalledWith('error', sortError)
+  emitSpy.mockRestore()
+})


### PR DESCRIPTION
[AIS-96](https://contentful.atlassian.net/browse/AIS-96)

## Summary
- Adds import support for Experience Orchestration (ExO) — Contentful's system for composing and rendering structured page experiences, sitting above the traditional entry/content-type layer
- Six new ExO entity types are now exported when present in the source space: Design Tokens, Components, Experience Templates, Data Assemblies, Experience Fragments, and Experiences
- New `includeExperienceOrchestration` flag (`--include-experience-orchestration` on the CLI) controls this behavior and defaults to `true`. Pass `includeExperienceOrchestration: false` to opt out

## Test plan
- [ ] Unit test suite passes (`npm test`)
- [ ] Build succeeds (`npm run build`)
- [ ] Integration test for ExO import (`test/integration/import-exo.test.ts`) passes against a source space containing ExO entities
- [ ] Verify `--include-experience-orchestration=false` skips ExO entities on import

Generated with [Claude Code](https://claude.com/claude-code)

[AIS-96]: https://contentful.atlassian.net/browse/AIS-96?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ