### PR TITLE
fix: strip metadata.tags from ExO entities when destination lacks Tags access [AIS-552]

### DIFF
--- a/lib/transform/exo-rename.ts
+++ b/lib/transform/exo-rename.ts
@@ -1,3 +1,5 @@
+import { removeMetadataTags } from './transformers'
+
 /**
  * Upgrades legacy-shaped Experience Orchestration (ExO) entities to the renamed
  * form the current API expects, so exports taken before the rename can still be
@@ -199,19 +201,32 @@ function upgradeExperience (entity: any): any {
   }
 }
 
+/** Upgrades one entity array, if present, and scrubs metadata.tags per-entity. */
+function upgradeEntityArray (key: string, resources: Record<string, any>, upgrade: (entity: any) => any, tagsEnabled: boolean) {
+  const items = resources[key]
+  if (!Array.isArray(items)) return {}
+
+  const upgraded = items.map((entity: any) => removeMetadataTags(upgrade(entity), tagsEnabled))
+  return { [key]: upgraded }
+}
+
 /**
  * Upgrades the renameable ExO entity arrays on a resources object to the new
  * form, leaving all other keys (and entities that were not renamed, such as
  * dataAssemblies and designTokens) untouched. Idempotent.
+ *
+ * Also strips metadata.tags when the destination lacks Tags access
+ * (tagsEnabled = false) — otherwise the create/upsert call 400s server-side
+ * (see AIS-552).
  */
-export function upgradeExoResources<T extends Record<string, any>> (resources: T): T {
+export function upgradeExoResources<T extends Record<string, any>> (resources: T, tagsEnabled = false): T {
   if (!resources) return resources
   return {
     ...resources,
-    ...(Array.isArray(resources.components) ? { components: resources.components.map(upgradeComponent) } : {}),
-    ...(Array.isArray(resources.experienceTemplates) ? { experienceTemplates: resources.experienceTemplates.map(upgradeExperienceTemplate) } : {}),
-    ...(Array.isArray(resources.experienceFragments) ? { experienceFragments: resources.experienceFragments.map(upgradeExperienceFragment) } : {}),
-    ...(Array.isArray(resources.experiences) ? { experiences: resources.experiences.map(upgradeExperience) } : {})
+    ...upgradeEntityArray('components', resources, upgradeComponent, tagsEnabled),
+    ...upgradeEntityArray('experienceTemplates', resources, upgradeExperienceTemplate, tagsEnabled),
+    ...upgradeEntityArray('experienceFragments', resources, upgradeExperienceFragment, tagsEnabled),
+    ...upgradeEntityArray('experiences', resources, upgradeExperience, tagsEnabled)
   }
 }
 

--- a/lib/transform/exo-rename.ts
+++ b/lib/transform/exo-rename.ts
@@ -211,13 +211,13 @@ function upgradeEntityArray (key: string, resources: Record<string, any>, upgrad
 }
 
 /**
- * Upgrades the renameable ExO entity arrays on a resources object to the new
- * form, leaving all other keys (and entities that were not renamed, such as
- * dataAssemblies and designTokens) untouched. Idempotent.
+ * Upgrades components, experienceTemplates, experienceFragments, and experiences to the
+ * new (post-rename) shape. Everything else on the resources object - including
+ * dataAssemblies and designTokens, which were never renamed - passes through untouched.
+ * Safe to call more than once; already-upgraded data is left as-is.
  *
- * Also strips metadata.tags when the destination lacks Tags access
- * (tagsEnabled = false) — otherwise the create/upsert call 400s server-side
- * (see AIS-552).
+ * Also drops metadata.tags when the destination can't resolve tags (tagsEnabled = false),
+ * since sending them would 400 on create/upsert.
  */
 export function upgradeExoResources<T extends Record<string, any>> (resources: T, tagsEnabled = false): T {
   if (!resources) return resources

--- a/lib/transform/transform-space.ts
+++ b/lib/transform/transform-space.ts
@@ -6,8 +6,6 @@ import sortLocales from '../utils/sort-locales'
 import { upgradeExoResources } from './exo-rename'
 import { DestinationData, OriginalSourceData, TransformedSourceData } from '../types'
 
-// ExO entities bypass this loop (see upgradeExoResources() below) - intentional, but unlike
-// entries/assets it doesn't strip metadata.tags when the destination lacks Tags access. See AIS-552.
 const entities = [
   'contentTypes', 'entries', 'assets', 'locales', 'webhooks', 'tags', 'releases'
 ]
@@ -18,16 +16,27 @@ const entities = [
  */
 export default function (
   sourceData: OriginalSourceData, destinationData: DestinationData): TransformedSourceData {
-  // ExO entities (components, experienceTemplates, experienceFragments,
-  // experiences) are not handled by the per-entity transformers above; they
-  // pass through as-is except for a rename upgrade so exports taken before the
-  // ExO field rename can still be imported. Upgrading here — before
-  // sorting and push — means the rest of the pipeline only ever sees the new
-  // form. The upgrade is idempotent, so already-new-form data is untouched.
-  const baseSpaceData = upgradeExoResources(omit(sourceData, ...entities)) as TransformedSourceData
+  const tagsEnabled = !!destinationData.tags
+
+  // ExO entities aren't handled by the per-entity transformers above; they just get
+  // a rename upgrade (pre-rename exports) and a metadata.tags scrub (AIS-552).
+  const baseSpaceData = upgradeExoResources(omit(sourceData, ...entities), tagsEnabled) as TransformedSourceData
+
+  // dataAssemblies/designTokens skip upgradeExoResources() (no rename applies), so they
+  // need their own scrub. DataAssembly.metadata is required, so it's zeroed instead of deleted.
+  if (!tagsEnabled) {
+    if (Array.isArray(baseSpaceData.dataAssemblies)) {
+      baseSpaceData.dataAssemblies = baseSpaceData.dataAssemblies.map((entity) => ({
+        ...entity,
+        metadata: { ...entity.metadata, tags: [] }
+      }))
+    }
+    if (Array.isArray(baseSpaceData.designTokens)) {
+      baseSpaceData.designTokens = baseSpaceData.designTokens.map((entity) => transformers.removeMetadataTags({ ...entity }, false))
+    }
+  }
 
   sourceData.locales = sortLocales(sourceData.locales)
-  const tagsEnabled = !!destinationData.tags
 
   return entities.reduce((transformedSpaceData, type) => {
     // tags don't contain links to other entities, don't need to be sorted

--- a/lib/transform/transform-space.ts
+++ b/lib/transform/transform-space.ts
@@ -1,5 +1,7 @@
 import { omit } from 'lodash-es'
 
+import { logEmitter } from 'contentful-batch-libs/dist/logging'
+
 import * as transformers from './transformers'
 import sortEntries from '../utils/sort-entries'
 import sortLocales from '../utils/sort-locales'
@@ -10,6 +12,20 @@ const entities = [
   'contentTypes', 'entries', 'assets', 'locales', 'webhooks', 'tags', 'releases'
 ]
 
+// Every entity type whose metadata.tags gets scrubbed when the destination lacks Tags
+// access - used to size the single warning below (AIS-552).
+const TAG_SCRUBBED_ENTITY_TYPES = [
+  'entries', 'assets', 'components', 'experienceTemplates', 'experienceFragments',
+  'experiences', 'dataAssemblies', 'designTokens'
+] as const
+
+function countEntitiesWithTags (sourceData: OriginalSourceData): number {
+  return TAG_SCRUBBED_ENTITY_TYPES.reduce((count, type) => {
+    const entitiesOfType = sourceData[type] ?? []
+    return count + entitiesOfType.filter((entity: any) => entity.metadata?.tags?.length).length
+  }, 0)
+}
+
 /**
  * Run transformer methods on each item for each kind of entity, in case there
  * is a need to transform data when copying it to the destination space
@@ -17,6 +33,13 @@ const entities = [
 export default function (
   sourceData: OriginalSourceData, destinationData: DestinationData): TransformedSourceData {
   const tagsEnabled = !!destinationData.tags
+
+  if (!tagsEnabled) {
+    const strippedCount = countEntitiesWithTags(sourceData)
+    if (strippedCount > 0) {
+      logEmitter.emit('warning', `The destination space/environment does not have access to the Tags feature. metadata.tags was removed from ${strippedCount} ${strippedCount === 1 ? 'entity' : 'entities'} during import.`)
+    }
+  }
 
   // ExO entities aren't handled by the per-entity transformers above; they just get
   // a rename upgrade (pre-rename exports) and a metadata.tags scrub (AIS-552).

--- a/lib/transform/transform-space.ts
+++ b/lib/transform/transform-space.ts
@@ -32,7 +32,7 @@ export default function (
       }))
     }
     if (Array.isArray(baseSpaceData.designTokens)) {
-      baseSpaceData.designTokens = baseSpaceData.designTokens.map((entity) => transformers.removeMetadataTags({ ...entity }, false))
+      baseSpaceData.designTokens = baseSpaceData.designTokens.map((entity) => transformers.removeMetadataTags(entity, false))
     }
   }
 

--- a/lib/transform/transform-space.ts
+++ b/lib/transform/transform-space.ts
@@ -13,7 +13,7 @@ const entities = [
 ]
 
 // Every entity type whose metadata.tags gets scrubbed when the destination lacks Tags
-// access - used to size the single warning below (AIS-552).
+// access - used to size the warning in warnIfTagsWillBeStripped().
 const TAG_SCRUBBED_ENTITY_TYPES = [
   'entries', 'assets', 'components', 'experienceTemplates', 'experienceFragments',
   'experiences', 'dataAssemblies', 'designTokens'
@@ -26,6 +26,32 @@ function countEntitiesWithTags (sourceData: OriginalSourceData): number {
   }, 0)
 }
 
+function warnIfTagsWillBeStripped (sourceData: OriginalSourceData, tagsEnabled: boolean): void {
+  if (tagsEnabled) return
+
+  const strippedCount = countEntitiesWithTags(sourceData)
+  if (strippedCount === 0) return
+
+  logEmitter.emit('warning', `The destination space/environment does not have access to the Tags feature. metadata.tags was removed from ${strippedCount} ${strippedCount === 1 ? 'entity' : 'entities'} during import.`)
+}
+
+// dataAssemblies/designTokens skip upgradeExoResources() (no rename applies to them), so
+// they need their own metadata.tags scrub here. DataAssembly.metadata is a required field,
+// so it's zeroed out rather than deleted. Mutates spaceData in place.
+function stripTagsFromDataAssembliesAndDesignTokens (spaceData: TransformedSourceData, tagsEnabled: boolean): void {
+  if (tagsEnabled) return
+
+  if (Array.isArray(spaceData.dataAssemblies)) {
+    spaceData.dataAssemblies = spaceData.dataAssemblies.map((entity) => ({
+      ...entity,
+      metadata: { ...entity.metadata, tags: [] }
+    }))
+  }
+  if (Array.isArray(spaceData.designTokens)) {
+    spaceData.designTokens = spaceData.designTokens.map((entity) => transformers.removeMetadataTags(entity, false))
+  }
+}
+
 /**
  * Run transformer methods on each item for each kind of entity, in case there
  * is a need to transform data when copying it to the destination space
@@ -34,30 +60,12 @@ export default function (
   sourceData: OriginalSourceData, destinationData: DestinationData): TransformedSourceData {
   const tagsEnabled = !!destinationData.tags
 
-  if (!tagsEnabled) {
-    const strippedCount = countEntitiesWithTags(sourceData)
-    if (strippedCount > 0) {
-      logEmitter.emit('warning', `The destination space/environment does not have access to the Tags feature. metadata.tags was removed from ${strippedCount} ${strippedCount === 1 ? 'entity' : 'entities'} during import.`)
-    }
-  }
+  warnIfTagsWillBeStripped(sourceData, tagsEnabled)
 
-  // ExO entities aren't handled by the per-entity transformers above; they just get
-  // a rename upgrade (pre-rename exports) and a metadata.tags scrub (AIS-552).
+  // ExO entities aren't handled by the per-entity transformers above; they just get a
+  // rename upgrade (pre-rename exports) and a metadata.tags scrub.
   const baseSpaceData = upgradeExoResources(omit(sourceData, ...entities), tagsEnabled) as TransformedSourceData
-
-  // dataAssemblies/designTokens skip upgradeExoResources() (no rename applies), so they
-  // need their own scrub. DataAssembly.metadata is required, so it's zeroed instead of deleted.
-  if (!tagsEnabled) {
-    if (Array.isArray(baseSpaceData.dataAssemblies)) {
-      baseSpaceData.dataAssemblies = baseSpaceData.dataAssemblies.map((entity) => ({
-        ...entity,
-        metadata: { ...entity.metadata, tags: [] }
-      }))
-    }
-    if (Array.isArray(baseSpaceData.designTokens)) {
-      baseSpaceData.designTokens = baseSpaceData.designTokens.map((entity) => transformers.removeMetadataTags(entity, false))
-    }
-  }
+  stripTagsFromDataAssembliesAndDesignTokens(baseSpaceData, tagsEnabled)
 
   sourceData.locales = sortLocales(sourceData.locales)
 

--- a/lib/transform/transformers.ts
+++ b/lib/transform/transformers.ts
@@ -70,15 +70,18 @@ export function locales(locale, destinationLocales) {
 }
 
 export function removeMetadataTags(entity, tagsEnabled = false) {
-  if (!tagsEnabled && entity.metadata) {
-    // Only strip tags, not the whole metadata object - metadata.concepts (Taxonomy /
-    // ExO folder placement) is unrelated to Tags access and must survive the scrub.
-    delete entity.metadata.tags
-    if (Object.keys(entity.metadata).length === 0) {
-      delete entity.metadata
-    }
+  if (tagsEnabled || !entity.metadata) {
+    return entity
   }
-  return entity
+  // Only strip tags, not the whole metadata object - metadata.concepts (Taxonomy /
+  // ExO folder placement) and other metadata fields are unrelated to Tags access and
+  // must survive the scrub. Returns a new object rather than mutating entity.metadata,
+  // since callers pass in source data they don't expect to be changed in place.
+  const restMetadata = omit(entity.metadata, 'tags')
+  return {
+    ...omit(entity, 'metadata'),
+    ...(Object.keys(restMetadata).length > 0 ? { metadata: restMetadata } : {})
+  }
 }
 
 export function releases(release) {

--- a/lib/transform/transformers.ts
+++ b/lib/transform/transformers.ts
@@ -69,7 +69,7 @@ export function locales(locale, destinationLocales) {
   return transformedLocale
 }
 
-function removeMetadataTags(entity, tagsEnabled = false) {
+export function removeMetadataTags(entity, tagsEnabled = false) {
   if (!tagsEnabled) {
     delete entity.metadata
   }

--- a/lib/transform/transformers.ts
+++ b/lib/transform/transformers.ts
@@ -70,8 +70,13 @@ export function locales(locale, destinationLocales) {
 }
 
 export function removeMetadataTags(entity, tagsEnabled = false) {
-  if (!tagsEnabled) {
-    delete entity.metadata
+  if (!tagsEnabled && entity.metadata) {
+    // Only strip tags, not the whole metadata object - metadata.concepts (Taxonomy /
+    // ExO folder placement) is unrelated to Tags access and must survive the scrub.
+    delete entity.metadata.tags
+    if (Object.keys(entity.metadata).length === 0) {
+      delete entity.metadata
+    }
   }
   return entity
 }

--- a/test/unit/transform/exo-rename.test.ts
+++ b/test/unit/transform/exo-rename.test.ts
@@ -265,4 +265,16 @@ describe('upgradeExoResources', () => {
     const result: any = upgradeExoResources(input)
     expect(result.components[0].metadata).toBeUndefined()
   })
+
+  test('preserves metadata.concepts (ExO folder placement) while stripping metadata.tags', () => {
+    const input = {
+      components: [{
+        sys: { id: 'c1', type: 'Component' },
+        metadata: { tags: [{ sys: { id: 't1' } }], concepts: [{ sys: { id: 'contentful.folder-abc' } }] }
+      }]
+    }
+    const result: any = upgradeExoResources(input, false)
+    expect(result.components[0].metadata.tags).toBeUndefined()
+    expect(result.components[0].metadata.concepts).toEqual([{ sys: { id: 'contentful.folder-abc' } }])
+  })
 })

--- a/test/unit/transform/exo-rename.test.ts
+++ b/test/unit/transform/exo-rename.test.ts
@@ -235,4 +235,34 @@ describe('upgradeExoResources', () => {
     expect(result).not.toHaveProperty('components')
     expect(result).not.toHaveProperty('experiences')
   })
+
+  test('strips metadata.tags on all 4 mapped entity types when tagsEnabled is false', () => {
+    const input = {
+      components: [{ sys: { id: 'c1', type: 'Component' }, metadata: { tags: [{ sys: { id: 't1' } }] } }],
+      experienceTemplates: [{ sys: { id: 't1', type: 'ExperienceTemplate' }, metadata: { tags: [{ sys: { id: 't1' } }] } }],
+      experienceFragments: [{ sys: { id: 'f1', type: 'ExperienceFragment', component: newComponentLink('hero') }, metadata: { tags: [{ sys: { id: 't1' } }] } }],
+      experiences: [{ sys: { id: 'e1', type: 'Experience', experienceTemplate: newComponentLink('t1') }, metadata: { tags: [{ sys: { id: 't1' } }] } }]
+    }
+    const result: any = upgradeExoResources(input, false)
+    expect(result.components[0].metadata).toBeUndefined()
+    expect(result.experienceTemplates[0].metadata).toBeUndefined()
+    expect(result.experienceFragments[0].metadata).toBeUndefined()
+    expect(result.experiences[0].metadata).toBeUndefined()
+  })
+
+  test('keeps metadata.tags on all 4 mapped entity types when tagsEnabled is true', () => {
+    const input = {
+      components: [{ sys: { id: 'c1', type: 'Component' }, metadata: { tags: [{ sys: { id: 't1' } }] } }]
+    }
+    const result: any = upgradeExoResources(input, true)
+    expect(result.components[0].metadata).toEqual({ tags: [{ sys: { id: 't1' } }] })
+  })
+
+  test('defaults to stripping metadata.tags when tagsEnabled is omitted', () => {
+    const input = {
+      components: [{ sys: { id: 'c1', type: 'Component' }, metadata: { tags: [{ sys: { id: 't1' } }] } }]
+    }
+    const result: any = upgradeExoResources(input)
+    expect(result.components[0].metadata).toBeUndefined()
+  })
 })

--- a/test/unit/transform/exo-rename.test.ts
+++ b/test/unit/transform/exo-rename.test.ts
@@ -277,4 +277,13 @@ describe('upgradeExoResources', () => {
     expect(result.components[0].metadata.tags).toBeUndefined()
     expect(result.components[0].metadata.concepts).toEqual([{ sys: { id: 'contentful.folder-abc' } }])
   })
+
+  test('does not mutate the source entity\'s metadata when stripping tags', () => {
+    const sourceMetadata = { tags: [{ sys: { id: 't1' } }], concepts: [{ sys: { id: 'contentful.folder-abc' } }] }
+    const input = {
+      components: [{ sys: { id: 'c1', type: 'Component' }, metadata: sourceMetadata }]
+    }
+    upgradeExoResources(input, false)
+    expect(sourceMetadata).toEqual({ tags: [{ sys: { id: 't1' } }], concepts: [{ sys: { id: 'contentful.folder-abc' } }] })
+  })
 })

--- a/test/unit/transform/transform-space.test.ts
+++ b/test/unit/transform/transform-space.test.ts
@@ -1,5 +1,6 @@
 import { cloneDeep } from 'lodash-es'
 
+import { logEmitter } from 'contentful-batch-libs/dist/logging'
 import {
   contentTypeMock,
   entryMock,
@@ -12,6 +13,16 @@ import transformSpace from '../../../lib/transform/transform-space'
 import { Resources, TransformedSourceData } from '../../../lib/types'
 import { TagSysProps } from 'contentful-management'
 import type { AssetProps, LocaleProps, WebhookProps } from 'contentful-management'
+
+jest.mock('contentful-batch-libs/dist/logging', () => ({
+  logEmitter: { emit: jest.fn() }
+}))
+
+const mockEmit = jest.mocked(logEmitter.emit)
+
+afterEach(() => {
+  mockEmit.mockClear()
+})
 
 const tagMock = {
   sys: ({
@@ -140,5 +151,49 @@ describe('ExO metadata.tags scrubbing (AIS-552)', () => {
     transformSpace(space, destinationWithoutTags)
 
     expect(sourceMetadata).toEqual({ tags: [tagLink], concepts: [{ sys: { id: 'contentful.folder-abc' } }] })
+  })
+
+  test('warns once, counting every affected entity across entries/assets/ExO types, when tags are stripped', () => {
+    const destinationWithoutTags = { contentTypes: [], locales: [] }
+    transformSpace(cloneDeep(exoSpace), destinationWithoutTags)
+
+    const tagWarnings = mockEmit.mock.calls.filter(([event]) => event === 'warning')
+    expect(tagWarnings).toHaveLength(1)
+    expect(tagWarnings[0][1]).toMatch(/6 entities/)
+  })
+
+  test('does not warn when the destination has Tags access', () => {
+    const destinationWithTags = { contentTypes: [], locales: [], tags: [tagMock] }
+    transformSpace(cloneDeep(exoSpace), destinationWithTags)
+
+    expect(mockEmit).not.toHaveBeenCalled()
+  })
+
+  test('does not warn when no entity actually has metadata.tags set', () => {
+    const spaceWithoutTagData: ResourcesWithDoNotTouch = {
+      contentTypes: [contentTypeMock],
+      locales: [localeMock as LocaleProps],
+      components: [{ sys: { id: 'c1', type: 'Component' } } as any]
+    }
+    const destinationWithoutTags = { contentTypes: [], locales: [] }
+    transformSpace(spaceWithoutTagData, destinationWithoutTags)
+
+    expect(mockEmit).not.toHaveBeenCalled()
+  })
+
+  test('counts entries and assets alongside ExO types in the same warning', () => {
+    const mixedSpace: ResourcesWithDoNotTouch = {
+      contentTypes: [contentTypeMock],
+      locales: [localeMock as LocaleProps],
+      entries: [{ ...entryMock, metadata: { tags: [tagLink] } }] as any,
+      assets: [{ ...assetMock, metadata: { tags: [tagLink] } }] as any,
+      components: [{ sys: { id: 'c1', type: 'Component' }, metadata: { tags: [tagLink] } } as any]
+    }
+    const destinationWithoutTags = { contentTypes: [], locales: [] }
+    transformSpace(mixedSpace, destinationWithoutTags)
+
+    const tagWarnings = mockEmit.mock.calls.filter(([event]) => event === 'warning')
+    expect(tagWarnings).toHaveLength(1)
+    expect(tagWarnings[0][1]).toMatch(/3 entities/)
   })
 })

--- a/test/unit/transform/transform-space.test.ts
+++ b/test/unit/transform/transform-space.test.ts
@@ -57,3 +57,55 @@ test('applies transformers to give space data', () => {
   expect(result.webhooks?.[0]).toHaveProperty('transformed')
   expect(result.doNotTouch).toBe(true)
 })
+
+describe('ExO metadata.tags scrubbing (AIS-552)', () => {
+  const tagLink = { sys: { id: 'myTagId', linkType: 'Tag', type: 'Link' } }
+
+  const exoSpace: ResourcesWithDoNotTouch = {
+    contentTypes: [contentTypeMock],
+    locales: [localeMock as LocaleProps],
+    components: [
+      { sys: { id: 'c1', type: 'Component' }, metadata: { tags: [tagLink] } } as any
+    ],
+    experienceTemplates: [
+      { sys: { id: 'et1', type: 'ExperienceTemplate' }, metadata: { tags: [tagLink] } } as any
+    ],
+    experienceFragments: [
+      { sys: { id: 'ef1', type: 'ExperienceFragment' }, metadata: { tags: [tagLink] } } as any
+    ],
+    experiences: [
+      { sys: { id: 'e1', type: 'Experience' }, metadata: { tags: [tagLink] } } as any
+    ],
+    dataAssemblies: [
+      { sys: { id: 'da1', type: 'DataAssembly' }, metadata: { tags: [tagLink] } } as any
+    ],
+    designTokens: [
+      { sys: { id: 'dt1', type: 'DesignToken' }, metadata: { tags: [tagLink] } } as any
+    ]
+  }
+
+  test('strips metadata.tags from all 6 ExO entity types when destination lacks Tags access', () => {
+    const destinationWithoutTags = { contentTypes: [], locales: [] }
+    const result = transformSpace(cloneDeep(exoSpace), destinationWithoutTags) as any
+
+    expect(result.components[0].metadata).toBeUndefined()
+    expect(result.experienceTemplates[0].metadata).toBeUndefined()
+    expect(result.experienceFragments[0].metadata).toBeUndefined()
+    expect(result.experiences[0].metadata).toBeUndefined()
+    expect(result.designTokens[0].metadata).toBeUndefined()
+    // DataAssembly.metadata is typed required, so it's zeroed out rather than deleted
+    expect(result.dataAssemblies[0].metadata).toEqual({ tags: [] })
+  })
+
+  test('keeps metadata.tags on all 6 ExO entity types when destination has Tags access', () => {
+    const destinationWithTags = { contentTypes: [], locales: [], tags: [tagMock] }
+    const result = transformSpace(cloneDeep(exoSpace), destinationWithTags) as any
+
+    expect(result.components[0].metadata).toEqual({ tags: [tagLink] })
+    expect(result.experienceTemplates[0].metadata).toEqual({ tags: [tagLink] })
+    expect(result.experienceFragments[0].metadata).toEqual({ tags: [tagLink] })
+    expect(result.experiences[0].metadata).toEqual({ tags: [tagLink] })
+    expect(result.designTokens[0].metadata).toEqual({ tags: [tagLink] })
+    expect(result.dataAssemblies[0].metadata).toEqual({ tags: [tagLink] })
+  })
+})

--- a/test/unit/transform/transform-space.test.ts
+++ b/test/unit/transform/transform-space.test.ts
@@ -108,4 +108,24 @@ describe('ExO metadata.tags scrubbing (AIS-552)', () => {
     expect(result.designTokens[0].metadata).toEqual({ tags: [tagLink] })
     expect(result.dataAssemblies[0].metadata).toEqual({ tags: [tagLink] })
   })
+
+  test('preserves metadata.concepts (ExO folder placement) on all 5 non-DataAssembly types when stripping tags', () => {
+    const folderConcept = { sys: { id: 'contentful.folder-abc' } }
+    const spaceWithConcepts: ResourcesWithDoNotTouch = {
+      contentTypes: [contentTypeMock],
+      locales: [localeMock as LocaleProps],
+      components: [{ sys: { id: 'c1', type: 'Component' }, metadata: { tags: [tagLink], concepts: [folderConcept] } } as any],
+      experienceTemplates: [{ sys: { id: 'et1', type: 'ExperienceTemplate' }, metadata: { tags: [tagLink], concepts: [folderConcept] } } as any],
+      experienceFragments: [{ sys: { id: 'ef1', type: 'ExperienceFragment' }, metadata: { tags: [tagLink], concepts: [folderConcept] } } as any],
+      experiences: [{ sys: { id: 'e1', type: 'Experience' }, metadata: { tags: [tagLink], concepts: [folderConcept] } } as any],
+      designTokens: [{ sys: { id: 'dt1', type: 'DesignToken' }, metadata: { tags: [tagLink], concepts: [folderConcept] } } as any]
+    }
+    const destinationWithoutTags = { contentTypes: [], locales: [] }
+    const result = transformSpace(cloneDeep(spaceWithConcepts), destinationWithoutTags) as any
+
+    for (const type of ['components', 'experienceTemplates', 'experienceFragments', 'experiences', 'designTokens']) {
+      expect(result[type][0].metadata.tags).toBeUndefined()
+      expect(result[type][0].metadata.concepts).toEqual([folderConcept])
+    }
+  })
 })

--- a/test/unit/transform/transform-space.test.ts
+++ b/test/unit/transform/transform-space.test.ts
@@ -128,4 +128,17 @@ describe('ExO metadata.tags scrubbing (AIS-552)', () => {
       expect(result[type][0].metadata.concepts).toEqual([folderConcept])
     }
   })
+
+  test('does not mutate the source DesignToken\'s metadata when stripping tags', () => {
+    const sourceMetadata = { tags: [tagLink], concepts: [{ sys: { id: 'contentful.folder-abc' } }] }
+    const space: ResourcesWithDoNotTouch = {
+      contentTypes: [contentTypeMock],
+      locales: [localeMock as LocaleProps],
+      designTokens: [{ sys: { id: 'dt1', type: 'DesignToken' }, metadata: sourceMetadata } as any]
+    }
+    const destinationWithoutTags = { contentTypes: [], locales: [] }
+    transformSpace(space, destinationWithoutTags)
+
+    expect(sourceMetadata).toEqual({ tags: [tagLink], concepts: [{ sys: { id: 'contentful.folder-abc' } }] })
+  })
 })

--- a/test/unit/transform/transformers.test.ts
+++ b/test/unit/transform/transformers.test.ts
@@ -106,3 +106,21 @@ test('It should transform an entry with tags disabled, and return it', () => {
   const transformed = transformers.entries(entryMock, null, false)
   expect(transformed.metadata).toBeUndefined()
 })
+
+test('removeMetadataTags keeps metadata when tags are enabled', () => {
+  const entity = { metadata: { tags: [{ sys: { id: 't1' } }] } }
+  expect(transformers.removeMetadataTags(entity, true)).toBe(entity)
+  expect(entity.metadata).toEqual({ tags: [{ sys: { id: 't1' } }] })
+})
+
+test('removeMetadataTags strips metadata when tags are disabled', () => {
+  const entity: any = { metadata: { tags: [{ sys: { id: 't1' } }] } }
+  transformers.removeMetadataTags(entity, false)
+  expect(entity.metadata).toBeUndefined()
+})
+
+test('removeMetadataTags defaults to stripping metadata when tagsEnabled is omitted', () => {
+  const entity: any = { metadata: { tags: [] } }
+  transformers.removeMetadataTags(entity)
+  expect(entity.metadata).toBeUndefined()
+})

--- a/test/unit/transform/transformers.test.ts
+++ b/test/unit/transform/transformers.test.ts
@@ -124,3 +124,10 @@ test('removeMetadataTags defaults to stripping metadata when tagsEnabled is omit
   transformers.removeMetadataTags(entity)
   expect(entity.metadata).toBeUndefined()
 })
+
+test('removeMetadataTags preserves metadata.concepts (ExO folder placement) when stripping tags', () => {
+  const entity: any = { metadata: { tags: [{ sys: { id: 't1' } }], concepts: [{ sys: { id: 'contentful.folder-abc' } }] } }
+  transformers.removeMetadataTags(entity, false)
+  expect(entity.metadata.tags).toBeUndefined()
+  expect(entity.metadata.concepts).toEqual([{ sys: { id: 'contentful.folder-abc' } }])
+})

--- a/test/unit/transform/transformers.test.ts
+++ b/test/unit/transform/transformers.test.ts
@@ -115,19 +115,34 @@ test('removeMetadataTags keeps metadata when tags are enabled', () => {
 
 test('removeMetadataTags strips metadata when tags are disabled', () => {
   const entity: any = { metadata: { tags: [{ sys: { id: 't1' } }] } }
-  transformers.removeMetadataTags(entity, false)
-  expect(entity.metadata).toBeUndefined()
+  const result = transformers.removeMetadataTags(entity, false)
+  expect(result.metadata).toBeUndefined()
 })
 
 test('removeMetadataTags defaults to stripping metadata when tagsEnabled is omitted', () => {
   const entity: any = { metadata: { tags: [] } }
-  transformers.removeMetadataTags(entity)
-  expect(entity.metadata).toBeUndefined()
+  const result = transformers.removeMetadataTags(entity)
+  expect(result.metadata).toBeUndefined()
 })
 
 test('removeMetadataTags preserves metadata.concepts (ExO folder placement) when stripping tags', () => {
   const entity: any = { metadata: { tags: [{ sys: { id: 't1' } }], concepts: [{ sys: { id: 'contentful.folder-abc' } }] } }
-  transformers.removeMetadataTags(entity, false)
-  expect(entity.metadata.tags).toBeUndefined()
-  expect(entity.metadata.concepts).toEqual([{ sys: { id: 'contentful.folder-abc' } }])
+  const result = transformers.removeMetadataTags(entity, false)
+  expect(result.metadata.tags).toBeUndefined()
+  expect(result.metadata.concepts).toEqual([{ sys: { id: 'contentful.folder-abc' } }])
+})
+
+test('removeMetadataTags does not mutate the entity passed in', () => {
+  const original = { metadata: { tags: [{ sys: { id: 't1' } }], concepts: [{ sys: { id: 'contentful.folder-abc' } }] } }
+  const entity = { ...original, metadata: { ...original.metadata } }
+  const result = transformers.removeMetadataTags(entity, false)
+  expect(result).not.toBe(entity)
+  expect(entity.metadata).toEqual(original.metadata)
+})
+
+test('removeMetadataTags preserves metadata.name (e.g. Experience variant label) when stripping tags', () => {
+  const entity: any = { metadata: { tags: [{ sys: { id: 't1' } }], name: 'Variant A' } }
+  const result = transformers.removeMetadataTags(entity, false)
+  expect(result.metadata.tags).toBeUndefined()
+  expect(result.metadata.name).toBe('Variant A')
 })


### PR DESCRIPTION
[AIS-552](https://contentful.atlassian.net/browse/AIS-552)

## Summary
- ExO entities (Component, ExperienceTemplate, ExperienceFragment, Experience, DataAssembly, DesignToken) support `metadata.tags`, but nothing stripped it before push like entries/assets already do. If the destination lacks Tags access, the create/upsert 400s server-side. This wires the existing `tagsEnabled` scrub into the ExO path too.
- `removeMetadataTags()` now only removes `tags` (not the whole `metadata` object), so `concepts` (ExO folder placement) and other fields survive — and it returns a new object instead of mutating the entity it's given.
- DataAssembly gets special handling since its `metadata` field is required by the type; it's zeroed to `{ tags: [] }` rather than removed.
- **Design decision, discussed on the ticket:** stripping tags silently (the existing entries/assets behavior, now extended to ExO) trades a loud, if unhelpful, failure for silent data loss on a migration tool — worse for the user. Added a single warning per import run when tags are actually stripped, so this is no longer invisible.

## Known test-coverage gap
Every account available to test with (personal, sandbox, staging) has Tags enabled — it's a universal feature on current plans, so we couldn't reproduce the actual `404` no-Tags-access condition live. Verified at the unit level instead, asserting the exact `tagsEnabled=false` branch the code takes.

## Test plan
- [x] Unit tests cover all 6 entity types across tags enabled/disabled/omitted, plus concepts-preservation, mutation-safety, and the new warning behavior
- [x] Full unit suite passes, `tsc --noEmit` clean
- [x] Integration suite passed against a live sandbox space (happy-path regression check)
- [ ] Manual staging check against a space genuinely lacking Tags access (not possible with available accounts)

Generated with [Claude Code](https://claude.com/claude-code)

[AIS-552]: https://contentful.atlassian.net/browse/AIS-552?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ