### PR TITLE
fix: ExO folders - should not throw when parent conceptSchemes are missing [AIS-96]

### DIFF
--- a/lib/utils/import-exo-folders.ts
+++ b/lib/utils/import-exo-folders.ts
@@ -271,7 +271,8 @@ export async function importExoFolders({
   const parentGroups = await ensureParentFolderGroupsExist(plainClient, organizationId)
 
   if (parentGroups.size === 0) {
-    return Promise.reject(new Error('One or more ExO folder group concept schemes are missing in the destination org. Please create them before importing.'))
+    logEmitter.emit('warn', 'One or more Experience Orchestration folder group concept schemes are missing in the destination organization. Please create them before importing.')
+    return;
   }
 
   // Step 2

--- a/test/unit/utils/import-exo-folders.test.ts
+++ b/test/unit/utils/import-exo-folders.test.ts
@@ -452,7 +452,7 @@ describe('importExoFolders', () => {
     expect(client.concept.get).not.toHaveBeenCalled()
   })
 
-  it('rejects when parent groups are missing', async () => {
+  it('does NOT reject when parent groups are missing', async () => {
     const client = makeClient()
     await expect(
       importExoFolders({
@@ -460,7 +460,7 @@ describe('importExoFolders', () => {
         ...BASE_ARGS,
         sourceEntities: { designTokens: [makeEntity(['contentful.folder-a-AA'])] },
       })
-    ).rejects.toThrow()
+    ).resolves.not.toThrow()
   })
 
   it('runs all steps in sequence: creates concept, links to scheme, rewrites entity metadata', async () => {


### PR DESCRIPTION
## Summary
An issue was disovered in internal testing where we are overzealously throwing an error when the parent `conceptSchemes` for Experience Orchestration folders don't exist.  We should instead warn, exit the `importExoFolders()` step early and continue import.  Any spaces that do not have exo enabled will experience this.

<!-- Give a short summary what your PR is introducing/fixing. -->

## Description

<!-- Describe your changes in detail -->

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

## PR Checklist

- [ ] I have read the `CONTRIBUTING.md` file
- [ ] All commits follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Documentation is updated (if necessary)
- [ ] PR doesn't contain any sensitive information
- [ ] There are no breaking changes
