### PR TITLE
fix: clean up import logging listeners [AIS-171]

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -6,7 +6,7 @@ import VerboseRenderer from 'listr-verbose-renderer'
 import { startCase } from 'lodash-es'
 import PQueue from 'p-queue'
 
-import { setupLogging, teardownLogging, writeErrorLogFile } from 'contentful-batch-libs/dist/logging'
+import { setupLogging, teardownLogging, writeErrorLogFile, type LogMessage } from 'contentful-batch-libs/dist/logging'
 import { wrapTask } from 'contentful-batch-libs/dist/listr'
 
 import initClient from './tasks/init-client'
@@ -15,7 +15,7 @@ import pushToSpace from './tasks/push-to-space/push-to-space'
 import transformSpace from './transform/transform-space'
 import { assertDefaultLocale, assertPayload } from './utils/validations'
 import parseOptions from './parseOptions'
-import { ContentfulMultiError, LogItem } from './utils/errors'
+import { ContentfulMultiError } from './utils/errors'
 import displayErrorLog from './utils/display-error-log'
 
 const ONE_SECOND = 1000
@@ -69,7 +69,7 @@ type RunContentfulImportParams = {
 }
 
 async function runContentfulImport (params: RunContentfulImportParams) {
-  const log: LogItem[] = []
+  const log: LogMessage[] = []
   const options = await parseOptions(params)
   const listrOptions = createListrOptions(options)
   const requestQueue = new PQueue({
@@ -229,11 +229,13 @@ async function runContentfulImport (params: RunContentfulImportParams) {
       log.push({
         ts: (new Date()).toJSON(),
         level: 'error',
-        error: err
+        error: err instanceof Error ? err : new Error(String(err))
       })
     })
     .then((data) => {
-      const errorLog = log.filter((logMessage) => logMessage.level !== 'info' && logMessage.level !== 'warning')
+      const errorLog = log.filter(
+        (logMessage): logMessage is Extract<LogMessage, { level: 'error' }> => logMessage.level === 'error'
+      )
       const displayLog = log.filter((logMessage) => logMessage.level !== 'info')
       displayErrorLog(displayLog)
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -6,7 +6,7 @@ import VerboseRenderer from 'listr-verbose-renderer'
 import { startCase } from 'lodash-es'
 import PQueue from 'p-queue'
 
-import { setupLogging, writeErrorLogFile } from 'contentful-batch-libs/dist/logging'
+import { setupLogging, teardownLogging, writeErrorLogFile } from 'contentful-batch-libs/dist/logging'
 import { wrapTask } from 'contentful-batch-libs/dist/listr'
 
 import initClient from './tasks/init-client'
@@ -77,9 +77,6 @@ async function runContentfulImport (params: RunContentfulImportParams) {
     intervalCap: options.rateLimit,
     carryoverConcurrencyCount: true
   })
-
-  // Setup custom log listener to store log messages for later
-  setupLogging(log)
 
   const infoTable = new Table(tableOptions)
 
@@ -189,9 +186,19 @@ async function runContentfulImport (params: RunContentfulImportParams) {
     }
   ], listrOptions)
 
-  return tasks.run({
-    data: {}
-  })
+  let importPromise
+  try {
+    // Setup custom log listener to store log messages for later
+    setupLogging(log)
+    importPromise = tasks.run({
+      data: {}
+    })
+  } catch (err) {
+    teardownLogging(log)
+    throw err
+  }
+
+  return importPromise
     .then((ctx) => {
       console.log('Finished importing all data')
 
@@ -245,6 +252,7 @@ async function runContentfulImport (params: RunContentfulImportParams) {
 
       return data
     })
+    .finally(() => teardownLogging(log))
 }
 
 export default runContentfulImport

--- a/test/unit/index.test.ts
+++ b/test/unit/index.test.ts
@@ -1,6 +1,7 @@
 import { resolve } from 'path'
 
 import TableStub from 'cli-table3'
+import { logEmitter } from 'contentful-batch-libs/dist/logging'
 
 import pushToSpaceStub from '../../lib/tasks/push-to-space/push-to-space'
 import transformSpaceStub from '../../lib/transform/transform-space'
@@ -347,4 +348,26 @@ test('Intro CLI table respects contentModelOnly', () => {
       expect(introTable.push.mock.calls[3][0]).toEqual(['Locales', 2])
       expect(introTable.push.mock.calls).toHaveLength(4)
     })
+})
+
+test('does not retain logging listeners after successful or failed imports', async () => {
+  const eventNames = ['info', 'warning', 'error', 'display']
+  const listenerCountsBefore = eventNames.map((eventName) => logEmitter.listenerCount(eventName))
+  const options = {
+    content: {},
+    spaceId: 'someSpaceId',
+    managementToken: 'someManagementToken',
+    errorLogFile: 'errorlogfile'
+  }
+
+  await contentfulImport(options)
+  expect(eventNames.map((eventName) => logEmitter.listenerCount(eventName))).toEqual(listenerCountsBefore)
+
+  const initClientMock = initClientStub as jest.Mock
+  initClientMock.mockImplementationOnce(() => {
+    throw new Error('client initialization failed')
+  })
+
+  await expect(contentfulImport(options)).rejects.toMatchObject({ name: 'ContentfulMultiError' })
+  expect(eventNames.map((eventName) => logEmitter.listenerCount(eventName))).toEqual(listenerCountsBefore)
 })


### PR DESCRIPTION
[AIS-171](https://contentful.atlassian.net/browse/AIS-171)

## Summary
- Tear down the importer's logging listeners after successful and failed runs, including synchronous task-start errors.
- Align importer log-record handling with the batch-libs logging types.
- Depends on [contentful-batch-libs #1189](https://github.com/contentful/contentful-batch-libs/pull/1189).

## Scope
- This PR fixes listener retention for sequential `contentfulImport()` calls in one Node process.
- Concurrent-import isolation is intentionally out of scope. The shared emitter can still cross-talk while operations overlap; that requires a separate operation-scoped logging design.
- Other `setupLogging()` consumers, including export and organization-import paths, need separate caller-level adoption of `teardownLogging()`.

## Dependency and release note

The branch currently retains the existing `contentful-batch-libs` `^9.7.0` dependency because #1189 has not yet produced a compatible published release containing `teardownLogging()`. The current published `13.0.0` artifact does not contain this API, and a straight bump to v13 is not sufficient because this importer still uses multiple deep `dist/*` imports that are not exposed by the v13 package exports. After #1189 is released in a compatible form—or after a separately scoped importer migration—update the dependency and lockfile, then verify the packaged registry artifact rather than a local linked/build-only copy.

The current CI build failure is the expected result of this dependency gate: the registry-resolved `9.7.0` package has neither `teardownLogging()` nor the `LogMessage` export used by this branch.

## Test plan
- [x] Production CJS, ESM, and declaration builds pass when paired with the batch-libs implementation from #1189.
- [x] Focused importer lifecycle regression passes across successful, rejected, and synchronous startup-failure paths.
- [x] Real CMA integration suite passes.
- [x] Repeated live imports and a live validation failure return all logging listener counts to zero.
- [ ] Re-run against a compatible published batch-libs release after #1189 is released or the required compatibility migration lands.

Generated with [Codex](https://Codex.com/Codex)

[AIS-171]: https://contentful.atlassian.net/browse/AIS-171?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
