### PR TITLE
fix: forward timeout and retry options to plain client [AIS-170]

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,14 @@ Path to JSON file that contains data to be import to your space
 
 Content to import. Needs to match the expected structure (See below)
 
+#### `timeout` [number]
+
+Time between retries
+
+#### `retryLimit` [number]
+
+Maximum number of retries
+
 ### Filtering
 
 #### `contentModelOnly` [boolean] [default: false]
@@ -168,14 +176,6 @@ Skip updating existing assets
 #### `assetsDirectory` [string]
 
 Path to a directory with an asset export made using the [downloadAssets](https://github.com/contentful/contentful-export#downloadassets-boolean) option of the export. Requires `uploadAssets`
-
-#### `timeout` [number] [default: 3000]
-
-Time between retries on asset processing
-
-#### `retryLimit` [number] [default: 10]
-
-Maximum number of retries for asset processing
 
 ### Connection
 

--- a/lib/usageParams.ts
+++ b/lib/usageParams.ts
@@ -56,11 +56,11 @@ export default yargs
   })
   .implies('assets-directory', 'upload-assets')
   .option('timeout', {
-    describe: 'Time between retries on asset processing',
+    describe: 'Time between retries',
     type: 'number'
   })
   .option('retry-limit', {
-    describe: 'Maximum number of retries for asset processing',
+    describe: 'Maximum number of retries',
     type: 'number'
   })
   .option('error-log-file', {

--- a/lib/usageParams.ts
+++ b/lib/usageParams.ts
@@ -55,6 +55,14 @@ export default yargs
     type: 'string'
   })
   .implies('assets-directory', 'upload-assets')
+  .option('timeout', {
+    describe: 'Time between retries on asset processing',
+    type: 'number'
+  })
+  .option('retry-limit', {
+    describe: 'Maximum number of retries for asset processing',
+    type: 'number'
+  })
   .option('error-log-file', {
     describe: 'Full path to the error log file',
     type: 'string'

--- a/test/unit/yargs.test.ts
+++ b/test/unit/yargs.test.ts
@@ -33,6 +33,8 @@ describe("contentful-import yargs", () => {
       .stdout(/--skip-content-publishing/)
       .stdout(/--upload-assets/)
       .stdout(/--assets-directory/)
+      .stdout(/--timeout/)
+      .stdout(/--retry-limit/)
       .stdout(/--error-log-file/)
       .stdout(/--host/)
       .stdout(/--proxy/)
@@ -60,4 +62,3 @@ describe("contentful-import yargs", () => {
       .end(done);
   });
 });
-


### PR DESCRIPTION
[AIS-170](https://contentful.atlassian.net/browse/AIS-170)

## Summary
- Forward user-provided `timeout` and `retryLimit` values to the ExO plain CMA client.
- Preserve CMA SDK defaults when the options are omitted.
- Add regression coverage for custom and omitted values.

## Test plan
- [x] `npm exec jest -- test/unit --runInBand --coverage=false`
- [x] `npm exec eslint -- lib/tasks/init-client.ts test/unit/tasks/init-client.test.ts`
- [x] `npm exec tsc -- --project tsconfig.json --noEmit`
- [x] `npm run build`

Generated with [Codex](https://Codex.com/Codex)

[AIS-170]: https://contentful.atlassian.net/browse/AIS-170?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ